### PR TITLE
Update react-datepicker to v4.20

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "bootstrap": "4.4.1",
     "clean-insights-sdk": "2.6.2",
     "dompurify": "3.1.5",
+    "date-fns": "^3.6.0",
     "emailjs-mime-builder": "github:mailvelope/emailjs-mime-builder#bf4cea3bdf50bb26b0f86ee9b1e9ee7063b5a8cc",
     "emailjs-mime-parser": "2.0.7",
     "gpgmejs": "github:mailvelope/gpgmejs#c412917b2a111d99d9a1bb746dcc29b9802c869e",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "prop-types": "15.8.1",
     "qrcode.react": "3.1.0",
     "react": "16.14.0",
-    "react-datepicker": "1.7.0",
+    "react-datepicker": "4.25.0",
     "react-dom": "16.14.0",
     "react-router-dom": "5.2.0",
     "reactstrap": "8.10.1",

--- a/src/app/keyring/KeyImport.js
+++ b/src/app/keyring/KeyImport.js
@@ -329,13 +329,13 @@ export default class KeyImport extends React.Component {
             </div>
           </div>
         }>
-          {this.state.keySourceName && <p>
+          {this.state.keySourceName && <div>
             {l10n.map.key_import_search_found}
             <ul>
               <li>{l10n.map.key_import_search_found_source} <strong key="1"><a target="_blank" rel="noopener noreferrer" href={keySource.url}>{keySource.label}</a></strong></li>
               <li>{l10n.map.key_import_search_found_modified} <strong key="0">{this.state.keyLastModified.toLocaleDateString()}</strong></li>
             </ul>
-          </p>}
+          </div>}
           <p>{this.state.keys.length > 1 ? l10n.map.key_import_default_description_plural : l10n.map.key_import_default_description}</p>
           {this.state.errors.length > 0 && <Alert header={l10n.map.alert_header_warning} type="danger">{this.state.errors.length > 1 ? l10n.get('key_import_number_of_failed_plural', [this.state.errors.length]) : l10n.map.key_import_number_of_failed}</Alert>}
           <div className="table-responsive" style={{maxHeight: '360px'}}>

--- a/src/app/keyring/components/AdvKeyGenOptions.js
+++ b/src/app/keyring/components/AdvKeyGenOptions.js
@@ -5,6 +5,8 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import moment from 'moment';
+import {addDays, addYears} from 'date-fns';
 import * as l10n from '../../../lib/l10n';
 import {KeyringOptions} from '../KeyringOptions';
 import DatePicker from './DatePicker';
