### PR TITLE
Give credit to Mailvelope in PGP header Comment tag.

### DIFF
--- a/chrome/lib/pgpViewModel.js
+++ b/chrome/lib/pgpViewModel.js
@@ -46,6 +46,10 @@ define(function(require, exports, module) {
     return keys;
   }
 
+  function setOpenPGPComment(text) {
+    openpgp.config.commentstring = text;
+  }
+
   function getPublicKeys() {
     var result = [];
     openpgp.keyring.publicKeys.forEach(function(publicKey) {
@@ -74,6 +78,7 @@ define(function(require, exports, module) {
     return result;
   }
 
+  exports.setOpenPGPComment = setOpenPGPComment;
   exports.getKeys = getKeys;
   exports.getPublicKeys = getPublicKeys;
   exports.getPrivateKeys = getPrivateKeys;

--- a/common/lib/defaults.js
+++ b/common/lib/defaults.js
@@ -44,6 +44,7 @@ define(function (require, exports, module) {
   }
 
   function init() {
+    model.setOpenPGPComment('Email security by Mailvelope, http://mailvelope.com');
     if (!model.getWatchList()) {
       model.setWatchList(defaults.watch_list);
     }


### PR DESCRIPTION
I hope that by including a URL to Mailvelope in the Comment tag, more users will be encouraged to give it a try.
