### PR TITLE
Fix filtering User IDs

### DIFF
--- a/src/modules/key.js
+++ b/src/modules/key.js
@@ -324,10 +324,12 @@ export function filterUserIdsByEmail(key, email) {
   const keptUsers = [];
 
   for (const user of key.users) {
-    const userMapped = {userId: user.userId.userid};
-    mapKeyUserIds(userMapped);
-    if (userMapped.email.toLowerCase() === email.toLowerCase()) {
-      keptUsers.push(user);
+    if (user.userId) {
+      const userMapped = {userId: user.userId.userid};
+      mapKeyUserIds(userMapped);
+      if (userMapped.email.toLowerCase() === email.toLowerCase()) {
+        keptUsers.push(user);
+      }
     }
   }
 


### PR DESCRIPTION
Previously User Attributese (such as photos, but not limited to them) would trigger an error because `user.userId` attribute is `null` in that case (`user.userAttribute` property would be set).

The fix checks if an `userId` property is set before using it effectively omitting User Attributes.

See: https://openpgpjs.org/openpgpjs/doc/key.js.html#line800