@@ -21,7 +23,11 @@ l10n.register([
 
 export default function AdvKeyGenOptions({value: {keyAlgo, keySize, keyExpirationTime}, onChange, disabled}) {
   const context = React.useContext(KeyringOptions);
-  const handleDateChange = moment => onChange({target: {id: 'keyExpirationTime', value: moment}});
+  const tomorrow = addDays(new Date(), 1);
+  const farFuture = addYears(tomorrow, 80);
+  // TODO #moment-to-data-fns-migration
+  const keyExpirationTimeJsDate = keyExpirationTime ? keyExpirationTime.toDate() : null;
+  const handleDateChange = date => onChange({target: {id: 'keyExpirationTime', value: date && moment(date)}}); // TODO #moment-to-data-fns-migration
   const keyAlgos = [
     <option value="rsa" key={0}>RSA</option>,
     <option value="ecc" key={1}>ECC - Curve25519</option>
@@ -47,7 +53,7 @@ export default function AdvKeyGenOptions({value: {keyAlgo, keySize, keyExpiratio
       </div>
       <div className="form-group key-expiration-group">
         <label htmlFor="keyExpirationTime">{l10n.map.key_gen_expiration}</label>
-        <DatePicker id="keyExpirationTime" value={keyExpirationTime} onChange={handleDateChange} placeholder={l10n.map.keygrid_key_not_expire} minDate={new Date(new Date().getTime() + 24 * 60 * 60 * 1000)} maxDate={new Date(2080, 11, 31)} disabled={disabled} />
+        <DatePicker id="keyExpirationTime" value={keyExpirationTimeJsDate} onChange={handleDateChange} placeholder={l10n.map.keygrid_key_not_expire} minDate={tomorrow} maxDate={farFuture} disabled={disabled} />
       </div>
     </div>
   );

--- a/src/app/keyring/components/AdvKeyGenOptions.js
+++ b/src/app/keyring/components/AdvKeyGenOptions.js
@@ -6,7 +6,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import * as l10n from '../../../lib/l10n';
-import moment from 'moment';
 import {KeyringOptions} from '../KeyringOptions';
 import DatePicker from './DatePicker';
 
@@ -48,7 +47,7 @@ export default function AdvKeyGenOptions({value: {keyAlgo, keySize, keyExpiratio
       </div>
       <div className="form-group key-expiration-group">
         <label htmlFor="keyExpirationTime">{l10n.map.key_gen_expiration}</label>
-        <DatePicker id="keyExpirationTime" value={keyExpirationTime} onChange={handleDateChange} placeholder={l10n.map.keygrid_key_not_expire} minDate={moment().add({days: 1})} maxDate={moment('2080-12-31')} disabled={disabled} />
+        <DatePicker id="keyExpirationTime" value={keyExpirationTime} onChange={handleDateChange} placeholder={l10n.map.keygrid_key_not_expire} minDate={new Date(new Date().getTime() + 24 * 60 * 60 * 1000)} maxDate={new Date(2080, 11, 31)} disabled={disabled} />
       </div>
     </div>
   );

--- a/src/app/keyring/components/AdvKeyGenOptions.js
+++ b/src/app/keyring/components/AdvKeyGenOptions.js
@@ -25,9 +25,8 @@ export default function AdvKeyGenOptions({value: {keyAlgo, keySize, keyExpiratio
   const context = React.useContext(KeyringOptions);
   const tomorrow = addDays(new Date(), 1);
   const farFuture = addYears(tomorrow, 80);
-  // TODO #moment-to-data-fns-migration
   const keyExpirationTimeJsDate = keyExpirationTime ? keyExpirationTime.toDate() : null;
-  const handleDateChange = date => onChange({target: {id: 'keyExpirationTime', value: date && moment(date)}}); // TODO #moment-to-data-fns-migration
+  const handleDateChange = date => onChange({target: {id: 'keyExpirationTime', value: date && moment(date)}});
   const keyAlgos = [
     <option value="rsa" key={0}>RSA</option>,
     <option value="ecc" key={1}>ECC - Curve25519</option>

--- a/src/app/keyring/components/DatePicker.js
+++ b/src/app/keyring/components/DatePicker.js
@@ -5,10 +5,17 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import ReactDatePicker from 'react-datepicker';
+import ReactDatePicker, {registerLocale} from 'react-datepicker';
+import {ar, cs, da, de, es, faIR as fa, fr, he, id, ja, km, lt, ru, tr, uk} from 'date-fns/locale';
 
 import 'react-datepicker/dist/react-datepicker.css';
 import './DatePicker.scss';
+
+const language = navigator.language.substring(0, 2);
+const locales = {ar, cs, da, de, es, fa, fr, he, id, ja, km, lt, ru, tr, uk};
+if (locales[language]) {
+  registerLocale(language, locales[language]);
+}
 
 class CustomInput extends React.Component { // eslint-disable-line react/prefer-stateless-function
   render() {
@@ -47,9 +54,13 @@ export default function DatePicker({value, onChange, placeholder, minDate, maxDa
       forceShowMonthNavigation={false}
       minDate={minDate}
       maxDate={maxDate}
+      locale={language}
+      dateFormat="P"
       dropdownMode="select"
       onChange={onChange}
       placeholderText={placeholder}
+      scrollableYearDropdown
+      startDate={minDate}
       disabled={disabled} />
   );
 }

--- a/src/app/keyring/components/KeyDetails.js
+++ b/src/app/keyring/components/KeyDetails.js
@@ -179,7 +179,7 @@ export default class KeyDetails extends React.Component {
     const selectedKey = this.state.keys[this.state.selectedKeyIdx];
     const tomorrow = addDays(new Date(), 1);
     const farFuture = addYears(tomorrow, 80);
-    const keyExpirationTimeJsDate = this.state.keyExpirationTime ? this.state.keyExpirationTime.toDate() : null; // TODO #moment-to-data-fns-migration
+    const keyExpirationTimeJsDate = this.state.keyExpirationTime ? this.state.keyExpirationTime.toDate() : null;
     return (
       <div className="keyDetails">
         <div className="card card-clean">
@@ -246,7 +246,7 @@ export default class KeyDetails extends React.Component {
         <Modal isOpen={this.state.showExDateModal} toggle={() => this.setState(prevState => ({showExDateModal: !prevState.showExDateModal}))} size="medium" title={l10n.map.keydetails_change_exp_date_dialog_title} hideFooter={true} onHide={this.handleHiddenModal}>
           <>
             <div className="form-group">
-              <DatePicker value={keyExpirationTimeJsDate} onChange={date => this.handleChange({target: {id: 'keyExpirationTime', value: date && moment(date) /* #moment-to-data-fns-migration */}})} placeholder={l10n.map.keygrid_key_not_expire} minDate={tomorrow} maxDate={farFuture} disabled={false} />
+              <DatePicker value={keyExpirationTimeJsDate} onChange={date => this.handleChange({target: {id: 'keyExpirationTime', value: date && moment(date)}})} placeholder={l10n.map.keygrid_key_not_expire} minDate={tomorrow} maxDate={farFuture} disabled={false} />
             </div>
             <Alert type="warning" header={l10n.map.alert_header_warning}>
               {l10n.map.keydetails_change_exp_date_dialog_note}

--- a/src/app/keyring/components/KeyDetails.js
+++ b/src/app/keyring/components/KeyDetails.js
@@ -242,7 +242,7 @@ export default class KeyDetails extends React.Component {
         <Modal isOpen={this.state.showExDateModal} toggle={() => this.setState(prevState => ({showExDateModal: !prevState.showExDateModal}))} size="medium" title={l10n.map.keydetails_change_exp_date_dialog_title} hideFooter={true} onHide={this.handleHiddenModal}>
           <>
             <div className="form-group">
-              <DatePicker value={this.state.keyExpirationTime} onChange={moment => this.handleChange({target: {id: 'keyExpirationTime', value: moment}})} placeholder={l10n.map.keygrid_key_not_expire} minDate={moment().add({days: 1})} maxDate={moment('2080-12-31')} disabled={false} />
+              <DatePicker value={this.state.keyExpirationTime} onChange={moment => this.handleChange({target: {id: 'keyExpirationTime', value: moment}})} placeholder={l10n.map.keygrid_key_not_expire} minDate={new Date(new Date().getTime() + 24 * 60 * 60 * 1000)} maxDate={new Date(2080, 11, 31)} disabled={false} />
             </div>
             <Alert type="warning" header={l10n.map.alert_header_warning}>
               {l10n.map.keydetails_change_exp_date_dialog_note}

--- a/src/app/keyring/components/KeyDetails.js
+++ b/src/app/keyring/components/KeyDetails.js
@@ -5,6 +5,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import {addDays, addYears} from 'date-fns';
 import moment from 'moment';
 import {KeyringOptions} from './../KeyringOptions';
 import {formatFpr} from '../../../lib/util';
@@ -176,6 +177,9 @@ export default class KeyDetails extends React.Component {
 
   render() {
     const selectedKey = this.state.keys[this.state.selectedKeyIdx];
+    const tomorrow = addDays(new Date(), 1);
+    const farFuture = addYears(tomorrow, 80);
+    const keyExpirationTimeJsDate = this.state.keyExpirationTime ? this.state.keyExpirationTime.toDate() : null; // TODO #moment-to-data-fns-migration
     return (
       <div className="keyDetails">
         <div className="card card-clean">
@@ -242,7 +246,7 @@ export default class KeyDetails extends React.Component {
         <Modal isOpen={this.state.showExDateModal} toggle={() => this.setState(prevState => ({showExDateModal: !prevState.showExDateModal}))} size="medium" title={l10n.map.keydetails_change_exp_date_dialog_title} hideFooter={true} onHide={this.handleHiddenModal}>
           <>
             <div className="form-group">
-              <DatePicker value={this.state.keyExpirationTime} onChange={moment => this.handleChange({target: {id: 'keyExpirationTime', value: moment}})} placeholder={l10n.map.keygrid_key_not_expire} minDate={new Date(new Date().getTime() + 24 * 60 * 60 * 1000)} maxDate={new Date(2080, 11, 31)} disabled={false} />
+              <DatePicker value={keyExpirationTimeJsDate} onChange={date => this.handleChange({target: {id: 'keyExpirationTime', value: date && moment(date) /* #moment-to-data-fns-migration */}})} placeholder={l10n.map.keygrid_key_not_expire} minDate={tomorrow} maxDate={farFuture} disabled={false} />
             </div>
             <Alert type="warning" header={l10n.map.alert_header_warning}>
               {l10n.map.keydetails_change_exp_date_dialog_note}

--- a/src/app/settings/Provider.js
+++ b/src/app/settings/Provider.js
@@ -166,7 +166,7 @@ export default class Provider extends React.Component {
 
   async loadWatchList() {
     const watchList = await port.send('getWatchList');
-    this.setState({watchList});
+    return new Promise(resolve => this.setState({watchList}, resolve));
   }
 
   async removeAuthorisation(email) {


### PR DESCRIPTION
During the upgrade process the following problems came up:
- the new version of `react-datepicker` uses the `date-fns` instead of the moment library for date/time functionality.
- new version uses different mechanism for i18n

In this PR we 
* migrated to `react-datepicker` v4.20 in `DatePicker` component
* made `DatePicker` consume and return `Date` instead of `moment` objects 
* adjusted parent components to convert date to and from `moment` when passing it to/from `DatePicker`.
* implemented new i8n for underlying `react-datepicker`

Closes 9Tctd3vw, 9of4k6iz