### PR TITLE
Addition of a Czech Free Mail provider.

### DIFF
--- a/src/res/defaults.json
+++ b/src/res/defaults.json
@@ -222,6 +222,17 @@
           "api": false
         }
       ]
+    },
+    {
+      "active": true,
+      "site": "Volný.cz mail",
+      "frames": [
+        {
+          "scan": true,
+          "frame": "*.mail.volny.cz",
+          "api": false
+        }
+      ]
     }
   ],
   "preferences": {


### PR DESCRIPTION
I would like to propose an addition of Volný.cz email provider to the default settings. The integration is tested and works. Thank you for consideration of this request.