### PR TITLE
Fixed a translation to dutch

### DIFF
--- a/locales/nl/messages.json
+++ b/locales/nl/messages.json
@@ -480,7 +480,7 @@
         "description": "Import success message: $1: keyid, $2: userid."
     },
     "keygrid_key_fingerprint": {
-        "message": "ongeldig",
+        "message": "Vingerafdruk",
         "description": "Unique string identifier for a PGP key."
     },
     "keygrid_sort_type": {


### PR DESCRIPTION
The message keygrid_key_fingerprint was "ongeldig" which in Dutch means invalid while it should be "Vingerafdruk" which means Fingerprint.