### PR TITLE
ci: only attempt to build if secrets are present

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,20 @@ cache:
   directories:
   - node_modules
 before_install:
-- openssl aes-256-cbc -K $encrypted_5d28b41102c4_key -iv $encrypted_5d28b41102c4_iv -in .travis/crx_signing.pem.enc -out .travis/crx_signing.pem -d
 - npm install -g grunt-cli
 install:
 - npm install
-script:
-- npm test
-- .travis/deploy-grunt.sh
-- .travis/crxmake.sh build/chrome .travis/crx_signing.pem
+jobs:
+  include:
+  - script: npm test
+  - stage: deploy
+    script:
+      - openssl aes-256-cbc -K $encrypted_5d28b41102c4_key -iv $encrypted_5d28b41102c4_iv -in .travis/crx_signing.pem.enc -out .travis/crx_signing.pem -d
+      - .travis/crxmake.sh build/chrome .travis/crx_signing.pem
+    if: type != pull_request AND env(encrypted_5d28b41102c4_key) IS present
+  - stage: deploy
+    script: .travis/deploy-grunt.sh
+    if: branch = master AND env(GH_TOKEN) IS present
 env:
   global:
   - GH_REF=github.com/mailvelope/mailvelope.git


### PR DESCRIPTION
Otherwise builds on pull requests already fail in the before_install stage.

This pull request splits the test job in three:
* the npm test run
* the optional crxmake in deploy stage. (including the decryption of encrypted files)
* the optional deploy-grunt.sh in deploy stage.

The latter two run in parallel and check if the required environment variables are present
before they even trigger the job. So in forks where this is not the case they will not even show up.

:warning: **This is a pull request against the master branch!** :warning:
I'm happy to replace it with a pr against dev.
However since the deploy tasks only run on master
the only way to make sure this does not break your deploy
is to test it on master.
... So i thought... better propose that right away
then including it in dev without testing it
and then risking a surprise when merging dev.