### PR TITLE
Large key imports

### DIFF
--- a/common/ui/keyring/importKey.js
+++ b/common/ui/keyring/importKey.js
@@ -53,6 +53,10 @@ var mvelo = mvelo || null;
   function onImportKey(callback) {
     clearAlert();
     var keyText = $('#newKey').val();
+    importKeysInText(keyText, callback);
+  }
+
+  function importKeysInText(keyText, callback) {
     if (keyText.length > MAX_KEY_IMPORT_SIZE) {
       $('#importAlert').showAlert(options.l10n.key_import_error, options.l10n.key_import_too_big, 'danger', true);
       return;
@@ -114,17 +118,13 @@ var mvelo = mvelo || null;
     }
   }
 
-  exports.importKey = function(armored, callback) {
-    $('#impKeyClear').click();
-    $('#newKey').val(armored);
-    onImportKey(callback);
-  };
+  exports.importKey = importKeysInText;
 
   function onChangeFile(event) {
     clearAlert();
     var reader = new FileReader();
     var file = event.target.files[0];
-    reader.onloadend = function(ev) { $('#newKey').val(ev.target.result); };
+    reader.onloadend = function(ev) { importKeysInText(ev.target.result); };
 
     if (file.size > MAX_KEY_IMPORT_SIZE) {
       $('#importAlert').showAlert(options.l10n.key_import_error, options.l10n.key_import_too_big, 'danger', true);

--- a/common/ui/keyring/importKey.js
+++ b/common/ui/keyring/importKey.js
@@ -25,8 +25,11 @@ var mvelo = mvelo || null;
   var publicKeyRegex = /-----BEGIN PGP PUBLIC KEY BLOCK-----[\s\S]+?-----END PGP PUBLIC KEY BLOCK-----/g;
   var privateKeyRegex = /-----BEGIN PGP PRIVATE KEY BLOCK-----[\s\S]+?-----END PGP PRIVATE KEY BLOCK-----/g;
 
+  var MAX_KEY_IMPORT_SIZE = 10000000;
+
   options.registerL10nMessages([
     "key_import_error",
+    "key_import_too_big",
     "key_import_invalid_text",
     "key_import_exception",
     "alert_header_warning",
@@ -50,6 +53,10 @@ var mvelo = mvelo || null;
   function onImportKey(callback) {
     clearAlert();
     var keyText = $('#newKey').val();
+    if (keyText.length > MAX_KEY_IMPORT_SIZE) {
+      $('#importAlert').showAlert(options.l10n.key_import_error, options.l10n.key_import_too_big, 'danger', true);
+      return;
+    }
 
     // find all public and private keys in the textbox
     var publicKeys = keyText.match(publicKeyRegex);
@@ -114,9 +121,15 @@ var mvelo = mvelo || null;
   };
 
   function onChangeFile(event) {
+    clearAlert();
     var reader = new FileReader();
     var file = event.target.files[0];
     reader.onloadend = function(ev) { $('#newKey').val(ev.target.result); };
+
+    if (file.size > MAX_KEY_IMPORT_SIZE) {
+      $('#importAlert').showAlert(options.l10n.key_import_error, options.l10n.key_import_too_big, 'danger', true);
+      return;
+    }
     reader.readAsText(file);
   }
 

--- a/common/ui/keyring/tpl/importKey.html
+++ b/common/ui/keyring/tpl/importKey.html
@@ -4,7 +4,7 @@
     <label class="control-label" for="newKey"><h4 data-l10n-id="key_import_textarea"></h4></label>
     <div class="" data-l10n-id="key_import_multiple_keys"></div>
     <div class="help-block">
-      <textarea id="newKey" class="form-control" rows="12"></textarea>
+      <textarea id="newKey" class="form-control" rows="12" spellcheck="false" autocomplete="false"></textarea>
     </div>
   </div>
   <div class="form-group">

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -411,6 +411,10 @@
     "message": "An exception occured while processing the keys",
     "description": "Import error alert."
   },
+  "key_import_too_big": {
+    "message": "The key text you tried to import is too long to handle. Try doing it in smaller parts.",
+    "description": "Import error alert."
+  },
   "alert_invalid_domainmatchpattern_warning": {
     "message": "Domain match pattern should begin with *.",
     "description": "Alert header of category warning."


### PR DESCRIPTION
If you try to import a large key file, or paste a lot into the import box, chrome and firefox hang, and in the case of firefox especially, I had to kill the browser.

Here are a few things that improve this behaviour.

The size limit seems to work well.

The direct file import could do with some work on the UI, to indicate something is happening when the file is being read and processed. I can work on that if this approach looks like a good idea.