### PR TITLE
[#647] Fixing alert_invalid_domainmatchpattern_warning

### DIFF
--- a/locales/de/messages.json
+++ b/locales/de/messages.json
@@ -80,7 +80,7 @@
     "description": "Alert header of category warning."
   },
   "alert_invalid_domainmatchpattern_warning": {
-    "message": "Domänen-Übereinstimmungsmuster muss mit * beginnen.",
+    "message": "Domänen-Übereinstimmungsmuster muss mit '*.' beginnen.",
     "description": "Alert header of category warning."
   },
   "alert_no_domainmatchpattern_warning": {

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -13,7 +13,7 @@
   },
   "alert_invalid_domainmatchpattern_warning": {
     "description": "Alert header of category warning.",
-    "message": "Domain match pattern should begin with *."
+    "message": "Domain match pattern should begin with '*.'."
   },
   "alert_no_domainmatchpattern_warning": {
     "description": "Alert header of category warning.",


### PR DESCRIPTION
See: https://github.com/mailvelope/mailvelope/issues/647

`alert_invalid_domainmatchpattern_warning` fixed for en and de