### PR TITLE
Fix missing `fingerprint` property

### DIFF
--- a/src/components/editor/components/RecipientInput.js
+++ b/src/components/editor/components/RecipientInput.js
@@ -140,6 +140,9 @@ export class RecipientInputCtrl {
     }
     // lookup key in local cache
     recipient.key = this.getKey(recipient);
+    if (recipient.key) {
+      recipient.fingerprint = recipient.key.fingerprint;
+    }
     if (recipient.key || recipient.checkedServer) {
       // color tag only if a local key was found, or after server lookup
       this.colorTag(recipient);


### PR DESCRIPTION
In Encrypt/Encrypt data form using space key (`' '`) after typing an e-mail (such as `torvalds@kernel.org`) will properly add the tag to the list. Unfortunately the model will lack `fingerprint` property and throw `Cannot read property 'toHex' of null` later when Encrypt button has
been pressed.

The error does *not* appear when selecting items from drop-down list.

Adding the fingerprint based on a key solves the problem.

Alternative fix would be refactoring that always used `recipient.key.fingerprint` instead of `recipient.fingerprint` thus avoiding data duplication.

The error in question:

![2019-08-16T13:27:28,232356838+02:00](https://user-images.githubusercontent.com/1718963/63176791-e1cc0a00-c046-11e9-9bbf-84841c224d1a.png)
