### PR TITLE
Update copyright year to 2018

### DIFF
--- a/src/app/app.js
+++ b/src/app/app.js
@@ -1,6 +1,6 @@
 /**
  * Mailvelope - secure email with OpenPGP encryption for Webmail
- * Copyright (C) 2012-2017 Mailvelope GmbH
+ * Copyright (C) 2012-2018 Mailvelope GmbH
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License version 3
@@ -311,7 +311,7 @@ export class App extends React.Component {
             )} />
           </div>
           <footer className="row">
-            <p className="pull-left col-md-6">&copy; 2012-2017 Mailvelope GmbH</p>
+            <p className="pull-left col-md-6">&copy; 2012-2018 Mailvelope GmbH</p>
             <div id="version" className="pull-right col-md-6">{this.state.version}</div>
           </footer>
         </div>


### PR DESCRIPTION
Update visible copyright year to 2018 because there were lots of changes done in 2018 and it looks as modern as it should not first sight.