### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/src/app/keyring/KeyGrid.js
+++ b/src/app/keyring/KeyGrid.js
@@ -214,7 +214,7 @@ export default class KeyGrid extends React.Component {
                   <td><strong className="mr-2">{key.name}</strong>{this.props.defaultKeyFpr === key.fingerprint && <span className="badge badge-info text-nowrap" aria-hidden="true">{l10n.map.keygrid_default_label}</span>}</td>
                   <td className="emailCell">{key.email}</td>
                   <td className="monospaced">{key.keyId}</td>
-                  <td className="monospaced">{key.crDate.substr(0, 10)}</td>
+                  <td className="monospaced">{key.crDate.slice(0, 10)}</td>
                   <td className="text-center text-nowrap">
                     <div className="actions">
                       {!(this.context.gnupg && key.type === 'private') && <button type="button" onClick={e => { e.stopPropagation(); this.setState({showDeleteKeyModal: true, activeKey: key.keyId}); }} className="btn btn-secondary keyDeleteBtn"><span className="icon icon-delete" aria-hidden="true"></span></button>}

--- a/src/app/settings/WatchList.js
+++ b/src/app/settings/WatchList.js
@@ -156,7 +156,7 @@ export default class WatchList extends React.Component {
 
   addToWatchList({domain, protocol}) {
     if (domain.startsWith('www.')) {
-      domain = domain.substr(4);
+      domain = domain.slice(4);
     }
     this.setState(prevState => {
       let watchListIndex;

--- a/src/components/decrypt-message/DecryptMessage.js
+++ b/src/components/decrypt-message/DecryptMessage.js
@@ -222,7 +222,7 @@ export default class DecryptMessage extends React.Component {
       return keyId.toUpperCase();
     }
     if (fingerprint) {
-      return fingerprint.substr(-16).toUpperCase();
+      return fingerprint.slice(-16).toUpperCase();
     }
   }
 

--- a/src/components/recovery-sheet/recoverySheet.js
+++ b/src/components/recovery-sheet/recoverySheet.js
@@ -134,17 +134,17 @@ export default class RecoverySheet extends React.Component {
                 </div>
                 {this.state.backupCode && (
                   <SecurityBG className="recovery-sheet_code-container" port={this.port}>
-                    <span className="recovery-sheet_code-digit">{this.state.backupCode.substr(0, 5)}</span>
+                    <span className="recovery-sheet_code-digit">{this.state.backupCode.slice(0, 5)}</span>
                     <span className="recovery-sheet_code-separator">-</span>
-                    <span className="recovery-sheet_code-digit">{this.state.backupCode.substr(5, 5)}</span>
+                    <span className="recovery-sheet_code-digit">{this.state.backupCode.slice(5, 10)}</span>
                     <span className="recovery-sheet_code-separator">-</span>
-                    <span className="recovery-sheet_code-digit">{this.state.backupCode.substr(10, 5)}</span>
+                    <span className="recovery-sheet_code-digit">{this.state.backupCode.slice(10, 15)}</span>
                     <span className="recovery-sheet_code-separator">-</span>
-                    <span className="recovery-sheet_code-digit">{this.state.backupCode.substr(15, 5)}</span>
+                    <span className="recovery-sheet_code-digit">{this.state.backupCode.slice(15, 20)}</span>
                     <span className="recovery-sheet_code-separator">-</span>
-                    <span className="recovery-sheet_code-digit">{this.state.backupCode.substr(20, 5)}</span>
+                    <span className="recovery-sheet_code-digit">{this.state.backupCode.slice(20, 25)}</span>
                     <span className="recovery-sheet_code-separator">-</span>
-                    <span className="recovery-sheet_code-digit">{this.state.backupCode.substr(25, 1)}</span>
+                    <span className="recovery-sheet_code-digit">{this.state.backupCode.slice(25, 26)}</span>
                   </SecurityBG>
                 )}
               </div>

--- a/src/content-scripts/gmailIntegration.js
+++ b/src/content-scripts/gmailIntegration.js
@@ -63,7 +63,7 @@ export default class GmailIntegration {
 
   getMsgId(msgElem) {
     const rawID = msgElem.dataset.messageId;
-    return rawID[0] === '#' ? rawID.substr(1) : rawID;
+    return rawID[0] === '#' ? rawID.slice(1) : rawID;
   }
 
   onUpdateMessageData({msgId, data}) {

--- a/src/lib/inject.js
+++ b/src/lib/inject.js
@@ -134,7 +134,7 @@ async function authRequest({tabId, url}) {
   let hostname = targetUrl.hostname;
   const protocol = targetUrl.protocol;
   if (hostname.startsWith('www.')) {
-    hostname = hostname.substr(4);
+    hostname = hostname.slice(4);
   }
   const authDomainCtrl = sub.factory.get('authDomainCont');
   authDomainCtrl.setFrame({hostname, protocol, api, tabId});

--- a/src/modules/gmail.js
+++ b/src/modules/gmail.js
@@ -362,7 +362,7 @@ async function fetchJSON(resource, init) {
 
 function parseQuery(queryString, separator = '&') {
   const query = {};
-  const pairs = (queryString[0] === '?' ? queryString.substr(1) : queryString).split(separator);
+  const pairs = (queryString[0] === '?' ? queryString.slice(1) : queryString).split(separator);
   for (let i = 0; i < pairs.length; i++) {
     const pair = pairs[i].split('=');
     query[decodeURIComponent(pair[0].trim())] = decodeURIComponent((pair[1] || '').replace(/^"(.+(?="$))"$/, '$1'));


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.