### PR TITLE
Move the encryptframe button not beyond the parent

### DIFF
--- a/src/content-scripts/encryptFrame.js
+++ b/src/content-scripts/encryptFrame.js
@@ -148,8 +148,9 @@ export default class EncryptFrame extends mvelo.EventHandler {
     const editElementPos = this._editElement.position();
     const editElementWidth = this._editElement.width();
     const toolbarWidth = this._eFrame.width();
+    const left = editElementPos.left + editElementWidth - toolbarWidth - 20;
     this._eFrame.css('top', editElementPos.top + 3);
-    this._eFrame.css('left', editElementPos.left + editElementWidth - toolbarWidth - 20);
+    this._eFrame.css('left', left < 0 ? 0 : left);
   }
 
   _showMailEditor() {


### PR DESCRIPTION
With my webmailer I've some problem at this part.  
The substraction `- toolbarWidth - 20` moves the _eFrame to left position -23.  
I think there is some problem to detect the correct editElementWidth.  
The result is, that I can not see the button. It is under some other element of the webmailer.  
But the frame around the button is from -23 to the right border.  
My patch is a fast workaround. I think a negative left-position makes no sense at all and so you can see at least the button.  
Maybe you'll find the real bug and can fix it better.