### PR TITLE
added a makefile for compiling mailvelope for firefox from a fresh shallow clone.

### DIFF
--- a/make-mailvelope.sh
+++ b/make-mailvelope.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+# based on https://github.com/toberndo/mailvelope
+
+NOW="$(date "+%Y%m%d-%H%M%S")"
+
+echo Make a fresh and shallow clone of Mailvelope with all dependencies from git and compile
+echo Create a backup of local repositories in mailvelope-$NOW.tgz
+tar -czf mailvelope-$NOW.tgz mailvelope addon-sdk
+
+rm -r mailvelope addon-sdk
+
+git clone --depth 1 git://github.com/toberndo/mailvelope.git
+cd mailvelope
+git submodule init
+git submodule update
+make build
+
+cd ..
+git clone --depth 1 git://github.com/mozilla/addon-sdk.git
+cd addon-sdk
+source bin/activate
+
+cd ../mailvelope
+make dist-ff


### PR DESCRIPTION
I designed a makefile for
- (provisionally) saving a tarball of local repos
- downloading (clone) a fresh copy from github
- I used a shallow clone ( --depth 1 )
- compiling the mailvelope.firefox.xpi

Perhaps you want to add this to your code. Just as a proposal.
