### PR TITLE
Detect port in domain auth dialog

### DIFF
--- a/src/controller/authDomain.controller.js
+++ b/src/controller/authDomain.controller.js
@@ -50,12 +50,14 @@ export default class AuthDomainController extends sub.SubController {
   }
 
   onInitPopup() {
-    this.emit('set-frame', {hostname: this.options.hostname, urlPattern: `${this.options.protocol}//*.${this.options.hostname}`, api: this.options.api});
+    const port = this.options.port ? `:${this.options.port}` : '';
+    this.emit('set-frame', {hostname: this.options.hostname, urlPattern: `${this.options.protocol}//*.${this.options.hostname}${port}`, api: this.options.api});
   }
 
   async onOk() {
     const authDomainList = await getWatchList();
-    await setWatchList([...authDomainList, {site: this.options.hostname, active: true, https_only: this.options.protocol === 'https:' ? true : false, frames: [{scan: true, frame: `*.${this.options.hostname}`, api: this.options.api}]}]);
+    const port = this.options.port ? `:${this.options.port}` : '';
+    await setWatchList([...authDomainList, {site: `${this.options.hostname}${port}`, active: true, https_only: this.options.protocol === 'https:' ? true : false, frames: [{scan: true, frame: `*.${this.options.hostname}${port}`, api: this.options.api}]}]);
     await initScriptInjection();
     this.closePopup();
   }

--- a/src/lib/inject.js
+++ b/src/lib/inject.js
@@ -126,9 +126,10 @@ async function authRequest({tabId, url}) {
   const targetUrl = new URL(tab.url);
   let hostname = targetUrl.hostname;
   const protocol = targetUrl.protocol;
+  const port = targetUrl.port;
   if (hostname.startsWith('www.')) {
     hostname = hostname.slice(4);
   }
   const authDomainCtrl = sub.factory.get('authDomainDialog');
-  authDomainCtrl.authorizeDomain({hostname, protocol, api, tabId, url: tab.url});
+  authDomainCtrl.authorizeDomain({hostname, port, protocol, api, tabId, url: tab.url});
 }


### PR DESCRIPTION
### Current behavior
Context: Roundcube instance on non-default port: `http://localhost:8000`.
1. Trigger authorize domain dialog from Roundcube settings.
2. Dialog asks to authorize domain `*.localhost`
3. Click Confirm
4. Reload Roundcube
5. Roundcube doesn't see Mailvelope

### Expected behavior
2. Dialog asks to authorize domain `*.localhost:8000`
...
5. Roundcube sees Mailvelope

### Additional info
The domain auth process detects url of the tab from which it was triggered but doesn't consider port. 
Since we'd like to improve this process for the "Authorize this domain" button too, perhaps it make sense to modify "AuthDomainController#authorize" method to expect port.