### PR TITLE
Simplify lookup code

### DIFF
--- a/config/eslint.json
+++ b/config/eslint.json
@@ -64,7 +64,7 @@
     "semi": ["warn", "always"], // require or disallow semicolons instead of ASI
     "semi-spacing": 1, // enforce consistent spacing before and after semicolons
     "space-before-blocks": 1, // enforce consistent spacing before blocks
-    "space-before-function-paren": ["warn", "never"], // enforce consistent spacing before function definition opening parenthesis
+    "space-before-function-paren": ["warn", { "anonymous": "never", "named": "never", "asyncArrow": "always" }], // enforce consistent spacing before function definition opening parenthesis
     "space-in-parens": ["warn", "never"], // enforce consistent spacing inside parentheses
     "space-infix-ops": 1, // require spacing around operators
     /* ES6 */

--- a/src/modules/autoLocate.js
+++ b/src/modules/autoLocate.js
@@ -18,8 +18,6 @@ import {lookup as wkdLookup} from './wkdLocate';
  * key id, or fingerprint.
  *
  * @param {String} [options.email] - The user id's email address
- * @param {String} [options.keyId] - The long 16 char key id
- * @param {String} [options.fingerprint] - The 40 char v4 fingerprint
  * @return {String} - if auto-locate is successful the found armored key
  */
 export async function locate(options) {

--- a/src/modules/autoLocate.js
+++ b/src/modules/autoLocate.js
@@ -38,7 +38,7 @@ export async function locate(options) {
   if (!armored && options.email && isWKDEnabled()) {
     // As we do not (yet) handle key updates through WKD we only want one key.
     try {
-      armored = await wkdLookup(options.email, true);
+      armored = await wkdLookup(options.email);
     } catch (e) {
       // WKD Failures are not critical so we only info log them.
       console.log(`WKD: Did not find key (Errors are expected): ${e}`);

--- a/src/modules/autoLocate.js
+++ b/src/modules/autoLocate.js
@@ -24,13 +24,13 @@ export async function locate(options) {
   let armored;
 
   const strategies = [
-    { name: 'Mailvelope Server',
+    {name: 'Mailvelope Server',
       isEnabled: isMveloKeyServerEnabled,
-      lookup: mveloKSLookup },
-    { name: 'WKD',
+      lookup: mveloKSLookup},
+    {name: 'WKD',
       isEnabled: isWKDEnabled,
-      lookup: wkdLookup }
-  ]
+      lookup: wkdLookup}
+  ];
 
   for (const strategy of strategies) {
     if (strategy.isEnabled()) {
@@ -41,7 +41,7 @@ export async function locate(options) {
         }
       } catch (e) {
         // Failures are not critical so we only info log them.
-        console.log(strategy.name + `: Did not find key (Errors are expected): ${e}`);
+        console.log(`${strategy.name}: Did not find key (Errors are expected): ${e}`);
       }
     }
   }

--- a/src/modules/autoLocate.js
+++ b/src/modules/autoLocate.js
@@ -24,10 +24,7 @@ export async function locate(options) {
   let armored;
   if (isMveloKeyServerEnabled()) {
     try {
-      const key = await mveloKSLookup(options.email);
-      if (key) {
-        armored = key.publicKeyArmored;
-      }
+      armored = await mveloKSLookup(options.email);
     } catch (e) {
       // Failures are not critical so we only info log them.
       console.log(`Mailvelope Server: Did not find key (Errors are expected): ${e}`);

--- a/src/modules/autoLocate.js
+++ b/src/modules/autoLocate.js
@@ -21,21 +21,20 @@ import {lookup as wkdLookup} from './wkdLocate';
  * @return {String} - if auto-locate is successful the found armored key
  */
 export async function locate(options) {
-  let armored;
-
-  const strategies = [
-    {name: 'Mailvelope Server',
-      isEnabled: isMveloKeyServerEnabled,
-      lookup: mveloKSLookup},
-    {name: 'WKD',
-      isEnabled: isWKDEnabled,
-      lookup: wkdLookup}
-  ];
+  const strategies = [{
+    name: 'Mailvelope Server',
+    isEnabled: isMveloKeyServerEnabled,
+    lookup: mveloKSLookup
+  }, {
+    name: 'WKD',
+    isEnabled: isWKDEnabled,
+    lookup: wkdLookup
+  }];
 
   for (const strategy of strategies) {
     if (strategy.isEnabled()) {
       try {
-        armored = await strategy.lookup(options.email);
+        const armored = await strategy.lookup(options.email);
         if (armored) {
           return armored;
         }

--- a/src/modules/autoLocate.js
+++ b/src/modules/autoLocate.js
@@ -24,7 +24,7 @@ export async function locate(options) {
   let armored;
   if (isMveloKeyServerEnabled()) {
     try {
-      const key = await mveloKSLookup(options);
+      const key = await mveloKSLookup(options.email);
       if (key) {
         armored = key.publicKeyArmored;
       }

--- a/src/modules/mveloKeyServer.js
+++ b/src/modules/mveloKeyServer.js
@@ -14,16 +14,13 @@ import {filterUserIdsByEmail} from './key';
 const DEFAULT_URL = 'https://keys.mailvelope.com';
 
 /**
- * Get a verified public key either from the server by either email address,
- * key id, or fingerprint.
+ * Get a verified public key from the server by email address.
  *
- * If only the email is provided it will only return keys with UserIDs that
- * match the email. In that case the userIds from the json object are purely
- * informational as the userIds that are also on the key on the Key Server.
+ * It will only return keys with UserIDs that match the email.
+ * The userIds from the json object are purely informational
+ * as the userIds that are also on the key on the Key Server.
  *
  * @param {string} options.email         (optional) The user id's email address
- * @param {string} options.keyId         (optional) The long 16 char key id
- * @param {string} options.fingerprint   (optional) The 40 char v4 fingerprint
  * @yield {Object}                       The public key json object
  */
 export async function lookup(options) {
@@ -33,11 +30,10 @@ export async function lookup(options) {
     jsonKey = await response.json();
   }
 
-  if (jsonKey && options.email && !options.keyId && !options.fingerprint) {
-    // When only fetching by email only the userid matching
-    // the email should be imported. This avoids usability problems
-    // and potentioal security issues when unreleated userids are also part
-    // of the key.
+  if (jsonKey) {
+    // Only the userid matching the email should be imported.
+    // This avoids usability problems and potentioal security issues
+    // when unreleated userids are also part of the key.
     const parseResult = await openpgpKey.readArmored(jsonKey.publicKeyArmored);
     if (parseResult.err) {
       throw new Error(`mveloKeyServer: Failed to parse response '${jsonKey}': ${parseResult.err}`);
@@ -56,6 +52,26 @@ export async function lookup(options) {
     console.log(`mveloKeyServer: fetched key: '${filtered.primaryKey.getFingerprint()}'`);
   }
 
+  return jsonKey;
+}
+
+/**
+ * Get a verified public key either from the server by either key id, or fingerprint.
+ *
+ * We are not using this function yet.
+ * It's part of the Mailvelope Key Server API - so we leave this here
+ * for later use.
+ *
+ * @param {string} options.keyId         (optional) The long 16 char key id
+ * @param {string} options.fingerprint   (optional) The 40 char v4 fingerprint
+ * @yield {Object}                       The public key json object
+ */
+export async function fetch(options) {
+  let jsonKey;
+  const response = await window.fetch(url(options));
+  if (response.status === 200) {
+    jsonKey = await response.json();
+  }
   return jsonKey;
 }
 

--- a/src/modules/mveloKeyServer.js
+++ b/src/modules/mveloKeyServer.js
@@ -29,12 +29,10 @@ export async function lookup(email) {
   if (!email) {
     throw new Error("mveloKeyServer: Skipping lookup without email.");
   }
-
   const response = await window.fetch(url({email}));
   if (response.status === 200) {
     jsonKey = await response.json();
   }
-
   if (!jsonKey) {
     return;
   }
@@ -46,17 +44,15 @@ export async function lookup(email) {
   if (parseResult.err) {
     throw new Error(`mveloKeyServer: Failed to parse response '${jsonKey}': ${parseResult.err}`);
   }
-
   const keys = parseResult.keys;
   if (keys.length !== 1) {
     throw new Error(`mveloKeyServer: Response '${jsonKey}': contained ${keys.length} keys.`);
   }
-
   const filtered = filterUserIdsByEmail(keys[0], email);
+
   if (!filtered.users.length) {
     throw new Error(`mveloKeyServer: Response '${jsonKey}': contained no matching userIds.`);
   }
-
   console.log(`mveloKeyServer: fetched key: '${filtered.primaryKey.getFingerprint()}'`);
   return filtered.armor();
 }

--- a/src/modules/mveloKeyServer.js
+++ b/src/modules/mveloKeyServer.js
@@ -30,13 +30,13 @@ export async function lookup(email) {
     throw new Error("mveloKeyServer: Skipping lookup without email.");
   }
 
-  const response = await window.fetch(url({email: email}));
+  const response = await window.fetch(url({email}));
   if (response.status === 200) {
     jsonKey = await response.json();
   }
 
   if (!jsonKey) {
-    return
+    return;
   }
 
   // Only the userid matching the email should be imported.

--- a/src/modules/mveloKeyServer.js
+++ b/src/modules/mveloKeyServer.js
@@ -20,12 +20,16 @@ const DEFAULT_URL = 'https://keys.mailvelope.com';
  * The userIds from the json object are purely informational
  * as the userIds that are also on the key on the Key Server.
  *
- * @param {string} options.email         (optional) The user id's email address
- * @yield {Object}                       The public key json object
+ * @param {string} email         The user id's email address
+ * @yield {Object}               The public key json object
  */
-export async function lookup(options) {
+export async function lookup(email) {
   let jsonKey;
-  const response = await window.fetch(url(options));
+  if (!email) {
+    throw new Error("mveloKeyServer: Skipping lookup without email.");
+  }
+
+  const response = await window.fetch(url({email: email}));
   if (response.status === 200) {
     jsonKey = await response.json();
   }
@@ -44,7 +48,7 @@ export async function lookup(options) {
       throw new Error(`mveloKeyServer: Response '${jsonKey}': contained ${keys.length} keys.`);
     }
 
-    const filtered = filterUserIdsByEmail(keys[0], options.email);
+    const filtered = filterUserIdsByEmail(keys[0], email);
     if (!filtered.users.length) {
       throw new Error(`mveloKeyServer: Response '${jsonKey}': contained no matching userIds.`);
     }

--- a/test/modules/autoLocate-test.js
+++ b/test/modules/autoLocate-test.js
@@ -5,16 +5,15 @@ import keyFixtures from 'Fixtures/keys';
 
 describe('Looking up keys from different services', () => {
   describe('with all services disabled', () => {
-    it('should return an empty result', () => {
+    it('should return an empty result', async () => {
       prefs.prefs.keyserver = {
         wkd_lookup: false,
         mvelo_tofu_lookup: false
       };
       expect(autoLocate.isWKDEnabled()).to.be.false;
       expect(autoLocate.isMveloKeyServerEnabled()).to.be.false;
-      return autoLocate.locate({}).then(ret => {
-        expect(ret).to.be.undefined;
-      });
+      const key = await autoLocate.locate({});
+      expect(key).to.be.undefined;
     });
   });
 

--- a/test/modules/autoLocate-test.js
+++ b/test/modules/autoLocate-test.js
@@ -4,7 +4,6 @@ import * as prefs from 'modules/prefs';
 import keyFixtures from 'Fixtures/keys';
 
 describe('Looking up keys from different services', () => {
-
   describe('with all services disabled', () => {
     it('should return an empty result', () => {
       prefs.prefs.keyserver = {
@@ -13,7 +12,7 @@ describe('Looking up keys from different services', () => {
       };
       expect(autoLocate.isWKDEnabled()).to.be.false;
       expect(autoLocate.isMveloKeyServerEnabled()).to.be.false;
-      return autoLocate.locate({}).then((ret) => {
+      return autoLocate.locate({}).then(ret => {
         expect(ret).to.be.undefined;
       });
     });
@@ -32,17 +31,15 @@ describe('Looking up keys from different services', () => {
       window.fetch.restore();
     });
 
-    it('should not try the other services', () => {
+    it('should not try the other services', async () => {
       prefs.prefs.keyserver = {
         wkd_lookup: true,
         mvelo_tofu_lookup: true
       };
       expect(autoLocate.isWKDEnabled()).to.be.true;
       expect(autoLocate.isMveloKeyServerEnabled()).to.be.true;
-      return autoLocate.locate({email: 'test@mailvelope.com'})
-      .then(key => {
-        expect(key).to.include('PGP PUBLIC KEY BLOCK');
-      });
+      const key = await autoLocate.locate({email: 'test@mailvelope.com'});
+      expect(key).to.include('PGP PUBLIC KEY BLOCK');
     });
   });
 });

--- a/test/modules/autoLocate-test.js
+++ b/test/modules/autoLocate-test.js
@@ -1,0 +1,48 @@
+import {expect, sinon} from 'test';
+import * as autoLocate from 'modules/autoLocate';
+import * as prefs from 'modules/prefs';
+import keyFixtures from 'Fixtures/keys';
+
+describe('Looking up keys from different services', () => {
+
+  describe('with all services disabled', () => {
+    it('should return an empty result', () => {
+      prefs.prefs.keyserver = {
+        wkd_lookup: false,
+        mvelo_tofu_lookup: false
+      };
+      expect(autoLocate.isWKDEnabled()).to.be.false;
+      expect(autoLocate.isMveloKeyServerEnabled()).to.be.false;
+      return autoLocate.locate({}).then((ret) => {
+        expect(ret).to.be.undefined;
+      });
+    });
+  });
+
+  describe('with Mailvelope Keyserver returning an result', () => {
+    beforeEach(() => {
+      sinon.stub(window, 'fetch');
+      window.fetch.returns(Promise.resolve({
+        status: 200,
+        json() { return {publicKeyArmored: keyFixtures.public.demo}; }
+      }));
+    });
+
+    afterEach(() => {
+      window.fetch.restore();
+    });
+
+    it('should not try the other services', () => {
+      prefs.prefs.keyserver = {
+        wkd_lookup: true,
+        mvelo_tofu_lookup: true
+      };
+      expect(autoLocate.isWKDEnabled()).to.be.true;
+      expect(autoLocate.isMveloKeyServerEnabled()).to.be.true;
+      return autoLocate.locate({email: 'test@mailvelope.com'})
+      .then(key => {
+        expect(key).to.include('PGP PUBLIC KEY BLOCK');
+      });
+    });
+  });
+});

--- a/test/modules/mveloKeyServer-test.js
+++ b/test/modules/mveloKeyServer-test.js
@@ -17,7 +17,7 @@ describe('Talking to the Mailvelope Key Server', () => {
         status: 404,
         json() { return {}; }
       }));
-      return mveloKeyServer.lookup({email: 'test@mailvelope.com'})
+      return mveloKeyServer.lookup('test@mailvelope.com')
       .then(() => {
         expect(window.fetch.args[0][0]).to.equal('https://keys.mailvelope.com/api/v1/key?email=test%40mailvelope.com');
       });
@@ -29,7 +29,7 @@ describe('Talking to the Mailvelope Key Server', () => {
         json() { return {publicKeyArmored: keyFixtures.public.demo}; }
       }));
 
-      return mveloKeyServer.lookup({email: 'test@mailvelope.com'})
+      return mveloKeyServer.lookup('test@mailvelope.com')
       .then(key => {
         expect(key.publicKeyArmored).to.include('PGP PUBLIC KEY BLOCK');
       });
@@ -41,7 +41,7 @@ describe('Talking to the Mailvelope Key Server', () => {
         json() { return {}; }
       }));
 
-      return mveloKeyServer.lookup({email: 'asdf@asdf.de'})
+      return mveloKeyServer.lookup('asdf@asdf.de')
       .then(key => {
         expect(key).to.not.exist;
       });

--- a/test/modules/mveloKeyServer-test.js
+++ b/test/modules/mveloKeyServer-test.js
@@ -12,55 +12,47 @@ describe('Talking to the Mailvelope Key Server', () => {
   });
 
   describe('lookup', () => {
-    it('should query for the key by email', () => {
+    it('should query for the key by email', async () => {
       window.fetch.returns(Promise.resolve({
         status: 404,
         json() { return {}; }
       }));
-      return mveloKeyServer.lookup('test@mailvelope.com')
-      .then(() => {
-        expect(window.fetch.args[0][0]).to.equal('https://keys.mailvelope.com/api/v1/key?email=test%40mailvelope.com');
-      });
+      await mveloKeyServer.lookup('test@mailvelope.com');
+      expect(window.fetch.args[0][0]).to.equal('https://keys.mailvelope.com/api/v1/key?email=test%40mailvelope.com');
     });
 
-    it('should return key on success', () => {
+    it('should return key on success', async () => {
       window.fetch.returns(Promise.resolve({
         status: 200,
         json() { return {publicKeyArmored: keyFixtures.public.demo}; }
       }));
 
-      return mveloKeyServer.lookup('test@mailvelope.com')
-      .then(key => {
-        expect(key).to.include('PGP PUBLIC KEY BLOCK');
-      });
+      const key = await mveloKeyServer.lookup('test@mailvelope.com');
+      expect(key).to.include('PGP PUBLIC KEY BLOCK');
     });
 
-    it('should not return key on 404', () => {
+    it('should not return key on 404', async () => {
       window.fetch.returns(Promise.resolve({
         status: 404,
         json() { return {}; }
       }));
 
-      return mveloKeyServer.lookup('asdf@asdf.de')
-      .then(key => {
-        expect(key).to.not.exist;
-      });
+      const key = await mveloKeyServer.lookup('asdf@asdf.de');
+      expect(key).to.not.exist;
     });
   });
 
   describe('fetch', () => {
-    it('should query for the key by keyId', () => {
+    it('should query for the key by keyId', async () => {
       window.fetch.returns(Promise.resolve({
         status: 404,
         json() { return {}; }
       }));
-      return mveloKeyServer.fetch({keyId: '0123456789ABCDFE'})
-      .then(() => {
-        expect(window.fetch.args[0][0]).to.include('/api/v1/key?keyId=0123456789ABCDFE');
-      });
+      await mveloKeyServer.fetch({keyId: '0123456789ABCDFE'});
+      expect(window.fetch.args[0][0]).to.include('/api/v1/key?keyId=0123456789ABCDFE');
     });
 
-    it('should query for the key by fingerprint', () => {
+    it('should query for the key by fingerprint', async () => {
       window.fetch.returns(Promise.resolve({
         status: 404,
         json() { return {}; }

--- a/test/modules/mveloKeyServer-test.js
+++ b/test/modules/mveloKeyServer-test.js
@@ -71,7 +71,6 @@ describe('Talking to the Mailvelope Key Server', () => {
         expect(window.fetch.args[0][0]).to.include('/api/v1/key?fingerprint=0123456789ABCDFE0123456789ABCDFE01234567');
       });
     });
-
   });
 
   describe('upload', () => {

--- a/test/modules/mveloKeyServer-test.js
+++ b/test/modules/mveloKeyServer-test.js
@@ -23,29 +23,6 @@ describe('Talking to the Mailvelope Key Server', () => {
       });
     });
 
-    it('should query for the key by keyId', () => {
-      window.fetch.returns(Promise.resolve({
-        status: 404,
-        json() { return {}; }
-      }));
-      return mveloKeyServer.lookup({keyId: '0123456789ABCDFE'})
-      .then(() => {
-        expect(window.fetch.args[0][0]).to.include('/api/v1/key?keyId=0123456789ABCDFE');
-      });
-    });
-
-    it('should query for the key by fingerprint', () => {
-      window.fetch.returns(Promise.resolve({
-        status: 404,
-        json() { return {}; }
-      }));
-
-      return mveloKeyServer.lookup({fingerprint: '0123456789ABCDFE0123456789ABCDFE01234567'})
-      .then(() => {
-        expect(window.fetch.args[0][0]).to.include('/api/v1/key?fingerprint=0123456789ABCDFE0123456789ABCDFE01234567');
-      });
-    });
-
     it('should return key on success', () => {
       window.fetch.returns(Promise.resolve({
         status: 200,
@@ -69,6 +46,32 @@ describe('Talking to the Mailvelope Key Server', () => {
         expect(key).to.not.exist;
       });
     });
+  });
+
+  describe('fetch', () => {
+    it('should query for the key by keyId', () => {
+      window.fetch.returns(Promise.resolve({
+        status: 404,
+        json() { return {}; }
+      }));
+      return mveloKeyServer.fetch({keyId: '0123456789ABCDFE'})
+      .then(() => {
+        expect(window.fetch.args[0][0]).to.include('/api/v1/key?keyId=0123456789ABCDFE');
+      });
+    });
+
+    it('should query for the key by fingerprint', () => {
+      window.fetch.returns(Promise.resolve({
+        status: 404,
+        json() { return {}; }
+      }));
+
+      return mveloKeyServer.fetch({fingerprint: '0123456789ABCDFE0123456789ABCDFE01234567'})
+      .then(() => {
+        expect(window.fetch.args[0][0]).to.include('/api/v1/key?fingerprint=0123456789ABCDFE0123456789ABCDFE01234567');
+      });
+    });
+
   });
 
   describe('upload', () => {

--- a/test/modules/mveloKeyServer-test.js
+++ b/test/modules/mveloKeyServer-test.js
@@ -31,7 +31,7 @@ describe('Talking to the Mailvelope Key Server', () => {
 
       return mveloKeyServer.lookup('test@mailvelope.com')
       .then(key => {
-        expect(key.publicKeyArmored).to.include('PGP PUBLIC KEY BLOCK');
+        expect(key).to.include('PGP PUBLIC KEY BLOCK');
       });
     });
 


### PR DESCRIPTION
* we only ever fetch a single key from WKD for now
* we never lookup keys by key id or fingerprint from Mailvelope Key Server for now
* we always need an email for lookup
* we only use the armored key

This allows us to make WKD and Mailvelope Key Server lookup have the same signature and then define a set of strategies and try them one after the other.

This will hopefully make adding Autocrypt as a third lookup source easier.