### PR TITLE
Add EU Zoho datacenter URL as authorized domain

### DIFF
--- a/src/res/defaults.json
+++ b/src/res/defaults.json
@@ -174,6 +174,11 @@
           "scan": true,
           "frame": "*.mail.zoho.com",
           "api": false
+        },
+        {
+          "scan": true,
+          "frame": "*.mail.zoho.eu",
+          "api": false
         }
       ]
     },


### PR DESCRIPTION
This PR adds Zoho's EU datacenter to the list of authorized domains, for reference about their EU DC please see: https://www.zoho.com/blog/general/zoho-data-centers-in-europe.html