### PR TITLE
fix: webpack api had wrong path

### DIFF
--- a/config/webpack.api.js
+++ b/config/webpack.api.js
@@ -4,7 +4,7 @@
 const path = require('path');
 const common = require('./webpack.common');
 
-const entry = './src/client-api/main.js';
+const entry = './src/client-API/main.js';
 const output = {
   path: path.resolve('./build/tmp/client-API'),
   pathinfo: true,


### PR DESCRIPTION
Running grunt triggers an error for me:
```
    ERROR in Entry module not found: Error: Can't resolve './src/client-api/main.js' in '/home/azul/code/mailvelope'
```
it should be client-API not client-api in the webpack config.