### PR TITLE
Add keys.fedoraproject.org to the list of servers

### DIFF
--- a/src/res/defaults.json
+++ b/src/res/defaults.json
@@ -287,6 +287,7 @@
         "https://keyserver.ubuntu.com",
         "http://pool.sks-keyservers.net:11371",
         "https://pgp.mit.edu",
+        "https://keys.fedoraproject.org",
         "https://keys.mailvelope.com"
       ],
       "mvelo_tofu_lookup": true,


### PR DESCRIPTION
The Fedora project maintains its own pubkey server. I thought it would be a nice option to have.