### PR TITLE
Sending attachments not working when sign only

### DIFF
--- a/src/controller/editor.controller.js
+++ b/src/controller/editor.controller.js
@@ -536,7 +536,8 @@ export default class EditorController extends sub.SubController {
         data: options.message,
         signKeyFpr: this.signKeyFpr
       });
-      return {armored};
+      // we do not sign attachments
+      return {armored, encFiles: options.attachments};
     }
   }
 


### PR DESCRIPTION
Mail provider: Gmail
Browser: any
OS: any

### Description 
Message sent including attachment and while using the Sign Only option, the message is sent but without the attachment.

### Notes
This PR only adds passing attachments through, but not signing them, only clear text is signed. 

Closes #776 