### PR TITLE
Keep the input text after deleting a tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "react-datepicker": "1.7.0",
     "react-dom": "16.14.0",
     "react-router-dom": "5.2.0",
+    "react-tag-input": "6.5.4",
     "reactstrap": "8.10.1",
     "webextension-polyfill": "0.12.0"
   },

--- a/src/app/encrypt/Encrypt.js
+++ b/src/app/encrypt/Encrypt.js
@@ -269,7 +269,7 @@ export default class Encrypt extends React.Component {
                   <div className="form-group">
                     <label>{l10n.map.editor_label_recipient}</label>
                     <RecipientInput keys={this.state.keys} recipients={this.state.recipients}
-                      onChangeRecipient={({hasError}) => this.setState({recipientsError: hasError})}
+                      onChangeRecipients={({recipients, hasError}) => this.setState({recipients, recipientsError: hasError})}
                       onAutoLocate={recipient => this.handleAutoLocate(recipient)}
                     />
                   </div>

--- a/src/app/encrypt/Encrypt.js
+++ b/src/app/encrypt/Encrypt.js
@@ -267,7 +267,7 @@ export default class Encrypt extends React.Component {
                 </div>
                 <div className={this.state.encrypted.length ? 'd-none' : ''}>
                   <div className="form-group">
-                    <label>{l10n.map.editor_label_recipient}</label>
+                    <label htmlFor="recipients-input">{l10n.map.editor_label_recipient}</label>
                     <RecipientInput keys={this.state.keys} recipients={this.state.recipients}
                       onChangeRecipients={({recipients, hasError}) => this.setState({recipients, recipientsError: hasError})}
                       onAutoLocate={recipient => this.handleAutoLocate(recipient)}

--- a/src/components/editor/components/RecipientInput.js
+++ b/src/components/editor/components/RecipientInput.js
@@ -172,7 +172,7 @@ export function RecipientInput({
 
   useEffect(() => {
     onChangeRecipients && onChangeRecipients({recipients: tags.map(t => t.recipient), hasError});
-    // We do not want circular dependency, hence we do not set onChangeRecipient
+    // We do not want circular dependency, hence we do not set onChangeRecipients
     // as a dependency for `useEffect`
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [hasError, tags]);

--- a/src/components/editor/components/RecipientInput.js
+++ b/src/components/editor/components/RecipientInput.js
@@ -149,7 +149,6 @@ export function RecipientInput({extraKey, hideErrorMsg, keys, onAutoLocate, onCh
   }));
 
   return (
-    // TODO replace `has-error` class with bootstrap validation
     <div id={id} className="input-group mb-3">
       <ReactTags
         tags={tags}

--- a/src/components/editor/components/RecipientInput.js
+++ b/src/components/editor/components/RecipientInput.js
@@ -18,7 +18,6 @@ l10n.register([
   'editor_key_not_found_msg'
 ]);
 
-// TODO convert to function declation
 /**
  * Checks if all recipients have a public key and prevents encryption
  * if one of them does not have a key.
@@ -70,7 +69,6 @@ function findRecipientKey(keys, email) {
  * @param {Props} props - Component properties
  * @returns {React.JSX.Element}
  */
-// TODO make params in one line
 export function RecipientInput({extraKey, hideErrorMsg, keys, onAutoLocate, onChangeRecipients, recipients}) {
   const id = getUUID();
 

--- a/src/components/editor/components/RecipientInput.js
+++ b/src/components/editor/components/RecipientInput.js
@@ -27,7 +27,6 @@ l10n.register([
  * @returns {Boolean} true if any recipient is unencrypted
  */
 function isAnyRecipientUnencrypted(tags, keys, extraKey) {
-  // TODO calling findRecipientKey is suboptimal
   return tags.some(t => !findRecipientKey(keys, t.id)) && !extraKey;
 }
 
@@ -97,10 +96,9 @@ export function RecipientInput({extraKey, hideErrorMsg, keys, onAutoLocate, onCh
       recipient.key = key;
       recipient.fingerprint = key.fingerprint;
     }
-    if (!recipient.key && !recipient.checkedServer) {
+    if (!recipient.key && !recipient.checkServer) {
       // No local key found, do a search with the autoLocate module
-      // TODO rename `checkedServer`
-      recipient.checkedServer = true;
+      recipient.checkServer = true;
     }
     return recipient;
   }, [keys]);
@@ -117,7 +115,6 @@ export function RecipientInput({extraKey, hideErrorMsg, keys, onAutoLocate, onCh
     // as a dependency for `useEffect`
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [keys, extraKey]);
-  // TODO Follow up for proper state managament
 
   useEffect(() => {
     onChangeRecipients && onChangeRecipients({recipients: tags.map(t => tagToRecipient(t)), hasError});
@@ -133,7 +130,7 @@ export function RecipientInput({extraKey, hideErrorMsg, keys, onAutoLocate, onCh
   const onAddition = useCallback(newTag => {
     if (checkEmail(newTag.id)) {
       const recipient = tagToRecipient(newTag);
-      if (recipient.checkedServer) {
+      if (recipient.checkServer) {
         // No local key found, do a search with the autoLocate module
         onAutoLocate(recipient);
       }

--- a/src/components/editor/components/RecipientInput.js
+++ b/src/components/editor/components/RecipientInput.js
@@ -73,7 +73,7 @@ export function RecipientInput({
   hideErrorMsg,
   keys,
   onAutoLocate,
-  onChangeRecipient,
+  onChangeRecipients,
   recipients,
 }) {
   const id = getUUID();
@@ -171,11 +171,11 @@ export function RecipientInput({
   }, [keys, tags, extraKey, hideErrorMsg, updateRecipientKey, recipientToTag]);
 
   useEffect(() => {
-    onChangeRecipient && onChangeRecipient({hasError});
+    onChangeRecipients && onChangeRecipients({recipients: tags.map(t => t.recipient), hasError});
     // We do not want circular dependency, hence we do not set onChangeRecipient
     // as a dependency for `useEffect`
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [hasError]);
+  }, [hasError, tags]);
 
   const onDelete = useCallback(tagIndex => {
     setTags(tags.filter((_, i) => i !== tagIndex));
@@ -238,7 +238,7 @@ export function RecipientInput({
  * @property {boolean} hideErrorMsg - Flag indicating whether error message should be hidden
  * @property {Array<Key>} keys - Array of public keys
  * @property {Function} onAutoLocate - Callback function for auto-locating keys
- * @property {Function} onChangeRecipient - Callback function for recipient changes
+ * @property {Function} onChangeRecipients - Callback function for recipient changes
  * @property {Array<Recipient>} recipients - Array of recipients
  */
 RecipientInput.propTypes = {
@@ -246,6 +246,6 @@ RecipientInput.propTypes = {
   hideErrorMsg: PropTypes.bool,
   keys: PropTypes.array,
   onAutoLocate: PropTypes.func,
-  onChangeRecipient: PropTypes.func,
+  onChangeRecipients: PropTypes.func,
   recipients: PropTypes.array
 };

--- a/src/components/editor/components/RecipientInput.scss
+++ b/src/components/editor/components/RecipientInput.scss
@@ -1,82 +1,166 @@
 @import "../../../res/styles/_required";
 
-.recipients-input tags-input .tags .tag-item {
-  font-family: $font-family-base;
-  font-weight: 500;
-  background-color: theme-color-level("primary", $alert-bg-level);
-  border-color: theme-color-level("primary", $alert-border-level);
-  transition: background-color 0.3s, border-color 0.3s;
-}
+.recipients-input {
+  .react-tags {
+    position: relative;
+    padding: 6px 0 0 6px;
+    border: $border-width solid $input-border-color;
+    border-radius: $input-border-radius;
 
-@mixin tag-variant($background, $border, $color) {
-  color: $color;
-  @include gradient-bg($background);
-  border-color: $border;
-}
+    /* shared font styles */
+    font-size: 1em;
+    line-height: 1.2;
 
-.recipients-input tags-input .tags .remove-button {
-  color: inherit;
-}
+    /* clicking anywhere will focus the input */
+    cursor: text;
 
-@each $color, $value in $theme-colors {
-  .recipients-input tags-input .tags .tag-#{$color} {
-    @include alert-variant(theme-color-level($color, $alert-bg-level), theme-color-level($color, $alert-border-level), theme-color($color));
+    transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
   }
-  .recipients-input tags-input .tags .tag-#{$color} .remove-button {
-    color: theme-color($color);
-  }  
+
+  .react-tags.is-focused {
+    background-color: $input-focus-bg;
+    border-color: $input-focus-border-color;
+    box-shadow: $input-focus-box-shadow;
+  }
+
+  .react-tags__selected {
+    display: inline;
+  }
+
+  .react-tags__selected-tag {
+    display: inline-block;
+    box-sizing: border-box;
+    margin: 0 6px 6px 0;
+    padding: 6px 8px;
+    border-radius: 2px;
+    font-family: $font-family-base;
+    font-weight: 500;
+    background-color: theme-color-level("primary", $alert-bg-level);
+    border-color: theme-color-level("primary", $alert-border-level);
+    transition: background-color 0.3s, border-color 0.3s;
+
+    /* match the font styles */
+    font-size: inherit;
+    line-height: inherit;
+
+    :after {
+      content: '\2715';
+      color: #AAA;
+      margin-left: 8px;
+    }
+
+    :hover,
+    :focus {
+      border-color: #B1B1B1;
+    }
+
+    ::before {
+      font-family: 'MailvelopeIcons' !important;
+      font-style: normal;
+      font-weight: normal;
+      font-variant: normal;
+      text-transform: none;
+      line-height: 1;
+
+      /* Better Font Rendering =========== */
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+    }
+
+    .tag-success:before {
+      content: "\e90f \00a0";
+    }
+
+    .tag-danger:before {
+      content: "\e909 \00a0";
+    }
+  }
+
+  .react-tags__search {
+    display: inline-block;
+
+    /* match tag layout */
+    padding: 7px 2px;
+    margin-bottom: 6px;
+
+    /* prevent autoresize overflowing the container */
+    max-width: 100%;
+  }
+
+  @media screen and (min-width: 30em) {
+
+    .react-tags__search {
+      /* this will become the offsetParent for suggestions */
+      position: relative;
+    }
+
+  }
+
+  .react-tags__search-input {
+    /* prevent autoresize overflowing the container */
+    max-width: 100%;
+
+    /* remove styles and layout from this element */
+    margin: 0;
+    padding: 0;
+    border: 0;
+    outline: none;
+
+    /* match the font styles */
+    font-size: inherit;
+    line-height: inherit;
+
+    ::-ms-clear {
+      display: none;
+    }
+  }
+
+  .react-tags__suggestions {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    width: 100%;
+    z-index: 2;
+
+    ul {
+      margin: 4px -1px;
+      padding: 0;
+      list-style: none;
+      background: white;
+      border: 1px solid #D1D1D1;
+      border-radius: 2px;
+      box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+    }
+
+    li {
+      border-bottom: 1px solid #ddd;
+      padding: 6px 8px;
+    }
+
+    li mark {
+      text-decoration: underline;
+      background: none;
+      font-weight: 600;
+    }
+
+    li:hover {
+      cursor: pointer;
+      background: #eee;
+    }
+
+    li.is-active {
+      background: #b7cfe0;
+    }
+
+    li.is-disabled {
+      opacity: 0.5;
+      cursor: auto;
+    }
+  }
+
+  @media screen and (min-width: 30em) {
+    .react-tags__suggestions {
+      width: 240px;
+    }
+  }
 }
-
-.recipients-input tags-input .tags.focused {
-  background-color: $input-focus-bg;
-  border-color: $input-focus-border-color;
-  box-shadow: $input-focus-box-shadow;
-}
-
-.recipients-input tags-input .tags .tag-item:before {
-  font-family: 'MailvelopeIcons' !important;
-  speak: none;
-  font-style: normal;
-  font-weight: normal;
-  font-variant: normal;
-  text-transform: none;
-  line-height: 1;
-
-  /* Better Font Rendering =========== */
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
-
-.recipients-input tags-input .tags .tag-success:before {
-  content: "\e90f \00a0";
-}
-
-.recipients-input tags-input .tags .tag-danger:before {
-  content: "\e909 \00a0";
-}
-
-.recipients-input tags-input.ng-invalid .tags,
-.recipients-input.has-error tags-input .tags {
-  border-color: $form-feedback-invalid-color;
-  box-shadow: none;
-}
-
-.recipients-input tags-input.ng-invalid .tags.focused,
-.recipients-input.has-error tags-input .tags.focused {
-  border-color: $form-feedback-invalid-color;
-  box-shadow: 0 0 0 $input-focus-width rgba($form-feedback-invalid-color, .25);
-}
-
-.recipients-input tags-input .tags .input {
-  font-family: $font-family-base;
-  width: auto !important;
-}
-
-.recipients-input .alert {
-  margin: 10px 0 5px; 
-}
-
-.recipients-input tags-input .tags {
-  transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
-}
-

--- a/src/components/editor/components/RecipientInput.scss
+++ b/src/components/editor/components/RecipientInput.scss
@@ -1,104 +1,78 @@
 @import "../../../res/styles/_required";
 
-// TODO Utilize bootstrap classes instead of custom styling
-// eg. use @extend to extend bootstrap classes
-// or use the component's `classNames` to point on bootstrap classes directly
-// see https://getbootstrap.com/docs/4.6/components/forms/
+@import "/node_modules/bootstrap/scss/badge";
+@import "/node_modules/bootstrap/scss/dropdown";
+@import "/node_modules/bootstrap/scss/forms";
 
 .recipients-input {
-  .react-tags-wrapper {
-    position: relative;
-    padding: 6px 0 0 6px;
-    border: $border-width solid $input-border-color;
-    border-radius: $input-border-radius;
+  @extend .form-control;
+  padding: 1px;
+  position: relative; // for the dropdown
+  height: initial; // input should be stretchable
 
-    /* shared font styles */
-    font-size: 1em;
-    line-height: 1.2;
-
-    /* clicking anywhere will focus the input */
-    cursor: text;
-
-    transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+  &:focus-within {
+    @extend .form-control:focus;
   }
 
-  .react-tags-wrapper.is-focused {
-    background-color: $input-focus-bg;
-    border-color: $input-focus-border-color;
-    box-shadow: $input-focus-box-shadow;
-  }
-
-  .ReactTags__selected {
-    display: inline;
+  .tag-selected-list {
+    /* The layout has to be stretchable because the input should take all the space left */
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
 
     .tag-wrapper {
-      display: inline-block;
-      box-sizing: border-box;
-      margin: 0 6px 6px 0;
-      padding: 6px 8px;
-      border-radius: 2px;
-      font-family: $font-family-base;
-      font-weight: 500;
-      background-color: theme-color-level("primary", $alert-bg-level);
-      border-color: theme-color-level("primary", $alert-border-level);
-      transition: background-color 0.3s, border-color 0.3s;
+      @extend .badge;
+      margin: 2px;
 
-      /* match the font styles */
-      font-size: inherit;
-      line-height: inherit;
-
-      .ReactTags__remove {
-        color: #AAA;
+      .tag-remove {
+        /* Reset button styles */
+        padding: 0;
+        border: none;
+        background: none;
+        font-weight: 700;
+        font-size: 16px;
         margin-left: 8px;
       }
 
-      :hover,
-      :focus {
-        border-color: #B1B1B1;
+      &::before {
+        font: normal normal normal 14px/1 'MailvelopeIcons';
+        line-height: 1;
+
+        /* Better Font Rendering =========== */
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
       }
-    }
-
-    .tag-wrapper::before {
-      font: normal normal normal 14px/1 'MailvelopeIcons';
-      line-height: 1;
-
-      /* Better Font Rendering =========== */
-      -webkit-font-smoothing: antialiased;
-      -moz-osx-font-smoothing: grayscale;
     }
 
     @each $color, $value in $theme-colors {
-      .tag-#{$color} {
+      .badge-#{$color} {
         @include alert-variant(theme-color-level($color, $alert-bg-level), theme-color-level($color, $alert-border-level), theme-color($color));
       }
 
-      .tag-#{$color} .ReactTags__remove {
+      .badge-#{$color} .tag-remove {
         color: theme-color($color);
       }
     }
 
-    .tag-success::before {
+    .badge-success::before {
       content: "\e90f \00a0";
     }
 
-    .tag-danger::before {
+    .badge-danger::before {
       content: "\e909 \00a0";
     }
   }
 
-  .ReactTags__tagInput {
-    display: inline-block;
+  .tag-input-wrapper {
+    flex: 1;
 
     /* match tag layout */
     padding: 7px 2px;
-    margin-bottom: 6px;
+    margin: 2px;
 
-    /* prevent autoresize overflowing the container */
-    max-width: 100%;
-
-    .ReactTags__tagInputField {
-      /* prevent autoresize overflowing the container */
-      max-width: 100%;
+    .tag-input-field {      
+      width: 100%;
+      min-width: 12rem;
 
       /* remove styles and layout from this element */
       margin: 0;
@@ -116,61 +90,32 @@
     }
   }
 
-  @media screen and (min-width: 30em) {
-
-    .ReactTags__tagInput {
-      /* this will become the offsetParent for suggestions */
-      position: relative;
-    }
-
-  }
-
-  .ReactTags__suggestions {
-    position: absolute;
-    top: 100%;
-    left: 0;
-    width: 100%;
-    z-index: 2;
+  .suggestions {
+    @extend .dropdown-menu;
+    /* `react-tags` adds menu to the DOM instead of hiding it, so we override bootstap */
+    display: block;
 
     ul {
-      margin: 4px -1px;
+      /* Reset `ul`s padding */
       padding: 0;
-      list-style: none;
-      background: white;
-      border: 1px solid #D1D1D1;
-      border-radius: 2px;
-      box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+      margin: 0
     }
 
     li {
-      border-bottom: 1px solid #ddd;
-      padding: 6px 8px;
+      @extend .dropdown-item;
     }
 
+    /* `react-tags` does not set the focus state on keyboard navigation */
+    li.active-suggestion {
+      @extend .dropdown-item:hover;
+    }
+
+    /* Text highlighted by search */
     li mark {
+      padding: 0px;
       text-decoration: underline;
       background: none;
       font-weight: 600;
-    }
-
-    li:hover {
-      cursor: pointer;
-      background: #eee;
-    }
-
-    li.is-active {
-      background: #b7cfe0;
-    }
-
-    li.is-disabled {
-      opacity: 0.5;
-      cursor: auto;
-    }
-  }
-
-  @media screen and (min-width: 30em) {
-    .ReactTags__suggestions {
-      width: 240px;
     }
   }
 }

--- a/src/components/editor/components/RecipientInput.scss
+++ b/src/components/editor/components/RecipientInput.scss
@@ -3,10 +3,16 @@
 @import "/node_modules/bootstrap/scss/badge";
 @import "/node_modules/bootstrap/scss/dropdown";
 @import "/node_modules/bootstrap/scss/forms";
+@import "/node_modules/bootstrap/scss/utilities/display";
+@import "/node_modules/bootstrap/scss/utilities/flex";
+@import "/node_modules/bootstrap/scss/utilities/spacing";
+
+// Get spacer value from bootstrap
+$sp-1: map-get($spacers, 1);
 
 .recipients-input {
-  @extend .form-control;
-  padding: 1px;
+  @extend .form-control, .mb-1;
+  padding: 0 $sp-1 $sp-1 0; // mirror to tags and input margins
   position: relative; // for the dropdown
   height: initial; // input should be stretchable
 
@@ -16,13 +22,11 @@
 
   .tag-selected-list {
     /* The layout has to be stretchable because the input should take all the space left */
-    display: flex;
-    flex-direction: row;
-    flex-wrap: wrap;
+    @extend .d-flex, .flex-wrap;
 
     .tag-wrapper {
-      @extend .badge;
-      margin: 2px;
+      @extend .badge; // we later copy $badge-padding-y in .tag-input-wrapper
+      margin: $sp-1 0 0 $sp-1; // mirror to .recipients-input padding
 
       .tag-remove {
         /* Reset button styles */
@@ -64,19 +68,17 @@
   }
 
   .tag-input-wrapper {
-    flex: 1;
+    @extend .flex-grow-1;
+    /* match bage layout */
+    padding: $badge-padding-y 0; 
+    margin: $sp-1 0 0 $sp-1; // mirror to .recipients-input padding
 
-    /* match tag layout */
-    padding: 7px 2px;
-    margin: 2px;
-
-    .tag-input-field {      
+    .tag-input-field {
       width: 100%;
       min-width: 12rem;
 
       /* remove styles and layout from this element */
-      margin: 0;
-      padding: 0;
+      @extend .m-0, .p-0;
       border: 0;
       outline: none;
 
@@ -91,14 +93,12 @@
   }
 
   .suggestions {
-    @extend .dropdown-menu;
-    /* `react-tags` adds menu to the DOM instead of hiding it, so we override bootstap */
-    display: block;
+    @extend .dropdown-menu, .d-block;
+    /* `react-tags` adds menu to the DOM instead of hiding it, so we override bootstap */    
 
     ul {
       /* Reset `ul`s padding */
-      padding: 0;
-      margin: 0
+      @extend .m-0, .p-0;
     }
 
     li {
@@ -112,7 +112,7 @@
 
     /* Text highlighted by search */
     li mark {
-      padding: 0px;
+      @extend .p-0;
       text-decoration: underline;
       background: none;
       font-weight: 600;

--- a/src/components/editor/components/RecipientInput.scss
+++ b/src/components/editor/components/RecipientInput.scss
@@ -93,8 +93,10 @@ $sp-1: map-get($spacers, 1);
   }
 
   .suggestions {
-    @extend .dropdown-menu, .d-block;
-    /* `react-tags` adds menu to the DOM instead of hiding it, so we override bootstap */    
+    @extend .dropdown-menu, 
+            .d-block; /* `react-tags` adds menu to the DOM instead of hiding it, so we override bootstap */    
+    width: 100%;
+    overflow-x: auto;
 
     ul {
       /* Reset `ul`s padding */

--- a/src/components/editor/components/RecipientInput.scss
+++ b/src/components/editor/components/RecipientInput.scss
@@ -1,7 +1,12 @@
 @import "../../../res/styles/_required";
 
+// TODO Utilize bootstrap classes instead of custom styling
+// eg. use @extend to extend bootstrap classes
+// or use the component's `classNames` to point on bootstrap classes directly
+// see https://getbootstrap.com/docs/4.6/components/forms/
+
 .recipients-input {
-  .react-tags {
+  .react-tags-wrapper {
     position: relative;
     padding: 6px 0 0 6px;
     border: $border-width solid $input-border-color;
@@ -17,49 +22,44 @@
     transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
   }
 
-  .react-tags.is-focused {
+  .react-tags-wrapper.is-focused {
     background-color: $input-focus-bg;
     border-color: $input-focus-border-color;
     box-shadow: $input-focus-box-shadow;
   }
 
-  .react-tags__selected {
+  .ReactTags__selected {
     display: inline;
-  }
 
-  .react-tags__selected-tag {
-    display: inline-block;
-    box-sizing: border-box;
-    margin: 0 6px 6px 0;
-    padding: 6px 8px;
-    border-radius: 2px;
-    font-family: $font-family-base;
-    font-weight: 500;
-    background-color: theme-color-level("primary", $alert-bg-level);
-    border-color: theme-color-level("primary", $alert-border-level);
-    transition: background-color 0.3s, border-color 0.3s;
+    .tag-wrapper {
+      display: inline-block;
+      box-sizing: border-box;
+      margin: 0 6px 6px 0;
+      padding: 6px 8px;
+      border-radius: 2px;
+      font-family: $font-family-base;
+      font-weight: 500;
+      background-color: theme-color-level("primary", $alert-bg-level);
+      border-color: theme-color-level("primary", $alert-border-level);
+      transition: background-color 0.3s, border-color 0.3s;
 
-    /* match the font styles */
-    font-size: inherit;
-    line-height: inherit;
+      /* match the font styles */
+      font-size: inherit;
+      line-height: inherit;
 
-    :after {
-      content: '\2715';
-      color: #AAA;
-      margin-left: 8px;
+      .ReactTags__remove {
+        color: #AAA;
+        margin-left: 8px;
+      }
+
+      :hover,
+      :focus {
+        border-color: #B1B1B1;
+      }
     }
 
-    :hover,
-    :focus {
-      border-color: #B1B1B1;
-    }
-
-    ::before {
-      font-family: 'MailvelopeIcons' !important;
-      font-style: normal;
-      font-weight: normal;
-      font-variant: normal;
-      text-transform: none;
+    .tag-wrapper::before {
+      font: normal normal normal 14px/1 'MailvelopeIcons';
       line-height: 1;
 
       /* Better Font Rendering =========== */
@@ -67,16 +67,26 @@
       -moz-osx-font-smoothing: grayscale;
     }
 
-    .tag-success:before {
+    @each $color, $value in $theme-colors {
+      .tag-#{$color} {
+        @include alert-variant(theme-color-level($color, $alert-bg-level), theme-color-level($color, $alert-border-level), theme-color($color));
+      }
+
+      .tag-#{$color} .ReactTags__remove {
+        color: theme-color($color);
+      }
+    }
+
+    .tag-success::before {
       content: "\e90f \00a0";
     }
 
-    .tag-danger:before {
+    .tag-danger::before {
       content: "\e909 \00a0";
     }
   }
 
-  .react-tags__search {
+  .ReactTags__tagInput {
     display: inline-block;
 
     /* match tag layout */
@@ -85,37 +95,37 @@
 
     /* prevent autoresize overflowing the container */
     max-width: 100%;
+
+    .ReactTags__tagInputField {
+      /* prevent autoresize overflowing the container */
+      max-width: 100%;
+
+      /* remove styles and layout from this element */
+      margin: 0;
+      padding: 0;
+      border: 0;
+      outline: none;
+
+      /* match the font styles */
+      font-size: inherit;
+      line-height: inherit;
+
+      ::-ms-clear {
+        display: none;
+      }
+    }
   }
 
   @media screen and (min-width: 30em) {
 
-    .react-tags__search {
+    .ReactTags__tagInput {
       /* this will become the offsetParent for suggestions */
       position: relative;
     }
 
   }
 
-  .react-tags__search-input {
-    /* prevent autoresize overflowing the container */
-    max-width: 100%;
-
-    /* remove styles and layout from this element */
-    margin: 0;
-    padding: 0;
-    border: 0;
-    outline: none;
-
-    /* match the font styles */
-    font-size: inherit;
-    line-height: inherit;
-
-    ::-ms-clear {
-      display: none;
-    }
-  }
-
-  .react-tags__suggestions {
+  .ReactTags__suggestions {
     position: absolute;
     top: 100%;
     left: 0;
@@ -159,7 +169,7 @@
   }
 
   @media screen and (min-width: 30em) {
-    .react-tags__suggestions {
+    .ReactTags__suggestions {
       width: 240px;
     }
   }

--- a/src/components/editor/editor.js
+++ b/src/components/editor/editor.js
@@ -377,15 +377,15 @@ export default class Editor extends React.Component {
     }, timeout);
   }
 
-  handleChangeRecipient(error) {
+  handleChangeRecipients(recipients, recipientsError) {
     this.setState(prevState => {
-      const errorState = {recipientsError: prevState.recipientsError, recipientsCcError: prevState.recipientsCcError, ...error};
-      return {...errorState, encryptDisabled: errorState.recipientsError || errorState.recipientsCcError || !prevState.recipients.length};
+      const errorState = {recipientsError, recipientsCcError: prevState.recipientsCcError};
+      return {...errorState, recipients, encryptDisabled: errorState.recipientsError || errorState.recipientsCcError || !recipients.length};
     });
   }
 
-  handleChangeExtraKeyInput({hasError}) {
-    this.setState({extraKeysError: hasError});
+  handleChangeExtraKeyInput(extraKeys, extraKeysError) {
+    this.setState({extraKeys, extraKeysError});
   }
 
   onNotificationEnteredTransition() {
@@ -413,7 +413,7 @@ export default class Editor extends React.Component {
                         {(!this.state.showRecipientsCc && this.state.integration) && <label><a href="#" role="button" className="text-reset" onClick={() => this.setState({showRecipientsCc: true})}>{l10n.map.editor_label_copy_recipient}</a></label>}
                       </div>
                       <RecipientInput keys={this.state.publicKeys} recipients={this.state.recipients}
-                        onChangeRecipient={({hasError}) => this.handleChangeRecipient({recipientsError: hasError})}
+                        onChangeRecipients={({recipients, hasError}) => this.handleChangeRecipients(recipients, hasError)}
                         onAutoLocate={recipient => this.handleKeyLookup(recipient)}
                         extraKey={hasExtraKey}
                       />
@@ -423,7 +423,7 @@ export default class Editor extends React.Component {
                     <div className="mb-3">
                       <label className="mr-auto">{l10n.map.editor_label_copy_recipient}</label>
                       <RecipientInput keys={this.state.publicKeys} recipients={this.state.recipientsCc}
-                        onChangeRecipient={({hasError}) => this.handleChangeRecipient({recipientsCcError: hasError})}
+                        onChangeRecipients={({recipients, hasError}) => this.handleChangeRecipients(recipients, hasError)}
                         onAutoLocate={recipient => this.handleKeyLookup(recipient)}
                         extraKey={hasExtraKey}
                       />
@@ -459,7 +459,7 @@ export default class Editor extends React.Component {
                     extraKey={this.state.extraKey}
                     extraKeyInput={
                       <RecipientInput keys={this.state.publicKeys} recipients={this.state.extraKeys} onAutoLocate={recipient => this.handleKeyLookup(recipient)} hideErrorMsg={true}
-                        onChangeRecipient={error => this.handleChangeExtraKeyInput(error)}
+                        onChangeRecipients={({recipients, hasError}) => this.handleChangeExtraKeyInput(recipients, hasError)}
                       />}
                     integration = {this.state.integration}
                     onCancel={() => this.handleCancel()}
@@ -468,6 +468,7 @@ export default class Editor extends React.Component {
                     onExtraKey={event => this.handleCheck(event)}
                     onOk={() => this.handleOk()}
                     onSignOnly={() => this.handleSign()}
+                    // TODO encryptDisabled should also consider extraKeysError flag
                     privKeys={this.state.privKeys} encryptDisabled={this.state.encryptDisabled || this.state.plainText === ''}
                   />
                 </div>


### PR DESCRIPTION
This is a hack to keep the text in the input field after a user hit
backspace and deleted a tag.

Manipulates with undocumented property of `ReactTags` (`inputValue` and with `allowDeleteFromEmptyInput` to enable event propagation after hitting backspace. 