### PR TITLE
Add clickable links and emails to decrypted message

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8244,6 +8244,16 @@
         "immediate": "~3.0.5"
       }
     },
+    "linkifyjs": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-2.1.7.tgz",
+      "integrity": "sha512-Cbn77BnYEslpAObZZoP6GVQHF1j5T6RsDydNq5RVxIy4eiZAiADRx7qHfWzfEMQecc1PtZFog1AsCGGX2WjQLA==",
+      "requires": {
+        "jquery": "^3.3.1",
+        "react": "^16.4.2",
+        "react-dom": "^16.4.2"
+      }
+    },
     "livereload-js": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/livereload-js/-/livereload-js-2.4.0.tgz",
@@ -9575,7 +9585,7 @@
         "node-localstorage": "~1.3.0",
         "pako": "^1.0.6",
         "seek-bzip": "github:openpgpjs/seek-bzip#3aca608ffedc055a1da1d898ecb244804ef32209",
-        "web-stream-tools": "github:openpgpjs/web-stream-tools#9ab800d46add161db496506d67338202ad0114ce"
+        "web-stream-tools": "github:openpgpjs/web-stream-tools#04aa4e195d2edb3ca63877f270995f89e738ca11"
       }
     },
     "opn": {
@@ -14002,7 +14012,7 @@
       }
     },
     "web-stream-tools": {
-      "version": "github:openpgpjs/web-stream-tools#9ab800d46add161db496506d67338202ad0114ce",
+      "version": "github:openpgpjs/web-stream-tools#04aa4e195d2edb3ca63877f270995f89e738ca11",
       "from": "github:openpgpjs/web-stream-tools"
     },
     "webextension-polyfill": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "font-awesome": "4.7.0",
     "gpgmejs": "github:mailvelope/gpgmejs",
     "jquery": "3.3.1",
+    "linkifyjs": "^2.1.7",
     "moment": "2.23.0",
     "ng-tags-input": "3.2.0",
     "openpgp": "4.3.0",

