### PR TITLE
generate 2048-bit RSA keys by default. 1024 bits is too weak.

### DIFF
--- a/common/ui/generateKey.js
+++ b/common/ui/generateKey.js
@@ -86,7 +86,7 @@
   function onClear() {
     $('#generateKey').find('input').val('');
     $('#genKeyAlgo').val('RSA');
-    $('#genKeySize').val('1024');
+    $('#genKeySize').val('2048');
     $('#genKeyExp').val('0')
                    .attr('disabled', 'disabled');
     $('#genKeyExpUnit').val('never')

--- a/common/ui/keyRing.html
+++ b/common/ui/keyRing.html
@@ -231,7 +231,7 @@
                     <div class="controls">
                       <select id="genKeySize" class="input-medium">
                         <option>1024</option>
-                        <option>2048</option>
+                        <option selected>2048</option>
                         <option>4096</option>
                       </select>
                       <span class="help-inline">bits</span>


### PR DESCRIPTION
I think mailvelope should encourage users to use at least 2048-bit RSA encryption, because there are reports that RSA-1024 can be decrypted by some agencies. NIST recommends using at least 2048-bit and has deprecated 1024-bits.
See page 5 of http://csrc.nist.gov/publications/nistpubs/800-131A/sp800-131A.pdf

I would also propose removing the 1024-bit option from the "Generate Keys" page, but I haven't included this in this pull request.
