### PR TITLE
Initial test for the API

### DIFF
--- a/src/content-scripts/clientAPI.js
+++ b/src/content-scripts/clientAPI.js
@@ -38,7 +38,7 @@ export function init() {
   if (!window.mailvelope) {
     $('<script/>', {
       id: 'mailvelope-api',
-      src: chrome.runtime.getURL('client-API/mailvelope-client-api.js'),
+      src: chrome.runtime.getURL('/client-API/mailvelope-client-api.js'),
       'data-version': prefs.version
     }).appendTo($('head'));
   }

--- a/src/modules/keyring.js
+++ b/src/modules/keyring.js
@@ -93,6 +93,8 @@ const keyringAttr = new KeyringAttrMap();
 const keyringMap = new Map();
 
 export async function init() {
+  keyringMap.clear();
+  keyringAttr.clear();
   await keyringAttr.init();
   const keyringIds = Array.from(keyringAttr.keys());
   await Promise.all(keyringIds.map(async keyringId => {

--- a/test/client-API/mailvelope-client-api-test.js
+++ b/test/client-API/mailvelope-client-api-test.js
@@ -3,6 +3,7 @@ import {LocalStorageStub} from 'utils';
 import mvelo from 'lib/lib-mvelo';
 import * as main from 'controller/main.controller';
 import * as api from 'content-scripts/clientAPI';
+import * as keyring from 'modules/keyring';
 
 /* global mailvelope */
 describe('Mailvelope Client API', async () => {
@@ -11,6 +12,7 @@ describe('Mailvelope Client API', async () => {
 
   beforeEach(() => {
     mvelo.storage = new LocalStorageStub();
+    keyring.init();
   });
 
   it('reports its version', () => {
@@ -22,4 +24,19 @@ describe('Mailvelope Client API', async () => {
     const keyring = await mailvelope.createKeyring('email@test.example');
     expect(keyring).to.be.ok;
   });
+
+  it('rejects creating duplicate keyring', async () => {
+    const keyring = await mailvelope.createKeyring('email@test.example');
+    return expect(mailvelope.createKeyring('email@test.example')).to.be.rejected;
+  });
+
+  it('can get a keyring', async () => {
+    const keyring = await mailvelope.createKeyring('email@test.example');
+    return expect(mailvelope.getKeyring('email@test.example')).to.become(keyring);
+  });
+
+  it('rejects getting missing keyring', async () => {
+    return expect(mailvelope.getKeyring('email@test.example')).to.be.rejected;
+  });
+
 });

--- a/test/client-API/mailvelope-client-api-test.js
+++ b/test/client-API/mailvelope-client-api-test.js
@@ -1,0 +1,25 @@
+import {expect} from 'test';
+import {LocalStorageStub} from 'utils';
+import mvelo from 'lib/lib-mvelo';
+import * as main from 'controller/main.controller';
+import * as api from 'content-scripts/clientAPI';
+
+/* global mailvelope */
+describe('Mailvelope Client API', async () => {
+  api.init();
+  await main.initController();
+
+  beforeEach(() => {
+    mvelo.storage = new LocalStorageStub();
+  });
+
+  it('reports its version', () => {
+    api.default.__Rewire__('prefs', {version: '1.2.3-dev'});
+    return expect(mailvelope.getVersion()).to.eventually.equal('1.2.3');
+  });
+
+  it('can create a keyring', async () => {
+    const keyring = await mailvelope.createKeyring('email@test.example');
+    expect(keyring).to.be.ok;
+  });
+});

--- a/test/client-API/mailvelope-client-api-test.js
+++ b/test/client-API/mailvelope-client-api-test.js
@@ -10,29 +10,32 @@ main.initController();
 
 /* global mailvelope */
 describe('Mailvelope Client API', () => {
-
-  let existing_keyring;
-
-  beforeEach(async () => {
-    mvelo.storage = new LocalStorageStub();
-    keyring.init();
-    existing_keyring = await mailvelope.createKeyring('existing@test.example');
+  describe('Versioning', () => {
+    it('reports its version', () => {
+      api.default.__Rewire__('prefs', {version: '1.2.3-dev'});
+      return expect(mailvelope.getVersion()).to.eventually.equal('1.2.3');
+    });
   });
 
-  it('reports its version', () => {
-    api.default.__Rewire__('prefs', {version: '1.2.3-dev'});
-    return expect(mailvelope.getVersion()).to.eventually.equal('1.2.3');
+  describe('Handling keyrings', () => {
+    let existing_keyring;
+
+    beforeEach(async () => {
+      mvelo.storage = new LocalStorageStub();
+      keyring.init();
+      existing_keyring = await mailvelope.createKeyring('existing@test.example');
+    });
+
+    it('can create a keyring', () =>
+      expect(mailvelope.createKeyring('email@test.example')).to.eventually.be.ok);
+
+    it('rejects creating duplicate keyring', () =>
+      expect(mailvelope.createKeyring('existing@test.example')).to.eventually.be.rejected);
+
+    it('can get a keyring', () =>
+      expect(mailvelope.getKeyring('existing@test.example')).to.become(existing_keyring));
+
+    it('rejects getting missing keyring', () =>
+      expect(mailvelope.getKeyring('email@test.example')).to.be.rejected);
   });
-
-  it('can create a keyring', () =>
-    expect(mailvelope.createKeyring('email@test.example')).to.eventually.be.ok);
-
-  it('rejects creating duplicate keyring', () =>
-    expect(mailvelope.createKeyring('existing@test.example')).to.eventually.be.rejected);
-
-  it('can get a keyring', () =>
-    expect(mailvelope.getKeyring('existing@test.example')).to.become(existing_keyring));
-
-  it('rejects getting missing keyring', () =>
-    expect(mailvelope.getKeyring('email@test.example')).to.be.rejected);
 });

--- a/test/client-API/mailvelope-client-api-test.js
+++ b/test/client-API/mailvelope-client-api-test.js
@@ -5,14 +5,18 @@ import * as main from 'controller/main.controller';
 import * as api from 'content-scripts/clientAPI';
 import * as keyring from 'modules/keyring';
 
-/* global mailvelope */
-describe('Mailvelope Client API', async () => {
-  api.init();
-  await main.initController();
+api.init();
+main.initController();
 
-  beforeEach(() => {
+/* global mailvelope */
+describe('Mailvelope Client API', () => {
+
+  let existing_keyring;
+
+  beforeEach(async () => {
     mvelo.storage = new LocalStorageStub();
     keyring.init();
+    existing_keyring = await mailvelope.createKeyring('existing@test.example');
   });
 
   it('reports its version', () => {
@@ -20,23 +24,15 @@ describe('Mailvelope Client API', async () => {
     return expect(mailvelope.getVersion()).to.eventually.equal('1.2.3');
   });
 
-  it('can create a keyring', async () => {
-    const keyring = await mailvelope.createKeyring('email@test.example');
-    expect(keyring).to.be.ok;
-  });
+  it('can create a keyring', () =>
+    expect(mailvelope.createKeyring('email@test.example')).to.eventually.be.ok);
 
-  it('rejects creating duplicate keyring', async () => {
-    const keyring = await mailvelope.createKeyring('email@test.example');
-    return expect(mailvelope.createKeyring('email@test.example')).to.be.rejected;
-  });
+  it('rejects creating duplicate keyring', () =>
+    expect(mailvelope.createKeyring('existing@test.example')).to.eventually.be.rejected);
 
-  it('can get a keyring', async () => {
-    const keyring = await mailvelope.createKeyring('email@test.example');
-    return expect(mailvelope.getKeyring('email@test.example')).to.become(keyring);
-  });
+  it('can get a keyring', () =>
+    expect(mailvelope.getKeyring('existing@test.example')).to.become(existing_keyring));
 
-  it('rejects getting missing keyring', async () => {
-    return expect(mailvelope.getKeyring('email@test.example')).to.be.rejected;
-  });
-
+  it('rejects getting missing keyring', () =>
+    expect(mailvelope.getKeyring('email@test.example')).to.be.rejected);
 });

--- a/test/client-API/mailvelope-client-api-test.js
+++ b/test/client-API/mailvelope-client-api-test.js
@@ -5,14 +5,14 @@ import * as main from 'controller/main.controller';
 import * as api from 'content-scripts/clientAPI';
 import * as keyring from 'modules/keyring';
 
+// TODO: This should be moved somewhere else.
+api.default.__Rewire__('prefs', {version: '1.2.3-dev'});
 api.init();
-main.initController();
 
 /* global mailvelope */
 describe('Mailvelope Client API', () => {
   describe('Versioning', () => {
     it('reports its version', () => {
-      api.default.__Rewire__('prefs', {version: '1.2.3-dev'});
       return expect(mailvelope.getVersion()).to.eventually.equal('1.2.3');
     });
   });

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -23,6 +23,7 @@ module.exports = function(config) {
       {pattern: '../node_modules/bootstrap/dist/js/bootstrap.js', watched: false},
       {pattern: '../node_modules/angular/angular.js', watched: false},
       {pattern: '../node_modules/angular-mocks/angular-mocks.js', watched: false},
+      {pattern: '../src/client-API/mailvelope-client-api.js', watched: false},
       {pattern: '../src/lib/jquery.ext.js', watched: false},
       {pattern: '../node_modules/openpgp/dist/openpgp.worker.js', watched: false, included: false,  nocache: false},
       {pattern: '../node_modules/openpgp/dist/openpgp.js', watched: false, included: false,  nocache: false},
@@ -34,6 +35,7 @@ module.exports = function(config) {
       'controller/**/*.js',
       'lib/**/*.js',
       'modules/**/*.js',
+      'client-API/**/*.js'
     ],
 
     // list of files to exclude

--- a/test/modules/keyring-test.js
+++ b/test/modules/keyring-test.js
@@ -30,7 +30,8 @@ describe('keyring unit tests', () => {
       storage
     });
     keyringRewireAPI.__Rewire__('mvelo', {
-      storage
+      storage,
+      Error
     });
     await init();
   });

--- a/test/polyfills.js
+++ b/test/polyfills.js
@@ -13,7 +13,21 @@ window.chrome.runtime.getURL = function(name) {
   return location.href.split('/test/')[0] + '/' + name;
 };
 
-window.chrome.runtime.onMessage = {
+(function() {
+  const listeners = [];
+  window.chrome.runtime.onMessage = {
+    addListener: function(listener) {
+      listeners.push(listener);
+    }
+  };
+  window.chrome.runtime.sendMessage = function(message, cb) {
+    for (const listener of listeners) {
+      listener(message, '', cb);
+    };
+  };
+})();
+
+window.chrome.runtime.onConnect = {
   addListener: function() {}
 };
 


### PR DESCRIPTION
**this pr mainly serves to showcase the approach. It does not test much of the functionality yet.**

API level tests allow testing the wiring in the event handling
inside the controllers and the content scripts.
It ensures that API calls actually accomplish their goals.

test/polyfills.js now includes a simple implementation of
sendMessage that triggers the corresponding functions in the main
controller (which in turn calls handleApiEvent in the api controller).

The local storage is stubbed entirely so we do not have to worry
about replacing it with rewire in some contexts.
We do not recover it after the run because there is no
working local storage in the test environment anyway.