### PR TITLE
fix missing deps in firefox plugin

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -92,7 +92,7 @@ module.exports = function (grunt) {
       common: {
         files: [{
           src: 'common/**/*',
-          dest: 'build/chrome/'
+          dest: 'build/'
         },
         {
           expand: true,


### PR DESCRIPTION
this seems to be a copy and paste error, those common files should be copied
to the build directory and from there into the browser-specific directories.
