### PR TITLE
fix openpgp signatures

### DIFF
--- a/src/modules/openpgpjs.js
+++ b/src/modules/openpgpjs.js
@@ -3,7 +3,7 @@
  * Licensed under the GNU Affero General Public License version 3
  */
 
-import {toArray, Uint8Array2str, dataURL2str, str2Uint8Array} from '../lib/util';
+import {Uint8Array2str, dataURL2str, str2Uint8Array} from '../lib/util';
 import * as openpgp from 'openpgp';
 
 /**
@@ -17,10 +17,10 @@ import * as openpgp from 'openpgp';
  * @param  {String} options.format - default is 'utf8', other value: 'binary'
  * @return {Object}
  */
-export async function decrypt({message, keyring, senderAddress, selfSigned, encryptionKeyIds, unlockKey, format}) {
+export async function decrypt({message, keyring, encryptionKeyIds, unlockKey, format}) {
   let privateKey = keyring.getPrivateKeyByIds(encryptionKeyIds);
   privateKey = await unlockKey({key: privateKey});
-  let signingKeys = signingKeys = keyring.keystore.publicKeys.keys.concat(keyring.keystore.privateKeys.keys.map(k => k.toPublic()));
+  let signingKeys = keyring.keystore.publicKeys.keys.concat(keyring.keystore.privateKeys.keys.map(k => k.toPublic()));
   const result = await openpgp.decrypt({message, privateKeys: privateKey, publicKeys: signingKeys, format});
   result.signatures = (result.signatures || []).map(signature => {
     const sig = {};


### PR DESCRIPTION
This intends to fix issue #736 with the openpgpjs backend. After a bit of debugging, I've found that OpenPGP backend does in fact verify signatures on the GMail / API, but only incidentally so. If the signature was signed by a different email address than in the email `From:` aka `senderAddress`, the signature would be unknown. Additionally, the in-place element decryption in web pages not in email APIs has no `senderAddress`, such as in Mailvelop's dashboard (decrypt). Without a `senderAddress`, mailvelope (and openPGP in general) would not be able to get the public key to verify the signatures.

In both cases, it's simply easiest to verify the signature against all public keys in the keyring. This fixes both issues.
GnuPG backend does not seem to have these problems.