### PR TITLE
Key Server Integration

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -54,7 +54,8 @@
         "resolves": true,
         "rejects": true,
         "angular": true,
-        "mvelo": true
+        "mvelo": true,
+        "fetch": true
     }
 
 }

--- a/chrome/lib/lib-mvelo.js
+++ b/chrome/lib/lib-mvelo.js
@@ -258,6 +258,8 @@ define(function(require, exports, module) {
     return window;
   };
 
+  mvelo.util.fetch = window.fetch.bind(window);
+
   mvelo.l10n.get = chrome.i18n.getMessage;
 
   mvelo.browserAction = {};

--- a/common/lib/controller/editor.controller.js
+++ b/common/lib/controller/editor.controller.js
@@ -46,7 +46,7 @@ define(function(require, exports, module) {
     this.signBuffer = null;
     this.pwdControl = null;
     this.keyring = require('../keyring');
-    this.keyserver = new KeyServer();
+    this.keyserver = new KeyServer(this.mvelo);
     this.mailbuild = require('emailjs-mime-builder');
     this.pgpMIME = false;
     this.signMsg = null;
@@ -217,7 +217,7 @@ define(function(require, exports, module) {
       // persist key in local keyring
       var localKeyring = this.keyring.getById(this.mvelo.LOCAL_KEYRING_ID);
       if (key && key.publicKeyArmored) {
-        localKeyring.importKeys([{type: 'public', armored:key.publicKeyArmored}]);
+        localKeyring.importKeys([{type:'public', armored:key.publicKeyArmored}]);
       }
       // send updated key cache to editor
       var keys = localKeyring.getKeyUserIDs({allUsers: true});
@@ -255,7 +255,8 @@ define(function(require, exports, module) {
     // get all public keys in the local keyring
     var localKeyring = this.keyring.getById(this.mvelo.LOCAL_KEYRING_ID);
     var keys = localKeyring.getKeyUserIDs({allUsers: true});
-    this.emit('public-key-userids', {keys:keys, recipients:recipients});
+    var tofu = this.keyserver.getTOFUPreference();
+    this.emit('public-key-userids', {keys:keys, recipients:recipients, tofu:tofu});
   };
 
   /**

--- a/common/lib/controller/editor.controller.js
+++ b/common/lib/controller/editor.controller.js
@@ -28,6 +28,7 @@ define(function(require, exports, module) {
   var DecryptController = require('./decrypt.controller').DecryptController;
   var uiLog = require('../uiLog');
   var syncCtrl = require('./sync.controller');
+  var KeyServer = require('../keyserver');
 
   function EditorController(port) {
     sub.SubController.call(this, port);
@@ -45,6 +46,7 @@ define(function(require, exports, module) {
     this.signBuffer = null;
     this.pwdControl = null;
     this.keyring = require('../keyring');
+    this.keyserver = new KeyServer();
     this.mailbuild = require('emailjs-mime-builder');
     this.pgpMIME = false;
     this.signMsg = null;
@@ -54,6 +56,7 @@ define(function(require, exports, module) {
     this.on('editor-init', this._onEditorInit);
     this.on('editor-plaintext', this._onSignAndEncrypt);
     this.on('editor-user-input', this._onEditorUserInput);
+    this.on('keyserver-lookup', this.lookupKeyOnServer);
     // standalone editor only
     this.on('editor-cancel', this._onEditorCancel);
     this.on('sign-dialog-init', this._onSignDialogInit);
@@ -201,6 +204,25 @@ define(function(require, exports, module) {
 
   EditorController.prototype._onEditorUserInput = function(msg) {
     uiLog.push(msg.source, msg.type);
+  };
+
+  /**
+   * Lookup a recipient's public key on the Mailvelope Key Server and
+   * store it locally using a TOFU (trust on first use) mechanic.
+   * @param  {Object} msg   The event message object
+   * @return {undefined}
+   */
+  EditorController.prototype.lookupKeyOnServer = function(msg) {
+    return this.keyserver.lookup(msg.recipient).then(function(key) {
+      // persist key in local keyring
+      var localKeyring = this.keyring.getById(this.mvelo.LOCAL_KEYRING_ID);
+      if (key && key.publicKeyArmored) {
+        localKeyring.importKeys([{type: 'public', armored:key.publicKeyArmored}]);
+      }
+      // send updated key cache to editor
+      var keys = localKeyring.getKeyUserIDs({allUsers: true});
+      this.emit('keyserver-response', {keys:keys}, this.ports.editor);
+    }.bind(this));
   };
 
   /**

--- a/common/lib/controller/main.controller.js
+++ b/common/lib/controller/main.controller.js
@@ -161,7 +161,7 @@ define(function(require, exports, module) {
         var localKeyring = keyring.getById(mvelo.LOCAL_KEYRING_ID);
         var primaryKey = localKeyring.getPrimaryKey();
         if (!primaryKey) {
-          sendResponse({error: new Error('Primary key not found')});
+          sendResponse({error: {message: 'Primary key not found'}});
           return;
         }
         keyServer.upload({
@@ -169,9 +169,9 @@ define(function(require, exports, module) {
         }).then(function() {
           sendResponse(true);
         }).catch(function(err) {
-          sendResponse({error: err});
+          sendResponse({error: mvelo.util.mapError(err)});
         });
-        break;
+        return true;
       default:
         console.log('unknown event:', request);
     }

--- a/common/lib/controller/main.controller.js
+++ b/common/lib/controller/main.controller.js
@@ -22,6 +22,8 @@ define(function(require, exports, module) {
   var mvelo = require('../../lib-mvelo').mvelo;
   var model = require('../pgpModel');
   var keyring = require('../keyring');
+  var KeyServer = require('../keyserver');
+  var keyServer = new KeyServer(mvelo);
   var defaults = require('../defaults');
   var prefs = require('../prefs');
   var sub = require('./sub.controller');
@@ -154,6 +156,21 @@ define(function(require, exports, module) {
         break;
       case 'options-ready':
         mvelo.tabs.onOptionsTabReady();
+        break;
+      case 'upload-primary-public-key':
+        var localKeyring = keyring.getById(mvelo.LOCAL_KEYRING_ID);
+        var primaryKey = localKeyring.getPrimaryKey();
+        if (!primaryKey) {
+          sendResponse({error: new Error('Primary key not found')});
+          return;
+        }
+        keyServer.upload({
+          publicKeyArmored: primaryKey.key.toPublic().armor()
+        }).then(function() {
+          sendResponse(true);
+        }).catch(function(err) {
+          sendResponse({error: err});
+        });
         break;
       default:
         console.log('unknown event:', request);

--- a/common/lib/defaults.js
+++ b/common/lib/defaults.js
@@ -71,6 +71,9 @@ define(function(require, exports, module) {
         if (typeof prefs.keyserver == 'undefined') {
           prefs.keyserver = defaults.preferences.keyserver;
         }
+        if (typeof prefs.keyserver.mvelo_tofu_lookup == 'undefined') {
+          prefs.keyserver.mvelo_tofu_lookup = defaults.preferences.keyserver.mvelo_tofu_lookup;
+        }
 
         // merge watchlist on version change
         mergeWatchlist(defaults);

--- a/common/lib/keyserver.js
+++ b/common/lib/keyserver.js
@@ -51,7 +51,7 @@ define(function(require, exports, module) {
    * @yield {Object}                       The public key object
    */
   KeyServer.prototype.lookup = function(options) {
-    return fetch(this._url(options))
+    return this._mvelo.util.fetch(this._url(options))
     .then(function(response) {
       if (response.status === 200) {
         return response.json();
@@ -72,7 +72,7 @@ define(function(require, exports, module) {
     if (options.primaryEmail) {
       payload.primaryEmail = options.primaryEmail;
     }
-    return fetch(this._url(), {
+    return this._mvelo.util.fetch(this._url(), {
       method: 'POST',
       body: JSON.stringify(payload)
     })
@@ -88,7 +88,7 @@ define(function(require, exports, module) {
    * @yield {undefined}
    */
   KeyServer.prototype.remove = function(options) {
-    return fetch(this._url(options), {
+    return this._mvelo.util.fetch(this._url(options), {
       method: 'DELETE'
     })
     .then(this._checkStatus);

--- a/common/lib/keyserver.js
+++ b/common/lib/keyserver.js
@@ -23,9 +23,24 @@
 
 define(function(require, exports, module) {
 
-  function KeyServer() {
-    this._baseUrl = 'https://keys.mailvelope.com';
+  /**
+   * Creates an instance of the keyserver client.
+   * @param {Object} mvelo      An instance of the mvelo lib
+   * @param {String} baseUrl    (optional) The server's base url
+   */
+  function KeyServer(mvelo, baseUrl) {
+    this._mvelo = mvelo;
+    this._baseUrl = baseUrl || 'https://keys.mailvelope.com';
   }
+
+  /**
+   * Check the user's preferences if TOFU/auto-lookup is enabled.
+   * @return {boolean}   If TOFU is enabled or not
+   */
+  KeyServer.prototype.getTOFUPreference = function() {
+    var prefs = this._mvelo.storage.get('mailvelopePreferences');
+    return prefs && prefs.keyserver && prefs.keyserver.mvelo_tofu_lookup === true;
+  };
 
   /**
    * Get a verified public key either from the server by either email address,

--- a/common/lib/keyserver.js
+++ b/common/lib/keyserver.js
@@ -68,9 +68,13 @@ define(function(require, exports, module) {
    * @yield {undefined}
    */
   KeyServer.prototype.upload = function(options) {
+    var payload = {publicKeyArmored: options.publicKeyArmored};
+    if (options.primaryEmail) {
+      payload.primaryEmail = options.primaryEmail;
+    }
     return fetch(this._url(), {
       method: 'POST',
-      body: JSON.stringify(options)
+      body: JSON.stringify(payload)
     })
     .then(this._checkStatus);
   };

--- a/common/lib/keyserver.js
+++ b/common/lib/keyserver.js
@@ -1,0 +1,116 @@
+/**
+ * Mailvelope - secure email with OpenPGP encryption for Webmail
+ * Copyright (C) 2012-2015 Mailvelope GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License version 3
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @fileOverview A simple HTTP client for Mailvelope Key Server's REST api.
+ */
+
+'use strict';
+
+define(function(require, exports, module) {
+
+  function KeyServer() {
+    this._baseUrl = 'https://keys.mailvelope.com';
+  }
+
+  /**
+   * Get a verified public key either from the server by either email address,
+   * key id, or fingerprint.
+   * @param {string} options.email         (optional) The user id's email address
+   * @param {string} options.keyId         (optional) The long 16 char key id
+   * @param {string} options.fingerprint   (optional) The 40 char v4 fingerprint
+   * @yield {Object}                       The public key object
+   */
+  KeyServer.prototype.lookup = function(options) {
+    return fetch(this._url(options))
+    .then(function(response) {
+      if (response.status === 200) {
+        return response.json();
+      }
+    });
+  };
+
+  /**
+   * Upload a public key to the server for verification by the user. Normally
+   * a verification mail is sent out to all of the key's user ids, unless a primary
+   * email attribute is supplied. In which case only one email is sent.
+   * @param {string} options.publicKeyArmored   The ascii armored key block
+   * @param {string} options.primaryEmail       (optional) user's primary email address
+   * @yield {undefined}
+   */
+  KeyServer.prototype.upload = function(options) {
+    return fetch(this._url(), {
+      method: 'POST',
+      body: JSON.stringify(options)
+    })
+    .then(this._checkStatus);
+  };
+
+  /**
+   * Request deletion of a user's key from the keyserver. Either an email address or
+   * the key id have to be specified. The user will receive a verification email
+   * after the request to confirm deletion.
+   * @param {string} options.email   (optional) The user id's email address
+   * @param {string} options.keyId   (optional) The long 16 char key id
+   * @yield {undefined}
+   */
+  KeyServer.prototype.remove = function(options) {
+    return fetch(this._url(options), {
+      method: 'DELETE'
+    })
+    .then(this._checkStatus);
+  };
+
+  /**
+   * Helper function to create a url with the proper query string for an
+   * api request.
+   * @param  {string} options.email         (optional) The user id's email address
+   * @param  {string} options.keyId         (optional) The long 16 char key id
+   * @param  {string} options.fingerprint   (optional) The 40 char v4 fingerprint
+   * @return {string}                       The complete request url
+   */
+  KeyServer.prototype._url = function(options) {
+    var url = this._baseUrl + '/api/v1/key';
+    if (options && options.email) {
+      url += '?email=' + encodeURIComponent(options.email);
+    } else if (options && options.fingerprint) {
+      url += '?fingerprint=' + encodeURIComponent(options.fingerprint);
+    } else if (options && options.keyId) {
+      url += '?keyId=' + encodeURIComponent(options.keyId);
+    }
+    return url;
+  };
+
+  /**
+   * Helper function to deal with the HTTP response status
+   * @param  {Object} response   The fetch api's response object
+   * @return {Object|Error}      Either the response object in case of a successful
+   *                             request or an Error containing the statusText
+   */
+  KeyServer.prototype._checkStatus = function(response) {
+    if (response.status >= 200 && response.status < 300) {
+      return response;
+    } else {
+      var error = new Error(response.statusText);
+      error.response = response;
+      throw error;
+    }
+  };
+
+  module.exports = KeyServer;
+
+});

--- a/common/res/defaults.json
+++ b/common/res/defaults.json
@@ -202,7 +202,8 @@
       "auto_add_primary": true
     },
     "keyserver": {
-      "hkp_base_url": "https://keyserver.ubuntu.com"
+      "hkp_base_url": "https://keyserver.ubuntu.com",
+      "mvelo_tofu_lookup": true
     },
     "main_active": true
   }

--- a/common/ui/editor/editor.js
+++ b/common/ui/editor/editor.js
@@ -74,8 +74,9 @@ EditorCtrl.prototype.verify = function(recipient) {
   }
   // lookup key in local cache
   recipient.key = this.getKey(recipient);
-  if (recipient.key || recipient.checkedServer) {
-    // color tag only if a local key was found or after server lookup
+  if (recipient.key || recipient.checkedServer || !this.tofu) {
+    // color tag only if a local key was found, or after server lookup,
+    // or if TOFU (Trust on First Use) is deactivated
     this.colorTag(recipient);
     this.checkEncryptStatus();
   } else {
@@ -207,9 +208,11 @@ EditorCtrl.prototype.registerEventListeners = function() {
  *                                     keys from the local keychain
  * @param {Array} options.recipients   recipients gather from the
  *                                     webmail ui
+ * @param {boolean} options.tofu       If the editor should to TOFU key lookup
  */
 EditorCtrl.prototype._setRecipients = function(options) {
   this._timeout(function() { // trigger $scope.$digest() after async call
+    this.tofu = options.tofu;
     this.keys = options.keys;
     this.recipients = options.recipients;
     this.recipients.forEach(this.verify.bind(this));

--- a/common/ui/editor/editor.js
+++ b/common/ui/editor/editor.js
@@ -166,8 +166,11 @@ EditorCtrl.prototype.autocomplete = function(query) {
       displayId: key.userid + ' - ' + key.keyid.substr(-8).toUpperCase()
     };
   });
+  // filter by display ID and ignore duplicates
+  var that = this;
   return cache.filter(function(i) {
-    return i.displayId.toLowerCase().indexOf(query.toLowerCase()) !== -1;
+    return i.displayId.toLowerCase().indexOf(query.toLowerCase()) !== -1 &&
+      !that.recipients.some(function(recipient) { return recipient.email === i.email; });
   });
 };
 

--- a/common/ui/fileEncrypt/encryptFile.js
+++ b/common/ui/fileEncrypt/encryptFile.js
@@ -71,7 +71,7 @@ var options = options || null;
     addEncryptInteractivity();
     addDecryptInteractivity();
 
-    $('.alert').hide();
+    $('#encrypting .alert').hide();
 
     options.getAllKeyUserId()
       .then(function(result) {

--- a/common/ui/keyring/generateKey.js
+++ b/common/ui/keyring/generateKey.js
@@ -158,6 +158,7 @@ var options = options || null;
       email: $('#genKeyEmail').val()
     }];
     parameters.passphrase = $('#genKeyPwd').val();
+    parameters.uploadPublicKey = $('#genKeyCheckBoxUpload').prop('checked');
     options.keyring('generateKey', [parameters])
       .then(function(result) {
         $('#genAlert').showAlert(options.l10n.alert_header_success, options.l10n.key_gen_success, 'success');

--- a/common/ui/keyring/keyRing.js
+++ b/common/ui/keyring/keyRing.js
@@ -91,20 +91,29 @@ var options = options || null;
   }
 
   function uploadToKeyServer() {
+    // hide success/error alerts
+    $('#keyUploadErrorAlert').addClass('hidden');
+    $('#keyUploadSuccessAlert').addClass('hidden');
+    // show progress bar
+    $('#keyUploadProgressBar .progress-bar').css('width', '100%');
+    $('#keyUploadProgressBar').removeClass('hidden');
     // send upload event to background script
     mvelo.extension.sendMessage({
       event: 'upload-primary-public-key'
     }, function(response) {
+      // hide progress bar
+      $('#keyUploadProgressBar').addClass('hidden');
       if (response.error) {
-        // TODO use alert and progress bar
-        $('#keyUploadError').modal('show');
+        $('#keyUploadErrorAlert').removeClass('hidden');
       } else {
+        $('#keyUploadSuccessAlert').removeClass('hidden');
         dismissKeyUpload();
       }
     });
   }
 
   function dismissKeyUpload() {
+    $('#keyUploadErrorAlert').addClass('hidden');
     $('#uploadKeyAlert').addClass('hidden');
     var update = {
       keyserver: {dismiss_key_upload: true}

--- a/common/ui/keyring/keyRing.js
+++ b/common/ui/keyring/keyRing.js
@@ -26,7 +26,12 @@ var options = options || null;
     'keygrid_key_not_expire',
     'keygrid_delete_confirmation',
     'keygrid_primary_label',
-    'key_set_as_primary'
+    'key_set_as_primary',
+    'keygrid_upload_alert_title',
+    'keygrid_upload_alert_msg',
+    'learn_more_link',
+    'keygrid_upload_alert_accept',
+    'keygrid_upload_alert_refuse'
   ]);
 
   var keyTmpl;
@@ -70,11 +75,29 @@ var options = options || null;
     $('#exportTabSwitch').on('click', function() {
       $('#exportPublic').get(0).click();
     });
+    $('#uploadKeyAcceptBtn').click(uploadToKeyServer);
+    $('#uploadKeyRefuseBtn').click(refuseUploadKey);
 
     if (!isKeygridLoaded) {
       reload();
       isKeygridLoaded = true;
     }
+  }
+
+  function uploadToKeyServer() {
+    // send upload event to background script
+    mvelo.extension.sendMessage({
+      event: 'upload-primary-public-key'
+    }, function(response) {
+      // TODO: handle upload success/error
+      // TODO: save uploaded state in localstorage
+    });
+    $('#uploadKeyAlert').hide();
+  }
+
+  function refuseUploadKey() {
+    // TODO: save refusal state in localstorage
+    $('#uploadKeyAlert').hide();
   }
 
   function reload() {

--- a/common/ui/keyring/tpl/displayKeys.html
+++ b/common/ui/keyring/tpl/displayKeys.html
@@ -2,6 +2,16 @@
     <span data-l10n-id="keyring_header"></span>
     <span class="third-party-logo"></span>
 </h3>
+
+<div id="uploadKeyAlert" class="alert alert-success" style="position:relative; padding-bottom:60px;">
+  <span class="glyphicon glyphicon-lock"></span>
+  <strong data-l10n-id="keygrid_upload_alert_title"></strong> <span data-l10n-id="keygrid_upload_alert_msg"></span>. <a href="https://keys.mailvelope.com" target="_blank" data-l10n-id="learn_more_link"></a>
+  <div style="position:absolute; bottom:15px; left:15px;">
+    <button id="uploadKeyAcceptBtn" type="button" class="btn btn-success" style="margin-right:5px;" data-l10n-id="keygrid_upload_alert_accept"></button>
+    <button id="uploadKeyRefuseBtn" type="button" class="btn btn-default" data-l10n-id="keygrid_upload_alert_refuse"></button>
+  </div>
+</div><!-- /uploadKeyAlert -->
+
 <div class="table-responsive-custom">
   <table class="table table-striped table-hover optionsTable sortable" id="keyRingTable">
     <div class="tableToolbar">

--- a/common/ui/keyring/tpl/displayKeys.html
+++ b/common/ui/keyring/tpl/displayKeys.html
@@ -3,6 +3,16 @@
     <span class="third-party-logo"></span>
 </h3>
 
+<div id="keyUploadSuccessAlert" class="alert alert-success hidden" role="alert">
+  <strong data-l10n-id="alert_header_success"></strong> <span data-l10n-id="keygrid_upload_success_msg"></span>
+</div>
+<div id="keyUploadErrorAlert" class="alert alert-danger hidden" role="alert">
+  <strong data-l10n-id="alert_header_error"></strong> <span data-l10n-id="keygrid_upload_error_msg"></span>
+</div>
+<div id="keyUploadProgressBar" class="progress hidden">
+  <div class="progress-bar progress-bar-striped active" role="progressbar"></div>
+</div>
+
 <div id="uploadKeyAlert" class="alert alert-success hidden" style="position:relative; padding-bottom:60px;">
   <span class="glyphicon glyphicon-lock"></span>
   <strong data-l10n-id="keygrid_upload_alert_title"></strong> <span data-l10n-id="keygrid_upload_alert_msg"></span>. <a href="https://keys.mailvelope.com" target="_blank" data-l10n-id="learn_more_link"></a>
@@ -11,23 +21,6 @@
     <button id="uploadKeyRefuseBtn" type="button" class="btn btn-default" data-l10n-id="keygrid_upload_alert_refuse"></button>
   </div>
 </div><!-- /uploadKeyAlert -->
-
-<div class="modal" id="keyUploadError" tabindex="-1" role="dialog" aria-hidden="true">
-  <div class="modal-dialog">
-    <div class="modal-content">
-      <div class="modal-header">
-        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-        <h3 data-l10n-id="alert_header_error"></h3>
-      </div>
-      <div class="modal-body">
-        <div data-l10n-id="keygrid_upload_error_msg"></div>
-      </div>
-      <div class="modal-footer">
-        <button type="button" class="btn btn-primary" data-dismiss="modal" data-l10n-id="dialog_popup_close"></button>
-      </div>
-    </div><!-- /.modal-content -->
-  </div><!-- /.modal-dialog -->
-</div><!-- /.modal -->
 
 <div class="table-responsive-custom">
   <table class="table table-striped table-hover optionsTable sortable" id="keyRingTable">

--- a/common/ui/keyring/tpl/displayKeys.html
+++ b/common/ui/keyring/tpl/displayKeys.html
@@ -3,7 +3,7 @@
     <span class="third-party-logo"></span>
 </h3>
 
-<div id="uploadKeyAlert" class="alert alert-success" style="position:relative; padding-bottom:60px;">
+<div id="uploadKeyAlert" class="alert alert-success hidden" style="position:relative; padding-bottom:60px;">
   <span class="glyphicon glyphicon-lock"></span>
   <strong data-l10n-id="keygrid_upload_alert_title"></strong> <span data-l10n-id="keygrid_upload_alert_msg"></span>. <a href="https://keys.mailvelope.com" target="_blank" data-l10n-id="learn_more_link"></a>
   <div style="position:absolute; bottom:15px; left:15px;">
@@ -11,6 +11,23 @@
     <button id="uploadKeyRefuseBtn" type="button" class="btn btn-default" data-l10n-id="keygrid_upload_alert_refuse"></button>
   </div>
 </div><!-- /uploadKeyAlert -->
+
+<div class="modal" id="keyUploadError" tabindex="-1" role="dialog" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+        <h3 data-l10n-id="alert_header_error"></h3>
+      </div>
+      <div class="modal-body">
+        <div data-l10n-id="keygrid_upload_error_msg"></div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-primary" data-dismiss="modal" data-l10n-id="dialog_popup_close"></button>
+      </div>
+    </div><!-- /.modal-content -->
+  </div><!-- /.modal-dialog -->
+</div><!-- /.modal -->
 
 <div class="table-responsive-custom">
   <table class="table table-striped table-hover optionsTable sortable" id="keyRingTable">

--- a/common/ui/keyring/tpl/generateKey.html
+++ b/common/ui/keyring/tpl/generateKey.html
@@ -58,6 +58,14 @@
     <span class="label label-success hide" data-l10n-id="key_gen_pwd_match"></span>
   </div>
   <div class="form-group">
+    <div class="checkbox">
+      <label class="checkbox" for="genKeyCheckBoxUpload">
+        <input type="checkbox" id="genKeyCheckBoxUpload" checked>
+        <span data-l10n-id="key_gen_upload"></span>. <a href="https://keys.mailvelope.com" target="_blank" data-l10n-id="learn_more_link"></a>
+      </label>
+    </div>
+  </div>
+  <div class="form-group">
     <div id="genAlert"></div>
   </div>
   <div class="form-group">

--- a/common/ui/settings/keyserver.js
+++ b/common/ui/settings/keyserver.js
@@ -33,6 +33,7 @@ function KeyServer(mvelo, options) {
 KeyServer.prototype.init = function() {
   // init jquery elements
   this._inputHkpUrl = $('#keyserverInputHkpUrl');
+  this._checkBoxTOFU = $('#keyserverCheckBoxMveloTOFULookup');
   this._saveBtn = $('#keyserverBtnSave');
   this._cancelBtn = $('#keyserverBtnCancel');
   this._alert = $('#keyserverAlert');
@@ -41,6 +42,7 @@ KeyServer.prototype.init = function() {
   this._saveBtn.click(this.save.bind(this));
   this._cancelBtn.click(this.cancel.bind(this));
   this._inputHkpUrl.on('input', this.onChangeHkpUrl.bind(this));
+  this._checkBoxTOFU.click(this.onChangeTOFU.bind(this));
 
   // load preferences
   this.loadPrefs();
@@ -61,6 +63,17 @@ KeyServer.prototype.onChangeHkpUrl = function() {
   this._cancelBtn.prop('disabled', false);
 };
 
+
+/**
+ * Is triggered when the text input for the HKP url changes.
+ * @return {Boolean}   If the event was successful
+ */
+KeyServer.prototype.onChangeTOFU = function() {
+  this.normalize();
+  this._saveBtn.prop('disabled', false);
+  this._cancelBtn.prop('disabled', false);
+};
+
 /**
  * Save the key server settings.
  * @return {Promise}   A promise with an empty result
@@ -69,9 +82,12 @@ KeyServer.prototype.save = function() {
   var self = this;
   var opt = self._options;
   var hkpBaseUrl = self._inputHkpUrl.val();
+  var tofu = self._checkBoxTOFU.prop('checked');
 
   return self.testUrl(hkpBaseUrl).then(function() {
-    var update = {keyserver: {hkp_base_url: hkpBaseUrl}};
+    var update = {
+      keyserver: {hkp_base_url: hkpBaseUrl, mvelo_tofu_lookup: tofu}
+    };
     self._mvelo.extension.sendMessage({event: 'set-prefs', data: update}, function() {
       self.normalize();
       opt.event.triggerHandler('hkp-url-update');
@@ -142,6 +158,7 @@ KeyServer.prototype.loadPrefs = function() {
   var self = this;
   return self._options.pgpModel('getPreferences').then(function(prefs) {
     self._inputHkpUrl.val(prefs.keyserver.hkp_base_url);
+    self._checkBoxTOFU.prop('checked', prefs.keyserver.mvelo_tofu_lookup);
   });
 };
 
@@ -159,7 +176,9 @@ var options = options || null;
     'alert_header_warning',
     'alert_header_error',
     'keyserver_url_warning',
-    'keyserver_url_error'
+    'keyserver_url_error',
+    'keyserver_tofu_label',
+    'keyserver_tofu_lookup'
   ]);
 
   var keyserver = new KeyServer(mvelo, options);

--- a/common/ui/settings/tpl/keyserver.html
+++ b/common/ui/settings/tpl/keyserver.html
@@ -4,6 +4,15 @@
   <div class="form-group">
     <input type="text" class="form-control" id="keyserverInputHkpUrl">
   </div>
+  <label data-l10n-id="keyserver_tofu_label"></label>
+  <div class="form-group">
+    <div class="radio">
+      <label class="checkbox" for="keyserverCheckBoxMveloTOFULookup">
+        <input type="checkbox" id="keyserverCheckBoxMveloTOFULookup" >
+        <span data-l10n-id="keyserver_tofu_lookup"></span>
+      </label>
+    </div>
+  </div>
   <div id="keyserverAlert"></div>
   <div class="form-group">
     <button id="keyserverBtnSave" class="btn btn-primary" disabled data-l10n-id="form_save"></button>

--- a/common/ui/settings/tpl/keyserver.html
+++ b/common/ui/settings/tpl/keyserver.html
@@ -6,10 +6,10 @@
   </div>
   <label data-l10n-id="keyserver_tofu_label"></label>
   <div class="form-group">
-    <div class="radio">
+    <div class="checkbox">
       <label class="checkbox" for="keyserverCheckBoxMveloTOFULookup">
         <input type="checkbox" id="keyserverCheckBoxMveloTOFULookup" >
-        <span data-l10n-id="keyserver_tofu_lookup"></span>
+        <span data-l10n-id="keyserver_tofu_lookup"></span>. <a href="https://keys.mailvelope.com" target="_blank" data-l10n-id="learn_more_link"></a>
       </label>
     </div>
   </div>

--- a/firefox/lib/lib-mvelo.js
+++ b/firefox/lib/lib-mvelo.js
@@ -29,6 +29,7 @@ var l10nGet = require('sdk/l10n').get;
 
 var mvelo = require('../data/common/ui/mvelo').mvelo;
 var CWorker = require('./web-worker').Worker;
+var request = require("sdk/request").Request;
 
 mvelo.ffa = true;
 mvelo.crx = false;
@@ -257,6 +258,35 @@ mvelo.util.getDOMWindow = function() {
 
 mvelo.util.getWorker = function() {
   return CWorker;
+};
+
+mvelo.util.fetch = function(url, options) {
+  options = options || {};
+  return new Promise(function(resolve, reject) {
+    var fetchRequ = request({
+      url: url,
+      content: options.body,
+      contentType: 'application/json',
+      onComplete: function(response) {
+        resolve({
+          status: response.status,
+          json: function() {
+            return Promise.resolve(response.json);
+          }
+        });
+      }
+    });
+    switch (options.method) {
+      case 'POST':
+        fetchRequ.post();
+        break;
+      case 'DELETE':
+        fetchRequ.delete();
+        break;
+      default:
+        fetchRequ.get();
+    }
+  });
 };
 
 mvelo.l10n = mvelo.l10n || {};

--- a/locales/de/messages.json
+++ b/locales/de/messages.json
@@ -311,6 +311,14 @@
     "message": "HKP Schlüssel Server",
     "description": "HKP key server option: url."
   },
+  "keyserver_tofu_label": {
+    "message": "Mailvelope Schlüssel Server",
+    "description": "Mailvelope Key Server Settings Label"
+  },
+  "keyserver_tofu_lookup": {
+    "message": "Automatisch nach Empfänger Schlüssel suchen",
+    "description": "Enable Mailvelope Key Server Auto Lookup"
+  },
   "keyserver_url_warning": {
     "message": "Schlüssel Server URL muss folgendes Format haben: http(s)://keys.example.com",
     "description": "HKP key server url warning."

--- a/locales/de/messages.json
+++ b/locales/de/messages.json
@@ -435,6 +435,14 @@
     "message": "Jahre",
     "description": "Key expires after time range"
   },
+  "key_gen_upload": {
+    "description": "Upload key to Mailvelope key server checkbox",
+    "message": "Öffentlichen Schlüssel zum Mailvelope Schlüssel Server hochladen (kann jederzeit gelöscht werden)"
+  },
+  "learn_more_link": {
+    "description": "Text of a link to a learn-more resource",
+    "message": "Mehr erfahren"
+  },
   "key_import_default_description": {
     "message": "Nach der Bestätigung ist die verschlüsselte Kommunikation mit diesem Kontakt eingerichtet.",
     "description": "Key import dialog description."

--- a/locales/de/messages.json
+++ b/locales/de/messages.json
@@ -463,6 +463,10 @@
     "description": "Upload error message",
     "message": "Hochladen des Schlüssels fehlgeschlagen."
   },
+  "keygrid_upload_success_msg": {
+    "description": "Upload success message",
+    "message": "Hochladen des Schlüssels war erfolgreich."
+  },
   "key_import_default_description": {
     "message": "Nach der Bestätigung ist die verschlüsselte Kommunikation mit diesem Kontakt eingerichtet.",
     "description": "Key import dialog description."

--- a/locales/de/messages.json
+++ b/locales/de/messages.json
@@ -443,6 +443,22 @@
     "description": "Text of a link to a learn-more resource",
     "message": "Mehr erfahren"
   },
+  "keygrid_upload_alert_title": {
+    "description": "Text of a link to a learn-more resource",
+    "message": "Neues Feature!"
+  },
+  "keygrid_upload_alert_msg": {
+    "description": "Text of a link to a learn-more resource",
+    "message": "Sie können Ihren öffentlichen Schlüssel jetzt auf den Mailvelope Schlüssel Server hochladen um automatischen Schlüsselaustausch in beteiligten OpenPGP Plugins zu ermöglichen. Dies verinfacht das Schreiben und Lesen von verschlüsselten Emails mit Ihren Kontakten. Probieren Sie es aus. Sie können Ihren Schlüssel jederzeit löschen"
+  },
+  "keygrid_upload_alert_accept": {
+    "description": "Button text to accept key upload",
+    "message": "Öffentlichen Schlüssel hochladen"
+  },
+  "keygrid_upload_alert_refuse": {
+    "description": "Button text to reject key upload",
+    "message": "Nein danke"
+  },
   "key_import_default_description": {
     "message": "Nach der Bestätigung ist die verschlüsselte Kommunikation mit diesem Kontakt eingerichtet.",
     "description": "Key import dialog description."

--- a/locales/de/messages.json
+++ b/locales/de/messages.json
@@ -459,6 +459,10 @@
     "description": "Button text to reject key upload",
     "message": "Nein danke"
   },
+  "keygrid_upload_error_msg": {
+    "description": "Upload error message",
+    "message": "Hochladen des Schlüssels fehlgeschlagen."
+  },
   "key_import_default_description": {
     "message": "Nach der Bestätigung ist die verschlüsselte Kommunikation mit diesem Kontakt eingerichtet.",
     "description": "Key import dialog description."

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -435,6 +435,14 @@
     "description": "Key expires after time range",
     "message": "years"
   },
+  "key_gen_upload": {
+    "description": "Upload key to Mailvelope key server checkbox",
+    "message": "Upload public key to Mailvelope Key Server (can be deleted at any time)"
+  },
+  "learn_more_link": {
+    "description": "Text of a link to a learn-more resource",
+    "message": "Learn more"
+  },
   "key_import_default_description": {
     "description": "Key import dialog description.",
     "message": "Encrypted communication with this recipient is ready after confirmation."

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -443,6 +443,22 @@
     "description": "Text of a link to a learn-more resource",
     "message": "Learn more"
   },
+  "keygrid_upload_alert_title": {
+    "description": "Text of a link to a learn-more resource",
+    "message": "New feature!"
+  },
+  "keygrid_upload_alert_msg": {
+    "description": "Text of a link to a learn-more resource",
+    "message": "You can now upload your public key to the Mailvelope Key Server for automatic lookup in participating OpenPGP plugins. This makes it easier to write encrypted email with your contacts. Give it a try. You can delete your key at any time"
+  },
+  "keygrid_upload_alert_accept": {
+    "description": "Button text to accept key upload",
+    "message": "Upload public key"
+  },
+  "keygrid_upload_alert_refuse": {
+    "description": "Button text to reject key upload",
+    "message": "No thanks"
+  },
   "key_import_default_description": {
     "description": "Key import dialog description.",
     "message": "Encrypted communication with this recipient is ready after confirmation."

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -463,6 +463,10 @@
     "description": "Upload error message",
     "message": "Key upload failed."
   },
+  "keygrid_upload_success_msg": {
+    "description": "Upload success message",
+    "message": "Key upload successful."
+  },
   "key_import_default_description": {
     "description": "Key import dialog description.",
     "message": "Encrypted communication with this recipient is ready after confirmation."

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -459,6 +459,10 @@
     "description": "Button text to reject key upload",
     "message": "No thanks"
   },
+  "keygrid_upload_error_msg": {
+    "description": "Upload error message",
+    "message": "Key upload failed."
+  },
   "key_import_default_description": {
     "description": "Key import dialog description.",
     "message": "Encrypted communication with this recipient is ready after confirmation."

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -311,6 +311,14 @@
     "description": "HKP key server option: url.",
     "message": "HKP key server"
   },
+  "keyserver_tofu_label": {
+    "description": "Mailvelope Key Server Settings Label",
+    "message": "Mailvelope key server"
+  },
+  "keyserver_tofu_lookup": {
+    "description": "Enable Mailvelope Key Server Auto Lookup",
+    "message": "Automatically lookup recipient keys"
+  },
   "keyserver_url_warning": {
     "description": "HKP key server url warning.",
     "message": "Key server URL must have the following format: http(s)://keys.example.com"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "emailjs-mime-builder": "mailvelope/emailjs-mime-builder#v1.0.1m",
     "emailjs-mime-codec": "mailvelope/emailjs-mime-codec#v1.0.2m",
     "mailreader": "~1.0.0",
-    "ng-tags-input": "~3.0.0"
+    "ng-tags-input": "^3.0.0"
   },
   "devDependencies": {
     "angular-mocks": "~1.5.5",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "grunt-mocha-phantomjs": "^3.0.0",
     "grunt-text-replace": "~0.3.11",
     "mocha": "^2.4.5",
-    "sinon": "^1.17.4"
+    "sinon": "^1.17.4",
+    "whatwg-fetch": "^1.0.0"
   },
   "private": true
 }

--- a/test/common/lib/controller/editor.controller-test.js
+++ b/test/common/lib/controller/editor.controller-test.js
@@ -29,6 +29,45 @@ define(function(require) {
       });
     });
 
+    describe('lookupKeyOnServer', function() {
+      var importKeysStub;
+
+      beforeEach(function() {
+        sinon.stub(ctrl.keyserver, 'lookup');
+        var keyRingMock = {
+          importKeys: function() {},
+          getKeyUserIDs: function() { return [{keyid:'0'}]; }
+        };
+        importKeysStub = sinon.stub(keyRingMock, 'importKeys');
+        sinon.stub(ctrl.keyring, 'getById').returns(keyRingMock);
+      });
+
+      afterEach(function() {
+        ctrl.keyserver.lookup.restore();
+        ctrl.keyring.getById.restore();
+      });
+
+      it('should find a key', function() {
+        ctrl.keyserver.lookup.returns(resolves({publicKeyArmored:'KEY BLOCK'}));
+
+        return ctrl.lookupKeyOnServer({recipient:{email:'a@b.co'}})
+        .then(function() {
+          expect(importKeysStub.calledOnce).to.be.true;
+          expect(ctrl.emit.calledOnce).to.be.true;
+        });
+      });
+
+      it('should not find a key', function() {
+        ctrl.keyserver.lookup.returns(resolves());
+
+        return ctrl.lookupKeyOnServer({recipient:{email:'a@b.co'}})
+        .then(function() {
+          expect(importKeysStub.calledOnce).to.be.false;
+          expect(ctrl.emit.calledOnce).to.be.true;
+        });
+      });
+    });
+
     describe('displayRecipientProposal', function() {
       beforeEach(function() {
         sinon.stub(ctrl.keyring, 'getById').returns({

--- a/test/common/lib/controller/editor.controller-test.js
+++ b/test/common/lib/controller/editor.controller-test.js
@@ -73,25 +73,27 @@ define(function(require) {
         sinon.stub(ctrl.keyring, 'getById').returns({
           getKeyUserIDs: function() { return [{keyid:'0'}]; }
         });
+        sinon.stub(ctrl.keyserver, 'getTOFUPreference').returns(true);
       });
 
       afterEach(function() {
         ctrl.keyring.getById.restore();
+        ctrl.keyserver.getTOFUPreference.restore();
       });
 
       it('should handle empty recipients', function() {
         ctrl.displayRecipientProposal([]);
-        expect(ctrl.emit.withArgs('public-key-userids', {keys:[{keyid:'0'}], recipients:[]}).calledOnce).to.be.true;
+        expect(ctrl.emit.withArgs('public-key-userids', {keys:[{keyid:'0'}], recipients:[], tofu:true}).calledOnce).to.be.true;
       });
 
       it('should handle undefined recipients', function() {
         ctrl.displayRecipientProposal();
-        expect(ctrl.emit.withArgs('public-key-userids', {keys:[{keyid:'0'}], recipients:[]}).calledOnce).to.be.true;
+        expect(ctrl.emit.withArgs('public-key-userids', {keys:[{keyid:'0'}], recipients:[], tofu:true}).calledOnce).to.be.true;
       });
 
       it('should handle recipients', function() {
         ctrl.displayRecipientProposal(testRecipients);
-        expect(ctrl.emit.withArgs('public-key-userids', {keys:[{keyid:'0'}], recipients:testRecipients}).calledOnce).to.be.true;
+        expect(ctrl.emit.withArgs('public-key-userids', {keys:[{keyid:'0'}], recipients:testRecipients, tofu:true}).calledOnce).to.be.true;
       });
     });
 

--- a/test/common/lib/keyring-test.js
+++ b/test/common/lib/keyring-test.js
@@ -32,6 +32,7 @@ define(function(require) {
 
   var mvelo = require('mvelo');
   var Keyring = require('common/lib/keyring').Keyring;
+  var KeyServer = require('common/lib/keyserver');
   var keyringSync = require('common/lib/keyringSync');
   var openpgp = require('openpgp');
 
@@ -40,7 +41,7 @@ define(function(require) {
     var keys = [];
 
     beforeEach(function() {
-      sinon.stub(window, 'fetch');
+      sinon.stub(KeyServer.prototype, 'upload');
       sinon.stub(openpgp, 'generateKeyPair');
       var openpgpKeyring = sinon.createStubInstance(openpgp.Keyring);
       sinon.stub(openpgp, 'Keyring');
@@ -61,7 +62,7 @@ define(function(require) {
     });
 
     afterEach(function() {
-      window.fetch.restore();
+      KeyServer.prototype.upload.restore();
       openpgp.generateKeyPair.restore();
       openpgp.Keyring.restore();
       keyringSync.KeyringSync.restore();
@@ -89,14 +90,14 @@ define(function(require) {
           privateKeyArmored: 'PRIVATE KEY BLOCK'
         }));
         keyring.hasPrimaryKey.returns(true);
-        window.fetch.returns(resolves({status:201}));
+        KeyServer.prototype.upload.returns(resolves({status:201}));
       });
 
       it('should generate and upload key', function() {
         keygenOpt.uploadPublicKey = true;
         return keyring.generateKey(keygenOpt).then(function(key) {
           expect(key.privateKeyArmored).to.exist;
-          expect(window.fetch.calledOnce).to.be.true;
+          expect(KeyServer.prototype.upload.calledOnce).to.be.true;
         });
       });
 
@@ -104,7 +105,7 @@ define(function(require) {
         keygenOpt.uploadPublicKey = false;
         return keyring.generateKey(keygenOpt).then(function(key) {
           expect(key.privateKeyArmored).to.exist;
-          expect(window.fetch.calledOnce).to.be.false;
+          expect(KeyServer.prototype.upload.calledOnce).to.be.false;
         });
       });
     });

--- a/test/common/lib/keyring-test.js
+++ b/test/common/lib/keyring-test.js
@@ -2,12 +2,6 @@
 
 define(function(require) {
 
-  var mvelo = require('mvelo');
-  var openpgp = require('openpgp');
-  var Keyring = require('common/lib/keyring').Keyring;
-  var keyring, pgpKeyring, krSync;
-  var keys = [];
-
   function keyMock(keyid) {
     return {
       verifyPrimaryKey: sinon.stub().returns(openpgp.enums.keyStatus.valid),
@@ -36,9 +30,23 @@ define(function(require) {
     };
   }
 
+  var mvelo = require('mvelo');
+  var Keyring = require('common/lib/keyring').Keyring;
+  var keyringSync = require('common/lib/keyringSync');
+  var openpgp = require('openpgp');
+
   describe('Keyring unit tests', function() {
+    var keyring, pgpKeyring, krSync;
+    var keys = [];
 
     beforeEach(function() {
+      sinon.stub(window, 'fetch');
+      sinon.stub(openpgp, 'generateKeyPair');
+      var openpgpKeyring = sinon.createStubInstance(openpgp.Keyring);
+      sinon.stub(openpgp, 'Keyring');
+      var sync = sinon.createStubInstance(keyringSync.KeyringSync);
+      sinon.stub(keyringSync, 'KeyringSync');
+
       pgpKeyring = {
         getAllKeys: function() {
           return keys;
@@ -46,10 +54,59 @@ define(function(require) {
       };
       krSync = {};
       keyring = new Keyring(mvelo.LOCAL_KEYRING_ID, pgpKeyring, krSync);
+      keyring.keyring = openpgpKeyring;
+      keyring.keyring.privateKeys = [];
+      keyring.sync = sync;
+      sinon.stub(keyring , 'hasPrimaryKey');
     });
 
     afterEach(function() {
+      window.fetch.restore();
+      openpgp.generateKeyPair.restore();
+      openpgp.Keyring.restore();
+      keyringSync.KeyringSync.restore();
       keys = [];
+    });
+
+    describe('generateKey', function() {
+      var keygenOpt;
+
+      beforeEach(function() {
+        keygenOpt = {
+          numBits: 2048,
+          userIds: [{email:'a@b.co', fullName:'A B'}],
+          passphrase: 'secret'
+        };
+
+        var keyStub = sinon.createStubInstance(openpgp.key.Key);
+        keyStub.primaryKey = {
+          getFingerprint: function() {},
+          keyid: {toHex: function() { return 'ASDF'; }}
+        };
+        openpgp.generateKeyPair.returns(resolves({
+          key: keyStub,
+          publicKeyArmored: 'PUBLIC KEY BLOCK',
+          privateKeyArmored: 'PRIVATE KEY BLOCK'
+        }));
+        keyring.hasPrimaryKey.returns(true);
+        window.fetch.returns(resolves({status:201}));
+      });
+
+      it('should generate and upload key', function() {
+        keygenOpt.uploadPublicKey = true;
+        return keyring.generateKey(keygenOpt).then(function(key) {
+          expect(key.privateKeyArmored).to.exist;
+          expect(window.fetch.calledOnce).to.be.true;
+        });
+      });
+
+      it('should generate and not upload key', function() {
+        keygenOpt.uploadPublicKey = false;
+        return keyring.generateKey(keygenOpt).then(function(key) {
+          expect(key.privateKeyArmored).to.exist;
+          expect(window.fetch.calledOnce).to.be.false;
+        });
+      });
     });
 
     describe('getKeyUserIDs', function() {

--- a/test/common/lib/keyring-test.js
+++ b/test/common/lib/keyring-test.js
@@ -48,10 +48,8 @@ define(function(require) {
       var sync = sinon.createStubInstance(keyringSync.KeyringSync);
       sinon.stub(keyringSync, 'KeyringSync');
 
-      pgpKeyring = {
-        getAllKeys: function() {
-          return keys;
-        }
+      openpgpKeyring.getAllKeys = function() {
+        return keys;
       };
       krSync = {};
       keyring = new Keyring(mvelo.LOCAL_KEYRING_ID, pgpKeyring, krSync);

--- a/test/common/lib/keyserver-test.js
+++ b/test/common/lib/keyserver-test.js
@@ -3,24 +3,23 @@
 define(function(require) {
 
   var KeyServer = require('common/lib/keyserver');
-  var keyServer;
+  var keyServer, mvelo;
 
   describe('Key Server unit tests', function() {
 
     beforeEach(function() {
-      var mvelo = {
+      mvelo = {
         storage: {
           get: function() { return {keyserver: {mvelo_tofu_lookup:true}}; }
+        },
+        util: {
+          fetch: function() {}
         }
       };
       keyServer = new KeyServer(mvelo, 'http://localhost:8888');
       expect(keyServer._baseUrl).to.equal('http://localhost:8888');
 
-      sinon.stub(window, 'fetch');
-    });
-
-    afterEach(function() {
-      fetch.restore();
+      sinon.stub(mvelo.util, 'fetch');
     });
 
     describe('getTOFUPreference', function() {
@@ -31,7 +30,7 @@ define(function(require) {
 
     describe('lookup', function() {
       it('should return key', function() {
-        fetch.returns(Promise.resolve({
+        mvelo.util.fetch.returns(Promise.resolve({
           status: 200,
           json: function() { return {foo:'bar'}; }
         }));
@@ -43,7 +42,7 @@ define(function(require) {
       });
 
       it('should not return key', function() {
-        fetch.returns(Promise.resolve({
+        mvelo.util.fetch.returns(Promise.resolve({
           status: 404,
           json: function() { return {foo:'bar'}; }
         }));
@@ -57,7 +56,7 @@ define(function(require) {
 
     describe('upload', function() {
       it('should upload a key', function() {
-        fetch.returns(Promise.resolve({
+        mvelo.util.fetch.returns(Promise.resolve({
           status: 201
         }));
 
@@ -65,7 +64,7 @@ define(function(require) {
       });
 
       it('should not upload a key', function() {
-        fetch.returns(Promise.resolve({
+        mvelo.util.fetch.returns(Promise.resolve({
           status: 304,
           statusText: 'Key already exists'
         }));
@@ -79,7 +78,7 @@ define(function(require) {
 
     describe('remove', function() {
       it('should remove a key', function() {
-        fetch.returns(Promise.resolve({
+        mvelo.util.fetch.returns(Promise.resolve({
           status: 200
         }));
 
@@ -87,7 +86,7 @@ define(function(require) {
       });
 
       it('should not remove a key', function() {
-        fetch.returns(Promise.resolve({
+        mvelo.util.fetch.returns(Promise.resolve({
           status: 404,
           statusText: 'Key not found'
         }));
@@ -101,7 +100,7 @@ define(function(require) {
 
     describe('_url', function() {
       it('should work for email', function() {
-        fetch.returns(Promise.resolve({
+        mvelo.util.fetch.returns(Promise.resolve({
           status: 200
         }));
 
@@ -110,7 +109,7 @@ define(function(require) {
       });
 
       it('should work for key id', function() {
-        fetch.returns(Promise.resolve({
+        mvelo.util.fetch.returns(Promise.resolve({
           status: 200
         }));
 
@@ -119,7 +118,7 @@ define(function(require) {
       });
 
       it('should work for fingerprint', function() {
-        fetch.returns(Promise.resolve({
+        mvelo.util.fetch.returns(Promise.resolve({
           status: 200
         }));
 

--- a/test/common/lib/keyserver-test.js
+++ b/test/common/lib/keyserver-test.js
@@ -1,0 +1,120 @@
+'use strict';
+
+define(function(require) {
+
+  var KeyServer = require('common/lib/keyserver');
+  var keyServer;
+
+  describe('Key Server unit tests', function() {
+
+    beforeEach(function() {
+      keyServer = new KeyServer();
+
+      sinon.stub(window, 'fetch');
+    });
+
+    afterEach(function() {
+      fetch.restore();
+    });
+
+    describe('lookup', function() {
+      it('should return key', function() {
+        fetch.returns(Promise.resolve({
+          status: 200,
+          json: function() { return {foo:'bar'}; }
+        }));
+
+        return keyServer.lookup({email: 'asdf@asdf.de'})
+        .then(function(key) {
+          expect(key.foo).to.equal('bar');
+        });
+      });
+
+      it('should not return key', function() {
+        fetch.returns(Promise.resolve({
+          status: 404,
+          json: function() { return {foo:'bar'}; }
+        }));
+
+        return keyServer.lookup({email: 'asdf@asdf.de'})
+        .then(function(key) {
+          expect(key).to.not.exist;
+        });
+      });
+    });
+
+    describe('upload', function() {
+      it('should upload a key', function() {
+        fetch.returns(Promise.resolve({
+          status: 201
+        }));
+
+        return keyServer.upload({publicKeyArmored:'KEY BLOCK'});
+      });
+
+      it('should not upload a key', function() {
+        fetch.returns(Promise.resolve({
+          status: 304,
+          statusText: 'Key already exists'
+        }));
+
+        return keyServer.upload({publicKeyArmored:'KEY BLOCK'})
+        .catch(function(error) {
+          expect(error.message).to.match(/exists/);
+        });
+      });
+    });
+
+    describe('remove', function() {
+      it('should remove a key', function() {
+        fetch.returns(Promise.resolve({
+          status: 200
+        }));
+
+        return keyServer.remove({email: 'asdf@asdf.de'});
+      });
+
+      it('should not remove a key', function() {
+        fetch.returns(Promise.resolve({
+          status: 404,
+          statusText: 'Key not found'
+        }));
+
+        return keyServer.remove({email: 'asdf@asdf.de'})
+        .catch(function(error) {
+          expect(error.message).to.match(/not found/);
+        });
+      });
+    });
+
+    describe('_url', function() {
+      it('should work for email', function() {
+        fetch.returns(Promise.resolve({
+          status: 200
+        }));
+
+        var url = keyServer._url({email: 'asdf@asdf.de'});
+        expect(url).to.equal('https://keys.mailvelope.com/api/v1/key?email=asdf%40asdf.de');
+      });
+
+      it('should work for key id', function() {
+        fetch.returns(Promise.resolve({
+          status: 200
+        }));
+
+        var url = keyServer._url({keyId: '0123456789ABCDFE'});
+        expect(url).to.equal('https://keys.mailvelope.com/api/v1/key?keyId=0123456789ABCDFE');
+      });
+
+      it('should work for fingerprint', function() {
+        fetch.returns(Promise.resolve({
+          status: 200
+        }));
+
+        var url = keyServer._url({fingerprint: '0123456789ABCDFE0123456789ABCDFE01234567'});
+        expect(url).to.equal('https://keys.mailvelope.com/api/v1/key?fingerprint=0123456789ABCDFE0123456789ABCDFE01234567');
+      });
+    });
+
+  });
+});

--- a/test/common/lib/keyserver-test.js
+++ b/test/common/lib/keyserver-test.js
@@ -8,13 +8,25 @@ define(function(require) {
   describe('Key Server unit tests', function() {
 
     beforeEach(function() {
-      keyServer = new KeyServer();
+      var mvelo = {
+        storage: {
+          get: function() { return {keyserver: {mvelo_tofu_lookup:true}}; }
+        }
+      };
+      keyServer = new KeyServer(mvelo, 'http://localhost:8888');
+      expect(keyServer._baseUrl).to.equal('http://localhost:8888');
 
       sinon.stub(window, 'fetch');
     });
 
     afterEach(function() {
       fetch.restore();
+    });
+
+    describe('getTOFUPreference', function() {
+      it('should return key', function() {
+        expect(keyServer.getTOFUPreference()).to.be.true;
+      });
     });
 
     describe('lookup', function() {
@@ -94,7 +106,7 @@ define(function(require) {
         }));
 
         var url = keyServer._url({email: 'asdf@asdf.de'});
-        expect(url).to.equal('https://keys.mailvelope.com/api/v1/key?email=asdf%40asdf.de');
+        expect(url).to.equal('http://localhost:8888/api/v1/key?email=asdf%40asdf.de');
       });
 
       it('should work for key id', function() {
@@ -103,7 +115,7 @@ define(function(require) {
         }));
 
         var url = keyServer._url({keyId: '0123456789ABCDFE'});
-        expect(url).to.equal('https://keys.mailvelope.com/api/v1/key?keyId=0123456789ABCDFE');
+        expect(url).to.equal('http://localhost:8888/api/v1/key?keyId=0123456789ABCDFE');
       });
 
       it('should work for fingerprint', function() {
@@ -112,7 +124,7 @@ define(function(require) {
         }));
 
         var url = keyServer._url({fingerprint: '0123456789ABCDFE0123456789ABCDFE01234567'});
-        expect(url).to.equal('https://keys.mailvelope.com/api/v1/key?fingerprint=0123456789ABCDFE0123456789ABCDFE01234567');
+        expect(url).to.equal('http://localhost:8888/api/v1/key?fingerprint=0123456789ABCDFE0123456789ABCDFE01234567');
       });
     });
 

--- a/test/common/ui/editor/editor-test.js
+++ b/test/common/ui/editor/editor-test.js
@@ -76,6 +76,7 @@ describe('Editor UI unit tests', function() {
         email: 'jon@smith.com',
         displayId: 'Jon Smith <jon@smith.com>'
       };
+      ctrl.tofu = true;
 
       ctrl.verify(recipient);
 
@@ -103,6 +104,20 @@ describe('Editor UI unit tests', function() {
         displayId: 'Jon Smith <jon@smith.com>',
         checkedServer: true
       };
+
+      ctrl.verify(recipient);
+
+      expect(ctrl.colorTag.withArgs(recipient).calledOnce).to.be.true;
+      expect(ctrl.checkEncryptStatus.calledOnce).to.be.true;
+    });
+
+    it('should color tag if TOFU is deactivated', function() {
+      var recipient = {
+        email: 'jon@smith.com',
+        displayId: 'Jon Smith <jon@smith.com>',
+        checkedServer: undefined
+      };
+      ctrl.tofu = false;
 
       ctrl.verify(recipient);
 
@@ -326,11 +341,13 @@ describe('Editor UI unit tests', function() {
 
     it('should work', function() {
       ctrl._setRecipients({
+        tofu: true,
         keys:[],
         recipients: [{}, {}]
       });
       ctrl._timeout.flush();
 
+      expect(ctrl.tofu).to.be.true;
       expect(ctrl.keys).to.exist;
       expect(ctrl.recipients).to.exist;
       expect(ctrl.verify.callCount).to.equal(2);

--- a/test/common/ui/editor/editor-test.js
+++ b/test/common/ui/editor/editor-test.js
@@ -297,36 +297,49 @@ describe('Editor UI unit tests', function() {
   describe('autocomplete', function() {
     it('should find none for keys undefined', function() {
       ctrl.keys = undefined;
+      ctrl.recipients = [];
       expect(ctrl.autocomplete('jon').length).to.equal(0);
     });
 
     it('should find none for empty keys', function() {
       ctrl.keys = [];
+      ctrl.recipients = [];
       expect(ctrl.autocomplete('jon').length).to.equal(0);
     });
 
     it('should find one for empty email', function() {
       ctrl.keys = [{email: '', userid: 'Jon Smith', keyid: '1ddcee8ad254cc42'}];
+      ctrl.recipients = [];
       expect(ctrl.autocomplete('jon').length).to.equal(1);
+    });
+
+    it('should find none if email is already in recipients', function() {
+      ctrl.keys = [{email: 'j@s.com', userid: 'Jon Smith', keyid: '1ddcee8ad254cc42'}];
+      ctrl.recipients = [{email: 'j@s.com'}];
+      expect(ctrl.autocomplete('jon').length).to.equal(0);
     });
 
     it('should find two matches', function() {
       ctrl.keys = [{userid: 'Jon Smith <j@s.com>', keyid: '1ddcee8ad254cc42'}, {userid: 'jon <j@b.com>', keyid: '1ddcee8ad254cc41'}];
+      ctrl.recipients = [];
       expect(ctrl.autocomplete('jOn').length).to.equal(2);
     });
 
     it('should find one match', function() {
       ctrl.keys = [{userid: 'Jon Smith <j@s.com>', keyid: '1ddcee8ad254cc42'}, {userid: 'jon <j@b.com>', keyid: '1ddcee8ad254cc41'}];
+      ctrl.recipients = [];
       expect(ctrl.autocomplete('sMith').length).to.equal(1);
     });
 
     it('should find match on short keyid', function() {
       ctrl.keys = [{userid: 'Jon Smith <j@s.com>', keyid: '1ddcee8ad254cc42'}, {userid: 'jon <j@b.com>', keyid: '1ddcee8ad254cc41'}];
+      ctrl.recipients = [];
       expect(ctrl.autocomplete('cc42').length).to.equal(1);
     });
 
     it('should concatenate userid and keyid', function() {
       ctrl.keys = [{userid: 'Jon Smith <j@s.com>', keyid: '1ddcee8ad254cc42'}];
+      ctrl.recipients = [];
       expect(ctrl.autocomplete('cc42')[0].displayId).to.equal('Jon Smith <j@s.com> - D254CC42');
     });
   });

--- a/test/config.js
+++ b/test/config.js
@@ -13,8 +13,8 @@ var expect = chai.expect;
 chai.config.includeStack = true;
 
 window.ES6Promise.polyfill(); // load ES6 Promises polyfill
-function resolves(val) { return new Promise(function(res) { res(val); }); }
-function rejects(val) { return new Promise(function(res, rej) { rej(val || new Error()); }); }
+function resolves(val) { return Promise.resolve(val); }
+function rejects(val) { return Promise.reject(val || new Error()); }
 
 window.chrome = window.chrome || {};
 window.chrome.extension = window.chrome.extension || {

--- a/test/index.html
+++ b/test/index.html
@@ -10,6 +10,7 @@
   <!-- polyfills required for PhantomJS -->
   <script src="../node_modules/es6-promise/dist/es6-promise.js"></script>
   <script src="../node_modules/es6-map-shim/es6-map-shim.js"></script>
+  <script src="../node_modules/whatwg-fetch/fetch.js"></script>
 
   <!-- test libs -->
   <script src="../node_modules/chai/chai.js"></script>

--- a/test/main.js
+++ b/test/main.js
@@ -43,7 +43,7 @@ define([
   'test/common/lib/controller/encrypt.controller-test',
   'test/common/lib/controller/editor.controller-test',
   'test/common/lib/keyserver-test',
-  'test/common/lib/keyring-test'
+  'test/common/lib/keyring-test',
 ], function() {
   mocha.run();
 });

--- a/test/main.js
+++ b/test/main.js
@@ -42,6 +42,7 @@ define([
   'test/common/lib/controller/sub.controller-test',
   'test/common/lib/controller/encrypt.controller-test',
   'test/common/lib/controller/editor.controller-test',
+  'test/common/lib/keyserver-test',
   'test/common/lib/keyring-test'
 ], function() {
   mocha.run();


### PR DESCRIPTION
Here is the current state of key server integration

### Done:
- [x] Auto-lookup while adding recipients in external editor
- [x] Auto-lookup opt-out checkbox in key server settings
- [x] Upload public key checkbox when generating new key pair
- [x] Alert existing users to upload primary public key in keyring UI

### TODOs / Bugs:
- [x] Handle key upload success/error in keyring UI alert (did not see a way to pass the response back)
- [x] Store "key uploaded" in localstorage, so that keyring UI alert does not show up again.
- [x] TOFU keys don't show up live in keyring settings UI when added from editor. Refresh needed.
- [x] `keyserver.mvelo_tofu_lookup` in `default.json` did not merged into stored prefs
- [x] Test on Firefox