### PR TITLE
Add VSCode's dev container support 

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,14 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/common-utils:2.4.5": {
+      "version": "2.4.5",
+      "resolved": "ghcr.io/devcontainers/features/common-utils@sha256:e232c240319c4e019467c1099536c5eefebd762cf017d6d50353ed50fbf66ba3",
+      "integrity": "sha256:e232c240319c4e019467c1099536c5eefebd762cf017d6d50353ed50fbf66ba3"
+    },
+    "ghcr.io/kreemer/features/chrometesting:1": {
+      "version": "1.0.0",
+      "resolved": "ghcr.io/kreemer/features/chrometesting@sha256:4ddd0cddfa9ebd82733f50bd3f14f79b93e439d4c212a001c7578b8eb1cf9df0",
+      "integrity": "sha256:4ddd0cddfa9ebd82733f50bd3f14f79b93e439d4c212a001c7578b8eb1cf9df0"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,51 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/javascript-node
+{
+	"name": "mailvelope",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/javascript-node:1-20-bullseye",
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	"features": {
+		"ghcr.io/devcontainers/features/common-utils:2.4.5": {
+			"upgradePackages": true,
+			"configureZshAsDefaultShell": true,
+			"nonFreePackages": true
+		},
+		"ghcr.io/kreemer/features/chrometesting:1": {}
+	},
+
+	"privileged": true, // this is for Chrome Headless to work without `--no-sandbox`
+	"containerEnv": {
+		"CHROME_BIN": "/opt/chrome/chrome-wrapper"
+	},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "npm i -g grunt-cli; npm i && grunt",
+
+	// If you'd like to expose your webext build folder, configure the soure path and uncomment
+	// for instance, if running inside WSL, you can use "/mnt/d/Temp/webext-build"
+	// "mounts": [
+	// 	"source=<SOURCE>,target=${containerWorkspaceFolder}/build,type=bind,consistency=cached"
+	// ],
+
+	// Configure tool-specific properties.
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"KnisterPeter.vscode-commitizen",
+				"mikestead.dotenv",
+				"dbaeumer.vscode-eslint",
+				"GitHub.vscode-pull-request-github",
+				"lucono.karma-test-explorer",
+				"dotenv.dotenv-vscode"
+			]
+		}
+	},
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+
+	// You can pass your local dev vars into the container safely, it is excluded from the version control
+	"runArgs": ["--env-file", ".devcontainer/.env.container.dev"]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ apidoc/
 cert/
 .eslintcache
 
+# devcontainer's env var configuration
+/.devcontainer/.env.container.dev
+
 # editors
 *.sublime*
 atlassian-ide-plugin.xml

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,12 @@
+{
+    "recommendations": [        
+        "KnisterPeter.vscode-commitizen",
+        "mikestead.dotenv",
+        "xabikos.JavaScriptSnippets",
+        "dbaeumer.vscode-eslint",
+        "Gruntfuggly.todo-tree",
+        "GitHub.vscode-pull-request-github",
+        "ypresto.vscode-intelli-refactor",
+        "donjayamanne.githistory"        
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,13 @@
+{
+    "eslint.lintTask.enable": true,
+    "eslint.options": {
+        "overrideConfigFile": "./config/eslint.json"
+    },
+    "eslint.format.enable": true,
+    "javascript.format.enable": false,
+    "javascript.validate.enable": true,
+    "typescript.format.enable": false,
+
+    "karmaTestExplorer.karmaConfFilePath": "./test/karma.conf.js",
+    "karmaTestExplorer.browser": "ChromeHeadless"
+}


### PR DESCRIPTION
Adding a VSCode's devcontainer configuration in order to quicker spawn development environment.
Based on Node.js bullsyeye.

Includes dependabot config too, it was added automatically by VSCode.