### PR TITLE
Add updated OWA Domain

### DIFF
--- a/src/res/defaults.json
+++ b/src/res/defaults.json
@@ -85,6 +85,11 @@
           "scan": true,
           "frame": "*.outlook.office.com",
           "api": false
+        },
+		{
+          "scan": true,
+          "frame": "*.outlook.office365.com",
+          "api": false
         }
       ]
     },


### PR DESCRIPTION
Add alternative domain name for Outlook Web App.

By default only outlook.office.com is provided but the OWA is also redirecting to outlook.office365.com.

The extra domain is added under the same entry as outlook.office365.com.

Obviously this is an alternative domain name managed by MS.
Also Whois report for due diligence : 

> Registry Registrant ID: 
> Registrant Name: Domain Administrator
> Registrant Organization: Microsoft Corporation
> Registrant Street: One Microsoft Way, 
> Registrant City: Redmond
> Registrant State/Province: WA
> Registrant Postal Code: 98052
> Registrant Country: US

Source : https://www.whois.com/whois/office365.com

Note : no issue were open for this as it was a trivial fix.