### PR TITLE
add grunt-bump to support releases

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -218,6 +218,14 @@ module.exports = function (grunt) {
           command: "run"
         }
       }
+    },
+    bump: {
+      options: {
+        commit: true,
+        createTag: false,
+        push: false,
+        files: ['package.json', 'bower.json', 'chrome/manifest.json', 'firefox/package.json']
+      }
     }
   });
 
@@ -229,6 +237,7 @@ module.exports = function (grunt) {
   grunt.loadNpmTasks('grunt-contrib-compress');
   grunt.loadNpmTasks('grunt-mozilla-addon-sdk');
   grunt.loadNpmTasks('grunt-modernizr');
+  grunt.loadNpmTasks('grunt-bump');
 
   //custom tasks
   grunt.registerTask('dist-cr', ['compress:chrome']);

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "grunt-contrib-compress": "~0.6.1",
     "grunt-mozilla-addon-sdk": "~0.3.2",
     "grunt-contrib-clean": "~0.5.0",
-    "grunt-modernizr": "~0.5.1"
+    "grunt-modernizr": "~0.5.1",
+    "grunt-bump": "0.0.13"
   },
   "private": true
 }


### PR DESCRIPTION
in order to help during the release process, the grunt-bump can be helpful.
Once configured, it will be possible to bump the version number in all files
with just one command and commit these changes. It's also possible to tag
and push the commits directly, but these are deactivated, since bumping
versions in all files might not be enough.

I recently recognised, you seem to do all the things needed for releasing a new version by hand. Especially handling the versions is quite error-prone, so I recently added grunt-bump to some of my projects and think it really does a good job.

You might want to have this for mailvelope, too, so I prepared a config that IMHO makes sense. It does the commit for you, but after that you can update the changelog and `git commit --amend` these changes. After that you can manually create a tag and push it to github.

I left out the file `common/res/defaults.json`, because it contains a tag-name, instead of a version string. It might be helpful to change this, so the file also contains the version string, so it can be added to the bump-configuration. This should make the list of files that need to be touched, complete.
