### PR TITLE
Activate API for Posteo

### DIFF
--- a/common/res/defaults.json
+++ b/common/res/defaults.json
@@ -73,7 +73,7 @@
         {
           "scan": true,
           "frame": "*.posteo.de",
-          "api": false
+          "api": true
         }
       ]
     },


### PR DESCRIPTION
@Posteo [integrated the API of Mailevelope](https://posteo.de/en/blog/new-posteo-webmail-interface-can-find-public-keys) ([German version](https://posteo.de/blog/neu-posteo-webmailer-findet-schl%C3%BCssel-automatisch)). Therefore it can be activated by default.