### PR TITLE
Show key ID in "Sign message with key" dialog as email is not unique.

### DIFF
--- a/common/ui/inline/dialogs/signDialog.js
+++ b/common/ui/inline/dialogs/signDialog.js
@@ -100,7 +100,7 @@ var mvelo = mvelo || null;
         var keySelect = $('#keySelect');
         keySelect.append(
           msg.keys.map(function(key) {
-            var option = $('<option/>').val(key.id.toLowerCase()).text(key.name + ' <' + key.email + '>');
+            var option = $('<option/>').val(key.id.toLowerCase()).text(key.name + ' <' + key.email + '> (0x' + key.id.slice(-8).toUpperCase() + ')');
             if (key.id === msg.primary) {
               option.prop('selected', true);
             }


### PR DESCRIPTION
I also feel a bit "safer" when selecting a key when I can see the ID. I
slice to the last 8 characters at that matches the classic GnuPG style.

Signed-off-by: Chris Lamb <chris@chris-lamb.co.uk>