### PR TITLE
grunt: eslint --fix to fix detected warnings

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -13,6 +13,7 @@ module.exports = function(grunt) {
         maxWarnings: 1,
         configFile: 'config/eslint.json',
         cache: true,
+        fix: grunt.option('fix'),
         reportUnusedDisableDirectives: true
       },
       target: [


### PR DESCRIPTION
taken from https://stackoverflow.com/a/52006112.

This way grunt eslint will not fix by default
but the "--fix" option will be handed on to eslint.