### PR TITLE
ci: deploy-nighty as deploy task

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,13 +17,16 @@ jobs:
       - grunt dist-ff
   - name: test
     script: npm test
-  - name: crxmake
+  - name: nightly
     stage: deploy
     script:
       - grunt
+      - grunt dist-cr
+      - grunt dist-ff
       - openssl aes-256-cbc -K $encrypted_5d28b41102c4_key -iv $encrypted_5d28b41102c4_iv -in .travis/crx_signing.pem.enc -out .travis/crx_signing.pem -d
       - .travis/crxmake.sh build/chrome .travis/crx_signing.pem
-    if: type != pull_request AND env(encrypted_5d28b41102c4_key) IS present
+      - .travis/deploy-nightly.sh
+    if: branch = dev AND NOT fork AND type != pull_request
   - name: github pages
     stage: deploy
     script: .travis/deploy-grunt.sh
@@ -49,4 +52,3 @@ addons:
   apt:
     packages:
     - sshpass
-after_success: ".travis/deploy-nightly.sh"


### PR DESCRIPTION
this was an after_success hook before.
after_success hooks will run after every successful task.
So if grunt succeeded but test failed grunt would still deploy the nightly.

Move the deploy-nightly.sh call into the deploy task.
This way all tasks in the test stage (test and grunt) need to pass
before it tries to deploy.