### PR TITLE
Gmail ExtractFrame: scroll bar hides close button

### DIFF
--- a/src/content-scripts/attachmentFrame.js
+++ b/src/content-scripts/attachmentFrame.js
@@ -36,7 +36,7 @@ export default class AttachmentFrame extends ExtractFrame {
     }
     this.pgpElement.style.display = 'inline-block';
     // let the element to take as much as it wants if there is a message text, like in `decryptFrame`
-    // but limit it in case it is empty; we then do simillar for the height in `#setFrameDim()`
+    // but set min height when empty; we then do simillar for the height in `setFrameDim()`
     this.pgpElement.style['min-height'] = '400px';
     // set status to attached
     this.pgpElement.dataset[FRAME_STATUS] = FRAME_ATTACHED;

--- a/src/content-scripts/attachmentFrame.js
+++ b/src/content-scripts/attachmentFrame.js
@@ -36,7 +36,7 @@ export default class AttachmentFrame extends ExtractFrame {
     }
     this.pgpElement.style.display = 'inline-block';
     // let the element to take as much as it wants if there is a message text, like in `decryptFrame`
-    // but set min height when empty; we then do simillar for the height in `setFrameDim()`
+    // but set min height when empty; we then do similar for the height in `setFrameDim()`
     this.pgpElement.style['min-height'] = '400px';
     // set status to attached
     this.pgpElement.dataset[FRAME_STATUS] = FRAME_ATTACHED;

--- a/src/content-scripts/attachmentFrame.js
+++ b/src/content-scripts/attachmentFrame.js
@@ -35,6 +35,9 @@ export default class AttachmentFrame extends ExtractFrame {
       this.pgpElement.classList.add('m-extract-wrapper');
     }
     this.pgpElement.style.display = 'inline-block';
+    // let the element to take as much as it wants if there is a message text, like in `decryptFrame`
+    // but limit it in case it is empty; we then do simillar for the height in `#setFrameDim()`
+    this.pgpElement.style['min-height'] = '400px';
     // set status to attached
     this.pgpElement.dataset[FRAME_STATUS] = FRAME_ATTACHED;
     this.pgpRange.append(this.pgpElement);
@@ -113,15 +116,14 @@ export default class AttachmentFrame extends ExtractFrame {
   }
 
   setFrameDim() {
+    let {width, height} = this.pgpElement.getBoundingClientRect();
     if (this.dDialog === null) {
-      const width = 500;
-      const height = 400;
-      this.pgpElement.style.width = `${width}px`;
-      this.pgpElement.style.height = `${height}px`;
+      if (!width) { // if no message contents
+        width = 500;
+      }
       this.eFrame.style.width = `${width}px`;
       this.eFrame.style.height = `${height}px`;
     } else {
-      const {height} = this.pgpRange.getBoundingClientRect();
       let {width} = this.pgpElement.parentElement.getBoundingClientRect();
       // less 1px border and 2 pixel box-shadow
       width -= 3;


### PR DESCRIPTION
In the top right corner of a extract frame we display a close button. In some cases this close button is hidden by vertical scrollbars on the right side. This was not there before and looks like a style change in Gmail.

## To reproduce:
- PGP/MIME message or a message that has text content and manually a .asc file attachment
- Gmail API is active

The fix also tries to mimic the default behavior of `decryptFrame` where when in popup mode, the overlay stretches to the whole width of the message instead of fixing width and height.