### PR TITLE
make dependencies within copy task more clear

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -93,8 +93,10 @@ module.exports = function (grunt) {
         files: [{
           src: 'common/**/*',
           dest: 'build/'
-        },
-        {
+        }]
+      },
+      common_browser: {
+        files: [{
           expand: true,
           src: 'common/**/*',
           cwd: 'build/',
@@ -194,5 +196,7 @@ module.exports = function (grunt) {
   grunt.registerTask('dist-ff', ['mozilla-addon-sdk', 'mozilla-cfx-xpi']);
   grunt.registerTask('start-ff-clean', ['mozilla-cfx:run_stable']);
 
-  grunt.registerTask('default', ['jshint', 'modernizr', 'concat', 'copy']);
+  grunt.registerTask('copy_default', ['copy:vendor', 'copy:common']);
+
+  grunt.registerTask('default', ['jshint', 'modernizr', 'concat', 'copy_default', 'copy:plugins', 'copy:common_browser']);
 };


### PR DESCRIPTION
there are dependencies within the copy tasks, so it’s better to explicitly
write them down. This way, it’s made sure, the copy tasks always have
previously copied files available.
