### PR TITLE
Add better hint when GnuPG installed but not working

### DIFF
--- a/locales/de/messages.json
+++ b/locales/de/messages.json
@@ -569,7 +569,7 @@
   },
   "general_gnupg_installed_question": {
     "description": "Status message with available user options",
-    "message": "Haben Sie GnuPG installiert? Falls nicht <0>Hier herunterladen</0> oder die Verfügbarkeit erneut überprüfen <1>Mailvelope neu starten</1>"
+    "message": "Haben Sie GnuPG installiert? Falls nicht <0>Hier herunterladen</0> oder die Verfügbarkeit erneut überprüfen <1>Mailvelope neu starten</1>. Wenn Sie sicher sind, dass es installiert ist, folgen Sie bitte <2>diesem Wiki</2>, um sicherzustellen, dass es richtig eingerichtet wurde"
   },
   "general_gnupg_not_available": {
     "description": "Indicator if GnuPG is not available",

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -569,7 +569,7 @@
   },
   "general_gnupg_installed_question": {
     "description": "Status message with available user options",
-    "message": "Do you have GnuPG installed? If not <0>Download here</0>. To check availability again <1>Restart Mailvelope</1>"
+    "message": "Do you have GnuPG installed? If not <0>Download here</0>. To check availability again <1>Restart Mailvelope</1>. If you are sure it is installed, please follow <2>this wiki</2> to make sure it has been set up properly"
   },
   "general_gnupg_not_available": {
     "description": "Indicator if GnuPG is not available",

--- a/locales/ru/messages.json
+++ b/locales/ru/messages.json
@@ -568,7 +568,7 @@
         "description": "Button label to check availability of GnuPG"
     },
     "general_gnupg_installed_question": {
-        "message": "У вас установлена программа GnuPG? Если нет, <0>скачайте ее отсюда</0>. Чтобы снова проверить доступность программы, <1>перезапустите Mailvelope</1>",
+        "message": "У вас установлена программа GnuPG? Если нет, <0>скачайте ее отсюда</0>. Чтобы снова проверить доступность программы, <1>перезапустите Mailvelope</1>. Если вы уверены, что она установлена, воспользуйтесь <2>этой вики</2>, чтобы убедиться, что она настроена правильно",
         "description": "Status message with available user options"
     },
     "general_gnupg_not_available": {

--- a/locales/uk/messages.json
+++ b/locales/uk/messages.json
@@ -568,7 +568,7 @@
         "description": "Button label to check availability of GnuPG"
     },
     "general_gnupg_installed_question": {
-        "message": "Чи встановлено у вас GnuPG? Якщо ні, <0>завантажте тут</0>. Щоб знову перевірити доступність, <1>перезапустіть Mailvelope</1>",
+        "message": "Чи встановлено у вас GnuPG? Якщо ні, <0>завантажте тут</0>. Щоб знову перевірити доступність, <1>перезапустіть Mailvelope</1>. Якщо ви впевнені що у вас є GnuPG, будь ласка почитайте <2>цю вікі</2>, щоб впевнитися, що все налаштовано правильно",
         "description": "Status message with available user options"
     },
     "general_gnupg_not_available": {

--- a/src/app/settings/General.js
+++ b/src/app/settings/General.js
@@ -125,7 +125,8 @@ export default class General extends React.Component {
                         <div>
                           <Trans id={l10n.map.general_gnupg_installed_question} components={[
                             <a key="0" href="https://www.gnupg.org/download/index.html" target="_blank" rel="noopener noreferrer" className="btn btn-secondary btn-sm my-1" role="button"></a>,
-                            <button key="1" type="button" onClick={() => chrome.runtime.reload()} className="btn btn-secondary btn-sm"></button>
+                            <button key="1" type="button" onClick={() => chrome.runtime.reload()} className="btn btn-secondary btn-sm"></button>,
+                            <a key="2" href="https://github.com/mailvelope/mailvelope/wiki/Mailvelope-GnuPG-integration" target="_blank" rel="noopener noreferrer"></a>
                           ]} />
                         </div>
                       </div>


### PR DESCRIPTION
## Description
This addresses #837 by just adding a hint for the user to check out the wiki page on how to setup GnuPGP properly. 

![image](https://github.com/mailvelope/mailvelope/assets/1504642/c980c598-b59d-4afe-af62-23a326a71171)

IMPORTANT: This is a Draft, since it needs more translations or another way of fixing 