### PR TITLE
Initial take on API for injecting autocrypt headers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- '10'
+  - node
 cache:
   directories:
   - node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: node_js
 node_js:
   - node
-cache:
-  directories:
-  - node_modules
+cache: npm
 before_install:
 - npm install -g grunt-cli
 install:

--- a/src/client-API/client-api.js
+++ b/src/client-API/client-api.js
@@ -273,11 +273,40 @@ class Keyring {
    * @throws {Error} error.code = 'NO_KEY_FOR_ADDRESS'
    * @example
    * keyring.exportOwnPublicKey('abc@web.de').then(function(armoredPublicKey) {
-   *   console.log('exportOwnPublicKey', armoredPublicKey); // prints: "-----BEGIN PGP PUBLIC KEY BLOCK..."
+   *   console.log('exportOwnPublicKey', armoredPublicKey);
+   *   // prints: "-----BEGIN PGP PUBLIC KEY BLOCK..."
    * });
    */
   exportOwnPublicKey(emailAddr) {
     return send('export-own-pub-key', {identifier: this.identifier, emailAddr});
+  }
+
+  /**
+   * @typedef {Object} additionalMailHeaders
+   * @property {String} autocrypt - the Autocrypt header that should be <br>
+   *                                added to the outgoing mail<br>
+   */
+
+  /**
+   * @typedef {Object} outgoingMailHeaders
+   * @property {String} from - the From header
+   */
+
+  /**
+   * Returns headers that should be added to an outgoing email.
+   * So far this is only the `autocrypt` header.
+   * @param {outgoingMailHeaders} headers - headers of the outgoing mail. <br>
+   *                              In particular `from` to select the key
+   * @returns {Promise.<additionalMailHeaders, Error>}
+   * @throws {Error} error.code = 'NO_KEY_FOR_ADDRESS'
+   * @example
+   * keyring.additionalHeadersForOutgoingEmail(from: 'abc@web.de').then(function(additional) {
+   *   console.log('additionalHeadersForOutgoingEmail', additional);
+   *   // logs: {autocrypt: "addr=abc@web.de; prefer-encrypt=mutual; keydata=..."}
+   * });
+   */
+  additionalHeadersForOutgoingEmail(headers) {
+    return send('additional-headers-for-outgoing', {identifier: this.identifier, headers});
   }
 
   /**

--- a/src/content-scripts/clientAPI.js
+++ b/src/content-scripts/clientAPI.js
@@ -104,6 +104,7 @@ function registerClientEventHandler() {
   clientPort.on('editor-create-draft', editorCreateDraft);
   clientPort.on('query-valid-key', validKeyForAddress);
   clientPort.on('export-own-pub-key', exportOwnPublicKey);
+  clientPort.on('additional-headers-for-outgoing', additionalHeadersForOutgoing);
   clientPort.on('import-pub-key', importPublicKey);
   clientPort.on('process-autocrypt-header', processAutocryptHeader);
   clientPort.on('set-logo', setLogo);
@@ -222,6 +223,10 @@ function validKeyForAddress({keyringId, recipients}) {
 
 function exportOwnPublicKey({keyringId, emailAddr}) {
   return controllerPort.send('export-own-pub-key', {keyringId, emailAddr});
+}
+
+function additionalHeadersForOutgoing({keyringId, headers}) {
+  return controllerPort.send('additional-headers-for-outgoing', {keyringId, headers});
 }
 
 function importPublicKey({keyringId, armored}) {

--- a/src/controller/app.controller.js
+++ b/src/controller/app.controller.js
@@ -18,7 +18,7 @@ import * as uiLog from '../modules/uiLog';
 import {getVersion} from '../modules/defaults';
 import {gpgme} from '../lib/browser.runtime';
 import * as mveloKeyServer from '../modules/mveloKeyServer';
-import * as autocryptWrapper from '../modules/autocryptWrapper';
+import * as autocrypt from '../modules/autocryptWrapper';
 
 const unlockQueue = new PromiseQueue();
 
@@ -81,7 +81,7 @@ export default class AppController extends sub.SubController {
       initOpenPGP();
     }
     if (disabledAutocryptFlag) {
-      await autocryptWrapper.deleteIdentities(getAllKeyringIds());
+      await autocrypt.deleteIdentities(getAllKeyringIds());
     }
   }
 
@@ -240,7 +240,7 @@ export default class AppController extends sub.SubController {
     }
     sub.setActiveKeyringId(MAIN_KEYRING_ID);
     await deleteKeyring(keyringId);
-    await autocryptWrapper.deleteIdentities([keyringId]);
+    await autocrypt.deleteIdentities([keyringId]);
   }
 
   async encryptFile(options) {

--- a/src/modules/autocryptWrapper.js
+++ b/src/modules/autocryptWrapper.js
@@ -8,6 +8,7 @@ import {MvError} from '../lib/util';
 import Autocrypt from 'autocrypt';
 import {prefs} from './prefs';
 import {goog} from './closure-library/closure/goog/emailaddress';
+export {stringify, parse} from 'autocrypt';
 
 export const name = 'AC';
 const stores = new Map();
@@ -94,7 +95,7 @@ export async function deleteIdentities(identities) {
   }
 }
 
-function armor(base64) {
+export function armor(base64) {
   const head = '-----BEGIN PGP PUBLIC KEY BLOCK-----';
   const footer = '-----END PGP PUBLIC KEY BLOCK-----';
   const lines = base64.match(/.{1,64}/g);

--- a/src/modules/autocryptWrapper.js
+++ b/src/modules/autocryptWrapper.js
@@ -8,7 +8,7 @@ import {MvError} from '../lib/util';
 import Autocrypt from 'autocrypt';
 import {prefs} from './prefs';
 import {goog} from './closure-library/closure/goog/emailaddress';
-export {stringify, parse} from 'autocrypt';
+export {parse} from 'autocrypt';
 
 export const name = 'AC';
 const stores = new Map();
@@ -20,6 +20,14 @@ const stores = new Map();
 */
 export function isEnabled() {
   return prefs.keyserver.autocrypt_lookup === true;
+}
+
+export function stringify({keydata, addr}) {
+  if (keydata.startsWith('-----')) {
+    return Autocrypt.stringify({keydata: keydataFromArmored(keydata), addr});
+  } else {
+    return Autocrypt.stringify({keydata, addr});
+  }
 }
 
 async function autocrypt(id) {
@@ -141,4 +149,12 @@ export class Store {
     this.map.forEach((value, key) => all[key] = value);
     return all;
   }
+}
+
+function keydataFromArmored(armored) {
+  // An empty line marks the end of the headers
+  const start = armored.search(/\r?\n\r?\n/);
+  // The checksum is on a new line starting with '='
+  const end = armored.search(/\n=/, start);
+  return armored.slice(start, end).trim();
 }

--- a/src/modules/key.js
+++ b/src/modules/key.js
@@ -237,17 +237,20 @@ export async function mapUsers(users = [], toKey, keyring, key) {
  * @return {openpgp.key.Key}
  */
 export async function minifyKey(key, userId) {
-  const uid = await key.getPrimaryUser(null, userId);
-  if (!uid || !uid.user) { return null; }
+  const {user: user} = await key.getPrimaryUser(undefined, userId);
+  if (!user) {
+    return null;
+  }
   const signSubkey = await key.getSigningKey();
   const encSubkey = await key.getEncryptionKey();
   const p = new openpgp.packet.List();
   p.push(key.primaryKey);
-  p.concat(uid.user.toPacketlist());
+  p.push(user.userId || user.userAttribute);
+  p.concat(user.selfCertifications);
   if (key !== signSubkey) {
     p.concat(signSubkey.toPacketlist());
   }
-  if (key !== encSubkey) {
+  if (key !== encSubkey && signSubkey !== encSubkey) {
     p.concat(encSubkey.toPacketlist());
   }
 

--- a/test/controller/api.controller-test.js
+++ b/test/controller/api.controller-test.js
@@ -1,0 +1,112 @@
+
+import {expect, sinon} from 'test';
+import {setupKeyring, teardownKeyring} from 'Fixtures/keyring';
+import {MAIN_KEYRING_ID} from 'lib/constants';
+import * as openpgp from 'openpgp';
+import * as autocrypt from 'modules/autocryptWrapper';
+import {mapSubKeys, mapUsers} from 'modules/key';
+import * as prefs from 'modules/prefs';
+import {Port} from 'utils';
+import ApiController from 'controller/api.controller';
+
+describe('Api controller unit tests', () => {
+  const sandbox = sinon.createSandbox();
+  let ctrl;
+  let port;
+
+  beforeEach(() => {
+    port = new Port('dummy-1');
+    ctrl = new ApiController(port);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+    /* eslint-disable-next-line no-undef */
+    __rewire_reset_all__();
+  });
+
+  describe('Check event handlers', () => {
+    it('should handle process-autocrypt-header', () => {
+      expect(ctrl._handlers.get('process-autocrypt-header')).to.exist;
+    });
+
+    it('should handle additional-headers-for-outgoing', () => {
+      expect(ctrl._handlers.get('additional-headers-for-outgoing')).to.exist;
+    });
+  });
+
+  describe('Delegation to autocrypt', () => {
+    beforeEach(setupKeyring);
+    afterEach(teardownKeyring);
+    const keyringId = MAIN_KEYRING_ID;
+
+    it('should process headers if enabled', async () => {
+      const headers = { };
+      const isEnabled = sandbox.stub().returns(true);
+      const processHeader = sandbox.stub();
+      ApiController.__Rewire__('autocrypt', {
+        isEnabled,
+        processHeader
+      });
+
+      ctrl.processAutocryptHeader({headers, keyringId});
+      expect(processHeader.withArgs(headers, keyringId).calledOnce).to.be.true;
+    });
+
+    it('should not process headers if disabled', async () => {
+      const headers = { };
+      const isEnabled = sandbox.stub().returns(false);
+      const processHeader = sandbox.stub();
+      ApiController.__Rewire__('autocrypt', {
+        isEnabled,
+        processHeader
+      });
+
+      ctrl.processAutocryptHeader({headers, keyringId});
+      expect(processHeader.called).to.be.false;
+    });
+
+    it('should propose autocrypt header if enabled', async () => {
+      prefs.prefs.keyserver = {
+        autocrypt_lookup: true
+      };
+
+      const headers = {from: 'madita@mailvelope.com'};
+      const additional = await ctrl.additionalHeadersForOutgoing({keyringId, headers});
+      const keydata = autocrypt.parse(additional.autocrypt).keydata;
+      const armored = autocrypt.armor(keydata);
+      const keys = await openpgp.key.readArmored(armored);
+      const key = keys.keys[0];
+      expect(key).to.be.ok;
+      const keyMap = {};
+      await mapSubKeys(key.subKeys, keyMap, key);
+      const {subkeys: mappedSubkeys} = keyMap;
+      expect(mappedSubkeys.length).to.equal(1);
+      const userMap = {};
+      await mapUsers(key.users, userMap, {}, key);
+      const {users: mappedUsers} = userMap;
+      expect(mappedUsers.length).to.equal(1);
+      expect(mappedUsers[0].userId).to.equal('Madita Bernstone <madita@mailvelope.com>');
+    });
+
+    it('should alert if email address is unknown', async () => {
+      prefs.prefs.keyserver = {
+        autocrypt_lookup: true
+      };
+
+      const headers = {from: 'missing@mailvelope.com'};
+      return expect(ctrl.additionalHeadersForOutgoing({keyringId, headers})).
+      to.eventually.be.rejectedWith('No key pair found for this email address.');
+    });
+
+    it('should not propose additional headers if disabled', async () => {
+      prefs.prefs.keyserver = {
+        autocrypt_lookup: false
+      };
+
+      const headers = {from: 'madita@mailvelope.com'};
+      return expect(ctrl.additionalHeadersForOutgoing({keyringId, headers})).
+      to.eventually.eql({});
+    });
+  });
+});

--- a/test/fixtures/keyring.js
+++ b/test/fixtures/keyring.js
@@ -1,0 +1,37 @@
+import {LocalStorageStub} from 'utils';
+import {MAIN_KEYRING_ID} from 'lib/constants';
+import KeyStoreLocal from 'modules/KeyStoreLocal';
+import testKeys from 'Fixtures/keys';
+import {init, __RewireAPI__ as keyringRewireAPI} from 'modules/keyring';
+
+export async function setupKeyring() {
+  const keyringIds = [MAIN_KEYRING_ID, 'test123'];
+  let keyringAttributes;
+  const storage = new LocalStorageStub();
+  for (const keyringId of keyringIds) {
+    let storedTestKeys;
+    if (keyringId === MAIN_KEYRING_ID) {
+      storedTestKeys = {public: [testKeys.maxp_pub], private: [testKeys.maditab_prv]};
+      keyringAttributes = {
+        default_key: '771f9119b823e06c0de306d466663688a83e9763'
+      };
+    } else {
+      storedTestKeys = {public: [testKeys.gordonf_pub], private: [testKeys.johnd_prv]};
+      keyringAttributes = {};
+    }
+    await storage.importKeys(keyringId, storedTestKeys);
+    await storage.importAttributes(keyringId, keyringAttributes);
+  }
+  KeyStoreLocal.__Rewire__('mvelo', {
+    storage
+  });
+  keyringRewireAPI.__Rewire__('mvelo', {
+    storage
+  });
+  await init();
+}
+
+export function teardownKeyring() {
+  /* eslint-disable-next-line no-undef */
+  __rewire_reset_all__();
+}

--- a/test/modules/autocryptWrapper-test.js
+++ b/test/modules/autocryptWrapper-test.js
@@ -1,16 +1,15 @@
 import {expect} from 'test';
 import {LocalStorageStub} from 'utils';
-import * as autocryptWrapper from 'modules/autocryptWrapper';
+import * as autocrypt from 'modules/autocryptWrapper';
 import {isValidEncryptionKey} from 'modules/key';
 import * as openpgp from 'openpgp';
-import Autocrypt from 'autocrypt';
 import testKeys from 'Fixtures/keys';
 
 describe('Test basic autocrypt wrapper functionality', () => {
   const keydata = testKeys.api_test_pub.split('\n').slice(2, 17).join();
   const addr = 'test@mailvelope.com';
   const headers = {
-    autocrypt: Autocrypt.stringify({keydata, addr}),
+    autocrypt: autocrypt.stringify({keydata, addr}),
     from: addr,
     date: Date.now().toString()
   };
@@ -19,7 +18,7 @@ describe('Test basic autocrypt wrapper functionality', () => {
 
   beforeEach(() => {
     storage = new LocalStorageStub();
-    autocryptWrapper.default.__Rewire__('mvelo', {storage});
+    autocrypt.default.__Rewire__('mvelo', {storage});
   });
 
   afterEach(() => {
@@ -29,8 +28,8 @@ describe('Test basic autocrypt wrapper functionality', () => {
 
   describe('receiving header', () => {
     it('parses and stores the key', async () => {
-      await autocryptWrapper.processHeader(headers, 'id');
-      const result = await autocryptWrapper.lookup(addr, 'id');
+      await autocrypt.processHeader(headers, 'id');
+      const result = await autocrypt.lookup(addr, 'id');
       const key = openpgp.key.readArmored(result.armored);
       // fixture keys have checksum which autocrypt keys do not.
       expect(result.armored.slice(0, 17)).to.equal(testKeys.api_test_pub.slice(0, 17));
@@ -40,50 +39,50 @@ describe('Test basic autocrypt wrapper functionality', () => {
     it('rejects headers larger than 10k', async () => {
       const large_keydata = '1234567890'.repeat(1025);
       const large_headers = {
-        autocrypt: Autocrypt.stringify({keydata: large_keydata, addr}),
+        autocrypt: autocrypt.stringify({keydata: large_keydata, addr}),
         from: addr,
         date: Date.now().toString()
       };
-      return expect(autocryptWrapper.processHeader(large_headers, 'id')).to.eventually.be.rejected;
+      return expect(autocrypt.processHeader(large_headers, 'id')).to.eventually.be.rejected;
     });
 
     it('handles from headers with names', async () => {
       const headers_with_name = {
-        autocrypt: Autocrypt.stringify({keydata, addr}),
+        autocrypt: autocrypt.stringify({keydata, addr}),
         from: `name goes here <${addr}>`,
         date: Date.now().toString()
       };
-      await autocryptWrapper.processHeader(headers_with_name, 'id2');
-      const result = await autocryptWrapper.lookup(addr, 'id2');
+      await autocrypt.processHeader(headers_with_name, 'id2');
+      const result = await autocrypt.lookup(addr, 'id2');
       // fixture keys have checksum which autocrypt keys do not.
       expect(result.armored.slice(0, 17)).to.equal(testKeys.api_test_pub.slice(0, 17));
     });
 
     it('stores the keys separately per identity', async () => {
-      await autocryptWrapper.processHeader(headers, 'other id');
-      const result = await autocryptWrapper.lookup(addr, 'yet another id');
+      await autocrypt.processHeader(headers, 'other id');
+      const result = await autocrypt.lookup(addr, 'yet another id');
       expect(result).to.be.undefined;
     });
   });
 
   describe('deleting storage', () => {
     it('removes keys from one storage', async () => {
-      await autocryptWrapper.processHeader(headers, 'id');
-      await autocryptWrapper.processHeader(headers, 'other');
-      await autocryptWrapper.deleteIdentities(['id']);
-      const result = await autocryptWrapper.lookup(addr, 'id');
+      await autocrypt.processHeader(headers, 'id');
+      await autocrypt.processHeader(headers, 'other');
+      await autocrypt.deleteIdentities(['id']);
+      const result = await autocrypt.lookup(addr, 'id');
       // fixture keys have checksum which autocrypt keys do not.
       expect(result).to.not.exist;
-      const other = await autocryptWrapper.lookup(addr, 'other');
+      const other = await autocrypt.lookup(addr, 'other');
       expect(other.armored.slice(0, 17)).to.equal(testKeys.api_test_pub.slice(0, 17));
     });
 
     it('removes keys from multiple storages', async () => {
-      await autocryptWrapper.processHeader(headers, 'id');
-      await autocryptWrapper.processHeader(headers, 'other');
-      await autocryptWrapper.deleteIdentities(['id', 'other']);
-      const result = await autocryptWrapper.lookup(addr, 'id');
-      const other = await autocryptWrapper.lookup(addr, 'other');
+      await autocrypt.processHeader(headers, 'id');
+      await autocrypt.processHeader(headers, 'other');
+      await autocrypt.deleteIdentities(['id', 'other']);
+      const result = await autocrypt.lookup(addr, 'id');
+      const other = await autocrypt.lookup(addr, 'other');
       expect(result).to.not.exist;
       expect(other).to.not.exist;
     });

--- a/test/modules/autocryptWrapper-test.js
+++ b/test/modules/autocryptWrapper-test.js
@@ -6,7 +6,7 @@ import * as openpgp from 'openpgp';
 import testKeys from 'Fixtures/keys';
 
 describe('Test basic autocrypt wrapper functionality', () => {
-  const keydata = testKeys.api_test_pub.split('\n').slice(2, 17).join();
+  const keydata = testKeys.api_test_pub.split('\n').slice(2, 17).join('');
   const addr = 'test@mailvelope.com';
   const headers = {
     autocrypt: autocrypt.stringify({keydata, addr}),
@@ -85,6 +85,14 @@ describe('Test basic autocrypt wrapper functionality', () => {
       const other = await autocrypt.lookup(addr, 'other');
       expect(result).to.not.exist;
       expect(other).to.not.exist;
+    });
+  });
+
+  describe('stringify extension', () => {
+    it('handles full armored keys just fine', () => {
+      const from_plain_keydata = autocrypt.stringify({keydata, addr});
+      const from_armored_key = autocrypt.stringify({keydata: testKeys.api_test_pub, addr});
+      expect(from_armored_key).to.eql(from_plain_keydata);
     });
   });
 });

--- a/test/modules/key-test.js
+++ b/test/modules/key-test.js
@@ -1,6 +1,6 @@
 import {expect} from 'test';
 import * as openpgp from 'openpgp';
-import {getUserInfo, parseUserId, mapKeys, mapSubKeys, mapUsers, verifyUserCertificate, checkKeyId, getLastModifiedDate, equalKey, toPublic, filterUserIdsByEmail} from 'modules/key';
+import {getUserInfo, parseUserId, mapKeys, mapSubKeys, mapUsers, minifyKey, verifyUserCertificate, checkKeyId, getLastModifiedDate, equalKey, toPublic, filterUserIdsByEmail} from 'modules/key';
 import testKeys from 'Fixtures/keys';
 
 describe('Key unit test', () => {
@@ -120,6 +120,25 @@ describe('Key unit test', () => {
         expect(user).to.have.property('signatures');
         expect(user.signatures[0].keyId).to.equal('66663688A83E9763');
       });
+    });
+  });
+
+  describe('minifyKey', () => {
+    it('should return minimal key', async () => {
+      const {keys: [key]} = await openpgp.key.readArmored(testKeys.maditab_pub);
+      const minimal = await minifyKey(key, {email: 'madita@mailvelope.com'});
+      const keyMap = {};
+      await mapSubKeys(minimal.subKeys, keyMap, minimal);
+      const {subkeys: mappedSubkeys} = keyMap;
+      expect(mappedSubkeys.length).to.equal(1);
+      const subkey = mappedSubkeys[0];
+      expect(subkey).not.to.equal(undefined);
+      expect(subkey.fingerprint).to.equal('ef4d0286504c2a77e6e05d0da9c26ff01f6f59e2');
+      const userMap = {};
+      await mapUsers(minimal.users, userMap, {}, minimal);
+      const {users: mappedUsers} = userMap;
+      expect(mappedUsers.length).to.equal(1);
+      expect(mappedUsers[0].userId).to.equal('Madita Bernstone <madita@mailvelope.com>');
     });
   });
 

--- a/test/modules/keyRegistry-test.js
+++ b/test/modules/keyRegistry-test.js
@@ -1,8 +1,7 @@
 import {expect, sinon} from 'test';
 import {LocalStorageStub} from 'utils';
 import * as prefs from 'modules/prefs';
-import * as autocryptWrapper from 'modules/autocryptWrapper';
-import Autocrypt from 'autocrypt';
+import * as autocrypt from 'modules/autocryptWrapper';
 import testKeys from 'Fixtures/keys';
 import * as keyRegistry from 'modules/keyRegistry';
 
@@ -50,7 +49,7 @@ describe('Looking up keys from different services', () => {
 
     beforeEach(() => {
       storage = new LocalStorageStub();
-      autocryptWrapper.default.__Rewire__('mvelo', {storage});
+      autocrypt.default.__Rewire__('mvelo', {storage});
     });
 
     afterEach(() => {
@@ -68,9 +67,9 @@ describe('Looking up keys from different services', () => {
       const keydata = testKeys.api_test_pub.split('\n').slice(2, 17).join();
       const headers = {
         from: addr,
-        autocrypt: Autocrypt.stringify({keydata, addr})
+        autocrypt: autocrypt.stringify({keydata, addr})
       };
-      await autocryptWrapper.processHeader(headers, 'id');
+      await autocrypt.processHeader(headers, 'id');
 
       const result = await keyRegistry.lookup(addr, 'id');
       expect(result.armored).to.include('-----BEGIN PGP PUBLIC KEY BLOCK-----');
@@ -84,7 +83,7 @@ describe('Looking up keys from different services', () => {
 
     beforeEach(() => {
       storage = new LocalStorageStub();
-      autocryptWrapper.default.__Rewire__('mvelo', {storage});
+      autocrypt.default.__Rewire__('mvelo', {storage});
     });
 
     afterEach(() => {
@@ -114,9 +113,9 @@ describe('Looking up keys from different services', () => {
       const keydata = testKeys.api_test_pub.split('\n').slice(2, 17).join();
       const headers = {
         from: addr,
-        autocrypt: Autocrypt.stringify({keydata, addr})
+        autocrypt: autocrypt.stringify({keydata, addr})
       };
-      await autocryptWrapper.processHeader(headers, 'id');
+      await autocrypt.processHeader(headers, 'id');
 
       const result = await keyRegistry.lookup(addr, 'id');
       expect(result.armored).to.include('-----BEGIN PGP PUBLIC KEY BLOCK-----');

--- a/test/modules/keyring-test.js
+++ b/test/modules/keyring-test.js
@@ -1,44 +1,11 @@
 import {expect} from 'test';
-import {LocalStorageStub} from 'utils';
 import {MAIN_KEYRING_ID} from 'lib/constants';
-import {init, createKeyring, deleteKeyring, getAll, getById, getAllKeyringAttr, getKeyringAttr, setKeyringAttr, getKeyData, getKeyByAddress, getKeyringWithPrivKey, getPreferredKeyring, syncPublicKeys, __RewireAPI__ as keyringRewireAPI} from 'modules/keyring';
-import KeyStoreLocal from 'modules/KeyStoreLocal';
-import testKeys from 'Fixtures/keys';
+import {setupKeyring, teardownKeyring} from 'Fixtures/keyring';
+import {createKeyring, deleteKeyring, getAll, getById, getAllKeyringAttr, getKeyringAttr, setKeyringAttr, getKeyData, getKeyByAddress, getKeyringWithPrivKey, getPreferredKeyring, syncPublicKeys} from 'modules/keyring';
 
 describe('keyring unit tests', () => {
-  let storage;
-
-  beforeEach(async () => {
-    const keyringIds = [MAIN_KEYRING_ID, 'test123'];
-    let keyringAttributes;
-    storage = new LocalStorageStub();
-    for (const keyringId of keyringIds) {
-      let storedTestKeys;
-      if (keyringId === MAIN_KEYRING_ID) {
-        storedTestKeys = {public: [testKeys.maxp_pub], private: [testKeys.maditab_prv]};
-        keyringAttributes = {
-          default_key: '771f9119b823e06c0de306d466663688a83e9763'
-        };
-      } else {
-        storedTestKeys = {public: [testKeys.gordonf_pub], private: [testKeys.johnd_prv]};
-        keyringAttributes = {};
-      }
-      await storage.importKeys(keyringId, storedTestKeys);
-      await storage.importAttributes(keyringId, keyringAttributes);
-    }
-    KeyStoreLocal.__Rewire__('mvelo', {
-      storage
-    });
-    keyringRewireAPI.__Rewire__('mvelo', {
-      storage
-    });
-    await init();
-  });
-
-  afterEach(() => {
-    /* eslint-disable-next-line no-undef */
-    __rewire_reset_all__();
-  });
+  beforeEach(setupKeyring);
+  afterEach(teardownKeyring);
 
   describe('createKeyring', () => {
     it('should create a new keyring and initialize keyring attributes', async () => {
@@ -83,8 +50,7 @@ describe('keyring unit tests', () => {
       await setKeyringAttr('test123', {
         default_key: '123456789'
       });
-      const storedAttrs = await storage.get('mvelo.keyring.attributes');
-      expect(storedAttrs['test123'].default_key).to.equal('123456789');
+
       expect(getKeyringAttr('test123', 'default_key')).to.equal('123456789');
     });
   });


### PR DESCRIPTION
API
---

```
let keyring = mailvelope.getKeyring('Posteo').then(function(kr) { keyring = kr }, console.error)
keyring.additionalHeadersForOutgoingEmail({from: "mvactest@posteo.de"}).then(console.log, console.error)
// logs: { Autocrypt: "addr=mvactest@posteo.de;keydata=xsFNBFwYsn..." }
```

Autocrypt
---------

* Key#minifyKey to build minimal version of a key.
  Create a minimal key consisting of only:
    * a signing-capable primary key
    * a user id
    * a self signature over the user id by the primary key
    * an encryption-capable subkey
    * a binding signature over the subkey by the primary key

* Export stringify from autocryptWrapper
  This way we do not need to access anything in Autocrypt.js directly.
  Also renaming all uses of autocryptWrapper to autocrypt.
  Outside of the wrapper itself we do not need to distinguish anymore.

Testing
-------

Initial api controller test testing `processAutocryptHeader`
and `additionalHeadersForOutgoing`

In order to have a keyring to test the api
extract setup and teardown from keyring-test.
This would also be useful to integration test the api