### PR TITLE
wkd: Add missing `l` parameter to WKD queries

### DIFF
--- a/src/modules/wkdLocate.js
+++ b/src/modules/wkdLocate.js
@@ -118,7 +118,8 @@ export async function buildWKDUrl(email) {
   const localPartBuffer = str2ab(localPart.toLowerCase());
   const digest = await crypto.subtle.digest('SHA-1', localPartBuffer);
   const localEncoded = openpgp.util.encodeZBase32(new Uint8Array(digest));
-  return `https://${domain}/.well-known/openpgpkey/hu/${localEncoded}`;
+  const localPartEncoded = encodeURIComponent(localPart);
+  return `https://${domain}/.well-known/openpgpkey/hu/${localEncoded}?l=${localPartEncoded}`;
 }
 
 /** Convert a promise into a promise with a timeout.

--- a/test/modules/wkdLocate-test.js
+++ b/test/modules/wkdLocate-test.js
@@ -5,7 +5,7 @@ describe('WKD unit test', () => {
   describe('buildWKDUrl', () => {
     it('should generate a WKD URL', async () => {
       const wkdURL = await buildWKDUrl('demo@mailvelope.com');
-      expect(wkdURL).to.equal('https://mailvelope.com/.well-known/openpgpkey/hu/t81jm3hwduh6edujodewwfi9ye6c4urt');
+      expect(wkdURL).to.equal('https://mailvelope.com/.well-known/openpgpkey/hu/t81jm3hwduh6edujodewwfi9ye6c4urt?l=demo');
     });
   });
 });


### PR DESCRIPTION
The [latest version of the WKD spec][0] specifies an `l` parameter that can be used by providers to select a key from a database.

This change adds the missing parameter to queries done by Mailvelope.

[0]: https://datatracker.ietf.org/doc/html/draft-koch-openpgp-webkey-service-10#section-3.1

CC: @toberndo 