--- a/src/lib/autolink.js
+++ b/src/lib/autolink.js
@@ -1,0 +1,33 @@
+import {tokenize} from 'linkifyjs';
+
+function escapeAttr(str) {
+  return str.replace(/"/g, '&quot;');
+}
+
+export default (str, {defaultProtocoll = 'https', nl2br = true, target = '_blank', escapeFn = text => text}) => {
+  const tokens = tokenize(str);
+  const result = [];
+
+  for (let i = 0; i < tokens.length; i++) {
+    const token = tokens[i];
+
+    if (token.type === 'nl' && nl2br) {
+      result.push('<br>\n');
+      continue;
+    } else if (!token.isLink) {
+      result.push(escapeFn(token.toString()));
+      continue;
+    }
+
+    let link = `<a href="${escapeAttr(token.toHref(defaultProtocoll))}"`;
+
+    if (target) {
+      link += ` target="${escapeAttr(target)}"`;
+    }
+
+    link += `>${escapeFn(token.toString())}</a>`;
+    result.push(link);
+  }
+
+  return result.join('');
+};

--- a/src/lib/autolink.js
+++ b/src/lib/autolink.js
@@ -4,13 +4,11 @@ function escapeAttr(str) {
   return str.replace(/"/g, '&quot;');
 }
 
-export default (str, {defaultProtocoll = 'https', nl2br = true, target = '_blank', escapeFn = text => text}) => {
+export default function autolink(str, {defaultProtocoll = 'https', nl2br = true, target = '_blank', escapeFn = text => text}) {
   const tokens = tokenize(str);
   const result = [];
 
-  for (let i = 0; i < tokens.length; i++) {
-    const token = tokens[i];
-
+  for (const token of tokens) {
     if (token.type === 'nl' && nl2br) {
       result.push('<br>\n');
       continue;
@@ -30,4 +28,4 @@ export default (str, {defaultProtocoll = 'https', nl2br = true, target = '_blank
   }
 
   return result.join('');
-};
+}

--- a/src/lib/lib-mvelo.js
+++ b/src/lib/lib-mvelo.js
@@ -6,6 +6,7 @@
 import mveloGlobal from '../mvelo';
 import browser from 'webextension-polyfill';
 import dompurify from 'dompurify';
+import autoLink from './autolink';
 
 const mvelo = {...mveloGlobal};
 
@@ -147,6 +148,10 @@ dompurify.addHook('afterSanitizeAttributes', node => {
 
 mvelo.util.sanitizeHTML = function(html) {
   return dompurify.sanitize(html, {SAFE_FOR_JQUERY: true});
+};
+
+mvelo.util.text2autoLinkHtml = function(text) {
+  return mvelo.util.sanitizeHTML(autoLink(text, {defaultProtocol: 'https', escapeFn: mvelo.util.encodeHTML}));
 };
 
 mvelo.util.getHostname = function(url) {

--- a/src/modules/mime.js
+++ b/src/modules/mime.js
@@ -38,7 +38,7 @@ function parseMIME(rawText, handlers, encoding) {
           } else {
             filterBodyParts(parsed, 'text', textParts);
             if (textParts.length) {
-              handlers.onMessage(textParts.map(part => mvelo.util.text2html(part.content)).join('<hr>'));
+              handlers.onMessage(textParts.map(part => mvelo.util.text2autoLinkHtml(part.content)).join('<hr>'));
             }
           }
         } else if (encoding === 'text') {

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -33,6 +33,7 @@ module.exports = function(config) {
       'components/**/*.js',
       'content-scripts/**/*.js',
       'controller/**/*.js',
+      'lib/**/*.js',
       'modules/**/*.js',
     ],
 

--- a/test/lib/lib-mvelo-test.js
+++ b/test/lib/lib-mvelo-test.js
@@ -1,0 +1,34 @@
+import {expect} from 'test';
+import mvelo from 'lib/lib-mvelo';
+
+describe('lib-mvelo unit tests', () => {
+  describe('text2autoLinkHtml', () => {
+    it('should auto link simple domain', () => {
+      expect(mvelo.util.text2autoLinkHtml('mailvelope.com')).to.equal('<a href="https://mailvelope.com" target="_blank">mailvelope.com</a>');
+    });
+    it('should auto link domain with query', () => {
+      expect(mvelo.util.text2autoLinkHtml('www.mailvelope.com/?key=value')).to.equal('<a href="https://www.mailvelope.com/?key=value" target="_blank">www.mailvelope.com/?key=value</a>');
+    });
+    it('should auto link domain with port', () => {
+      expect(mvelo.util.text2autoLinkHtml('www.mailvelope.com:8000')).to.equal('<a href="https://www.mailvelope.com:8000" target="_blank">www.mailvelope.com:8000</a>');
+    });
+    it('should auto link URL with scheme', () => {
+      expect(mvelo.util.text2autoLinkHtml('http://www.mailvelope.com')).to.equal('<a href="http://www.mailvelope.com" target="_blank">http://www.mailvelope.com</a>');
+    });
+    it('should auto link email address', () => {
+      expect(mvelo.util.text2autoLinkHtml('info@mailvelope.com')).to.equal('<a href="mailto:info@mailvelope.com" target="_blank">info@mailvelope.com</a>');
+    });
+    it('should auto link mixed case URL', () => {
+      expect(mvelo.util.text2autoLinkHtml('mailvelope.com/keyring?id=pS-gbqbVd8c')).to.equal('<a href="https://mailvelope.com/keyring?id=pS-gbqbVd8c" target="_blank">mailvelope.com/keyring?id=pS-gbqbVd8c</a>');
+    });
+    it('should auto link URL in parenthesis', () => {
+      expect(mvelo.util.text2autoLinkHtml('(www.mailvelope.com)')).to.equal('(<a href="https://www.mailvelope.com" target="_blank">www.mailvelope.com</a>)');
+    });
+    it('should auto link URL with non English letters', () => {
+      expect(mvelo.util.text2autoLinkHtml('https://test.mailvelope.com/user/მთავარი_გვერდი')).to.equal('<a href="https://test.mailvelope.com/user/მთავარი_გვერდი" target="_blank">https://test.mailvelope.com/user/მთავარი_გვერდი</a>');
+    });
+    it('should escape special chars', () => {
+      expect(mvelo.util.text2autoLinkHtml('& < > " \' \/')).to.equal('&amp; &lt; &gt; &quot; &#039; &#x2F;');
+    });
+  });
+});


### PR DESCRIPTION
Add html link tag to URLs and email addresses to make them clickable inside decrypted message container.

**Added dependency**
linkifyjs (https://github.com/SoapBox/linkifyjs)

**Added files**
src/lib/autolink.js
test/lib/lib-mvelo-test.js

**Modified files**
src/lib/lib-mvelo.js
src/modules/mime.js