### PR TITLE
Fix Firefox link

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -16,7 +16,7 @@ Mailvelope is available in the Chrome Web Store:
 https://chrome.google.com/webstore/detail/kajibbejlbohfaggdiogboambcijhkke
 
 For Firefox you can get it from addons.mozilla.org:
-https://addons.mozilla.org/de/firefox/addon/mailvelope/
+https://addons.mozilla.org/en/firefox/addon/mailvelope/
 
 Or check the [releases](https://github.com/mailvelope/mailvelope/releases) section for latest builds of Firefox and Chrome installation packages.
 


### PR DESCRIPTION
As the Readme.md is in English, so should the referring Firefox link be (it was previously German).