### PR TITLE
[Bugfix] Prevent .angular-squire-wrapper's z-index on protonmail.ch from stealing focus.

### DIFF
--- a/common/ui/inline/framestyles.css
+++ b/common/ui/inline/framestyles.css
@@ -81,6 +81,7 @@
   white-space: nowrap;
   font-size: 0;
   display: none;
+  z-index: 11;
 }
 
 :root .m-encrypt-frame-expanded {


### PR DESCRIPTION
Should fix #325 (encrypt icon visible but unclickable).

![2015-09-26-14 32 29-screenshot](https://cloud.githubusercontent.com/assets/7232674/10119134/7653c632-645b-11e5-9da7-0f3fab15bd5d.png)
