### PR TITLE
Basic Api tests

### DIFF
--- a/src/modules/keyring.js
+++ b/src/modules/keyring.js
@@ -94,6 +94,8 @@ const keyringAttr = new KeyringAttrMap();
 const keyringMap = new Map();
 
 export async function init() {
+  keyringMap.clear();
+  keyringAttr.clear();
   await keyringAttr.init();
   const keyringIds = Array.from(keyringAttr.keys());
   await Promise.all(keyringIds.map(async keyringId => {

--- a/test/client-API/mailvelope-client-api-test.js
+++ b/test/client-API/mailvelope-client-api-test.js
@@ -1,0 +1,73 @@
+import {expect} from 'test';
+import {LocalStorageStub} from 'utils';
+import mvelo from 'lib/lib-mvelo';
+import {init as initKeyring} from 'modules/keyring';
+import {initController} from 'controller/main.controller';
+import {setWatchList} from 'modules/prefs';
+import {prefs} from 'modules/prefs';
+import {testAutocryptHeaders} from 'Fixtures/headers';
+
+mvelo.storage = new LocalStorageStub();
+setWatchList([{
+  'active': true,
+  'site': 'Mailvelope Test',
+  'https_only': false,
+  'frames': [
+    {
+      'scan': true,
+      'frame': 'localhost',
+      'api': true
+    }
+  ]
+}]);
+initController();
+
+/* global mailvelope */
+describe('Mailvelope Client API', () => {
+  beforeEach(async () => {
+    mvelo.storage = new LocalStorageStub();
+    initKeyring();
+  });
+
+  describe('Handling keyrings', () => {
+    it('can create a keyring', () =>
+      expect(mailvelope.createKeyring('email@test.example')).to.eventually.be.ok);
+
+    it('rejects getting keyring if there is none', async () =>
+      expect(mailvelope.getKeyring('email@test.example')).to.be.rejected);
+
+    it('rejects creating duplicate keyring', async () => {
+      await mailvelope.createKeyring('existing@test.example');
+      return expect(mailvelope.createKeyring('existing@test.example')).to.eventually.be.rejected;
+    });
+
+    it('can get a keyring', async () => {
+      const existing_keyring = await mailvelope.createKeyring('existing@test.example');
+      return expect(mailvelope.getKeyring('existing@test.example')).to.become(existing_keyring);
+    });
+
+    it('rejects getting keyring with wrong handle', async () => {
+      await mailvelope.createKeyring('existing@test.example');
+      return expect(mailvelope.getKeyring('email@test.example')).to.be.rejected;
+    });
+  });
+
+  describe('Processing autocrypt', () => {
+    let keyring;
+    prefs.keyserver = {
+      autocrypt_lookup: true
+    };
+
+    beforeEach(async () => {
+      keyring = await mailvelope.createKeyring('email@test.example');
+    });
+
+    it('processes Autocrypt header, stores key, and makes it available', async () => {
+      const addr = testAutocryptHeaders.from;
+      await keyring.processAutocryptHeader(testAutocryptHeaders);
+      const result = await keyring.validKeyForAddress([addr]);
+      const {keys: [{source}]} = result[addr];
+      expect(source).to.eql('AC');
+    });
+  });
+});

--- a/test/controller/api.controller-test.js
+++ b/test/controller/api.controller-test.js
@@ -5,7 +5,7 @@ import {MAIN_KEYRING_ID} from 'lib/constants';
 import * as openpgp from 'openpgp';
 import * as autocrypt from 'modules/autocryptWrapper';
 import {mapSubKeys, mapUsers} from 'modules/key';
-import * as prefs from 'modules/prefs';
+import {prefs} from 'modules/prefs';
 import {Port} from 'utils';
 import ApiController from 'controller/api.controller';
 
@@ -67,7 +67,7 @@ describe('Api controller unit tests', () => {
     });
 
     it('should propose autocrypt header if enabled', async () => {
-      prefs.prefs.keyserver = {
+      prefs.keyserver = {
         autocrypt_lookup: true
       };
 
@@ -90,7 +90,7 @@ describe('Api controller unit tests', () => {
     });
 
     it('should alert if email address is unknown', async () => {
-      prefs.prefs.keyserver = {
+      prefs.keyserver = {
         autocrypt_lookup: true
       };
 
@@ -100,7 +100,7 @@ describe('Api controller unit tests', () => {
     });
 
     it('should not propose additional headers if disabled', async () => {
-      prefs.prefs.keyserver = {
+      prefs.keyserver = {
         autocrypt_lookup: false
       };
 

--- a/test/fixtures/headers.js
+++ b/test/fixtures/headers.js
@@ -1,0 +1,10 @@
+import testKeys from 'Fixtures/keys';
+import * as autocrypt from 'modules/autocryptWrapper';
+
+const addr = 'test@mailvelope.com';
+const keydata = testKeys.api_test_pub.split('\n').slice(2, 17).join('');
+export const testAutocryptHeaders = {
+  from: addr,
+  autocrypt: autocrypt.stringify({keydata, addr}),
+  date: Date.now().toString()
+};

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -25,6 +25,7 @@ module.exports = function(config) {
       {pattern: '../node_modules/angular/angular.js', watched: false},
       {pattern: '../node_modules/angular-mocks/angular-mocks.js', watched: false},
       {pattern: '../src/lib/jquery.ext.js', watched: false},
+      {pattern: '../src/client-API/main.js', watched: true, included: false},
       {pattern: '../node_modules/openpgp/dist/openpgp.worker.js', watched: false, included: false,  nocache: false},
       {pattern: '../node_modules/openpgp/dist/openpgp.js', watched: false, included: false,  nocache: false},
       {pattern: '../src/res/fonts/Courgette-Regular.woff2', watched: false, included: false,  nocache: false},
@@ -34,7 +35,8 @@ module.exports = function(config) {
       'content-scripts/**/*.js',
       'controller/**/*.js',
       'lib/**/*.js',
-      'modules/**/*.js'
+      'modules/**/*.js',
+      'client-API/**/*.js'
     ],
 
     // list of files to exclude
@@ -44,12 +46,14 @@ module.exports = function(config) {
     proxies: {
       '/dep/openpgp.worker.js': `/absolute${path.resolve('./node_modules/openpgp/dist/openpgp.worker.js')}`,
       '/dep/openpgp.js': `/absolute${path.resolve('./node_modules/openpgp/dist/openpgp.js')}`,
+      '/context.html/client-API/mailvelope-client-api.js': `/absolute${path.resolve('./src/client-API/main.js')}`,
       '/res/fonts/Courgette-Regular.woff2': `/absolute${path.resolve('./src/res/fonts/Courgette-Regular.woff2')}`
     },
 
     // preprocess matching files before serving them to the browser
     // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
     preprocessors: {
+      '../src/client-API/**/*.js': ['webpack', 'sourcemap'],
       '**/*.js': ['webpack', 'sourcemap'],
       '**/*.css': ['webpack', 'sourcemap'],
       '**/*.less': ['webpack', 'sourcemap'],

--- a/test/modules/keyRegistry-test.js
+++ b/test/modules/keyRegistry-test.js
@@ -3,6 +3,7 @@ import {LocalStorageStub} from 'utils';
 import * as prefs from 'modules/prefs';
 import * as autocrypt from 'modules/autocryptWrapper';
 import testKeys from 'Fixtures/keys';
+import {testAutocryptHeaders} from 'Fixtures/headers';
 import * as keyRegistry from 'modules/keyRegistry';
 
 describe('Looking up keys from different services', () => {
@@ -63,15 +64,8 @@ describe('Looking up keys from different services', () => {
         mvelo_tofu_lookup: false,
         autocrypt_lookup: true
       };
-      const addr = 'test@mailvelope.com';
-      const keydata = testKeys.api_test_pub.split('\n').slice(2, 17).join();
-      const headers = {
-        from: addr,
-        autocrypt: autocrypt.stringify({keydata, addr})
-      };
-      await autocrypt.processHeader(headers, 'id');
-
-      const result = await keyRegistry.lookup(addr, 'id');
+      await autocrypt.processHeader(testAutocryptHeaders, 'id');
+      const result = await keyRegistry.lookup(testAutocryptHeaders.from, 'id');
       expect(result.armored).to.include('-----BEGIN PGP PUBLIC KEY BLOCK-----');
       expect(result.source).to.be.equal('AC');
       expect(result.fingerprint).to.equal('aa1e01774bdf7d76a45bdc2df11db1250c3c3f1b');
@@ -109,15 +103,8 @@ describe('Looking up keys from different services', () => {
         mvelo_tofu_lookup: true,
         autocrypt_lookup: true
       };
-      const addr = 'test@mailvelope.com';
-      const keydata = testKeys.api_test_pub.split('\n').slice(2, 17).join();
-      const headers = {
-        from: addr,
-        autocrypt: autocrypt.stringify({keydata, addr})
-      };
-      await autocrypt.processHeader(headers, 'id');
-
-      const result = await keyRegistry.lookup(addr, 'id');
+      await autocrypt.processHeader(testAutocryptHeaders, 'id');
+      const result = await keyRegistry.lookup(testAutocryptHeaders.from, 'id');
       expect(result.armored).to.include('-----BEGIN PGP PUBLIC KEY BLOCK-----');
       expect(result.source).to.be.equal('AC');
       expect(result.fingerprint).to.equal('aa1e01774bdf7d76a45bdc2df11db1250c3c3f1b');

--- a/test/modules/keyring-test.js
+++ b/test/modules/keyring-test.js
@@ -19,10 +19,11 @@ describe('keyring unit tests', () => {
     });
   });
 
+  // TODO: This test does not test what it claims to do.
   describe('deleteKeyring', () => {
     it('Should delete keyring, all keys and keyring attributes', async () => {
-      expect(getById('testABC')).to.not.throw;
-      return expect(deleteKeyring('testABC')).to.eventually.throw;
+      expect(getById('test123')).to.not.throw;
+      return expect(deleteKeyring('test123')).to.eventually.throw;
     });
   });
 

--- a/test/polyfills.js
+++ b/test/polyfills.js
@@ -13,21 +13,72 @@ window.chrome.runtime.getURL = function(name) {
   return location.href.split('/test/')[0] + '/' + name;
 };
 
-window.chrome.runtime.onMessage = {
-  addListener: function() {}
-};
+(function() {
+  const listeners = [];
 
-window.chrome.runtime.connect = function() {
-  return {
-    onMessage: {
-      addListener: function() {}
-    },
-    onDisconnect: {
-      addListener: function() {}
-    },
-    postMessage: function() {}
+  window.chrome.runtime.onConnect = {
+    addListener: function(listener) {
+      console.log("polyfill add listener")
+      console.debug(listener)
+      listeners.push(listener);
+    }
   };
-};
+
+  window.chrome.runtime.connect = function({name}) {
+    console.log("polyfill connect " + name)
+    const message_listeners = [];
+    const disconnect_listeners = [];
+    const reply_listeners = [];
+    const port = {
+      name,
+      onMessage: {
+        addListener: function(listener) {
+          console.log("polyfill add message listener")
+          console.debug(listener)
+          message_listeners.push(listener);
+        }
+      },
+      onDisconnect: {
+        addListener: function(listener) {
+          disconnect_listeners.push(listener);
+        }
+      },
+      postMessage: function(message) {
+        console.log("polyfill reply message")
+        console.debug(message)
+        for (const listener of reply_listeners) {
+          listener(message);
+        };
+      }
+    };
+    for (const listener of listeners) {
+      listener(port);
+    };
+
+    return {
+      onMessage: {
+        addListener: function(listener) {
+          console.log("polyfill add reply listener")
+          console.debug(listener)
+          reply_listeners.push(listener);
+        }
+      },
+      onDisconnect: {
+        addListener: function(listener) {
+          disconnect_listeners.push(listener);
+        }
+      },
+      postMessage: function(message) {
+        console.log("polyfill post message")
+        console.debug(message)
+        for (const listener of message_listeners) {
+          listener(message);
+        };
+      }
+    }
+
+  }
+})();
 
 window.chrome.i18n = {
   getMessage: function(id) {


### PR DESCRIPTION
Initial test for the API

API level tests allow testing the wiring in the event handling
inside the controllers and the content scripts.
It ensures that API calls actually accomplish their goals.

Polyfills and Stubs
-------------------

test/polyfills.js now includes a simple implementation of
chrome.runtime.connect and .onConnect.

The local storage is stubbed entirely so we do not have to worry
about replacing it with rewire in some contexts.
We do not recover it after the run because there is no
working local storage in the test environment anyway.

Loading mailvelope-client-api.js
--------------------------------

content-scripts/clientAPI.js will add a script tag to the head
which then tries to load the mailvelope-client-api.js
This used to result in the following warning:
WARN [web-server]: 404: /context.html/client-API/mailvelope-client-api.js

We now have a proxy defined in test/karma.conf.js.
An additional preprocessor line was needed as
`'**/*.js'` will not include `'../src/client-API/**/*.js'`.

Make keyring.init clear internal state
--------------------------------------
 
We keep the keyringMap and keyringAttr as constants in the keyring closure.
This way they act as singletons that get initialized at load time
and then they keep some state that is also synchronized to the store.

During normal runs this is fine. But in tests the state in keyringMap
and keyringAttr gets out of sync if we clear the locale storage.
This way test state leaks from one test to the next.

The keyring test even made use of this creating a keyring in one test
and then depending on it in another.

This change clears the internal state of the keyring on init.

The dependency between the tests has also been removed
and we now have both tests run based on the same data
created during the initial beforeEach hooks.

Make main.initController not async
----------------------------------
 
initController only registers callbacks.
There's no need for this to be async.

This also makes running it in tests way easier.