### PR TITLE
Clear password field when entered incorrectly.

### DIFF
--- a/common/ui/modal/pwdDialog.js
+++ b/common/ui/modal/pwdDialog.js
@@ -129,7 +129,7 @@ var mvelo = mvelo || null;
         $('body').removeClass('busy');
         $('#spinner').hide();
         $('.modal-body').css('opacity', '1');
-        $('#password').closest('.control-group').addClass('error')
+        $('#password').val('').closest('.control-group').addClass('error')
                       .end().next().removeClass('hide');
         break;
       default:


### PR DESCRIPTION
As the password is masked, there is no benefit to keeping the asterisks
around if entered wrong. The user is extremely likely to want to start
"again" so we clear the field for them, saving them the effort of holding
down backspace or "ctrl+shift+left", etc.

Signed-off-by: Chris Lamb <chris@chris-lamb.co.uk>