### PR TITLE
prevent 'unknown event' message in error case

### DIFF
--- a/common/ui/inline/dialogs/decryptInline.js
+++ b/common/ui/inline/dialogs/decryptInline.js
@@ -125,6 +125,7 @@
         break;
       case 'error-message':
         showErrorMsg(msg.error);
+        break;
       default:
         console.log('unknown event');
     }


### PR DESCRIPTION
in case of an error, an error message is shown to the user, which is expected and works fine. But also an 'unknown event' message is printed on the console, which should not happen, because the event has been handled correctly.
