### PR TITLE
Detect port on "Auth this domain" button

### DIFF
--- a/src/app/settings/WatchList.js
+++ b/src/app/settings/WatchList.js
@@ -158,12 +158,12 @@ export default class WatchList extends React.Component {
     if (domain.startsWith('www.')) {
       domain = domain.slice(4);
     }
-    const hostPort = `${domain}${port ? `:${port}` : ''}`;
+    const hostAndPort = `${domain}${port ? `:${port}` : ''}`;
     this.setState(prevState => {
       let watchListIndex;
       const site = prevState.watchList.find((site, index) => {
         watchListIndex = index;
-        return site.site === hostPort;
+        return site.site === hostAndPort;
       });
       if (site) {
         return {
@@ -174,7 +174,7 @@ export default class WatchList extends React.Component {
         };
       } else {
         return {
-          editorSite: {site: hostPort, active: true, https_only: protocol === 'https' ? true : false, frames: [{scan: true, frame: `*.${hostPort}`, api: false}]},
+          editorSite: {site: hostAndPort, active: true, https_only: protocol === 'https' ? true : false, frames: [{scan: true, frame: `*.${hostAndPort}`, api: false}]},
           editorIndex: prevState.watchList.length,
           modified: true,
           showEditor: true

--- a/src/app/settings/WatchList.js
+++ b/src/app/settings/WatchList.js
@@ -154,15 +154,16 @@ export default class WatchList extends React.Component {
     this.modifyEditorSite(site => site.frames.splice(index, 1));
   }
 
-  addToWatchList({domain, protocol}) {
+  addToWatchList({domain, protocol, port}) {
     if (domain.startsWith('www.')) {
       domain = domain.slice(4);
     }
+    const hostPort = `${domain}${port ? `:${port}` : ''}`;
     this.setState(prevState => {
       let watchListIndex;
       const site = prevState.watchList.find((site, index) => {
         watchListIndex = index;
-        return site.site === domain;
+        return site.site === hostPort;
       });
       if (site) {
         return {
@@ -173,7 +174,7 @@ export default class WatchList extends React.Component {
         };
       } else {
         return {
-          editorSite: {site: domain, active: true, https_only: protocol === 'https' ? true : false, frames: [{scan: true, frame: `*.${domain}`, api: false}]},
+          editorSite: {site: hostPort, active: true, https_only: protocol === 'https' ? true : false, frames: [{scan: true, frame: `*.${hostPort}`, api: false}]},
           editorIndex: prevState.watchList.length,
           modified: true,
           showEditor: true

--- a/src/controller/menu.controller.js
+++ b/src/controller/menu.controller.js
@@ -77,10 +77,10 @@ export default class MenuController extends sub.SubController {
       if (!tab) {
         throw new Error('No tab found');
       }
-      const domain = mvelo.util.getDomain(tab.url);
-      const protocol = mvelo.util.getProtocol(tab.url);
+      const url = new URL(tab.url);
+      const domain = mvelo.util.normalizeDomain(url.hostname);
       const slotId = getUUID();
-      sub.setAppDataSlot(slotId, {domain, protocol});
+      sub.setAppDataSlot(slotId, {domain, protocol: url.protocol, port: url.port});
       mvelo.tabs.loadAppTab(`?slotId=${slotId}#/settings/watchlist/push`);
     });
   }

--- a/src/lib/inject.js
+++ b/src/lib/inject.js
@@ -49,7 +49,7 @@ async function getWatchListFilterURLs() {
     });
   });
   // add hkp key server to enable key import
-  let hkpHost = mvelo.util.getDomain(prefs.keyserver.hkp_base_url);
+  let hkpHost = mvelo.util.normalizeDomain(new URL(prefs.keyserver.hkp_base_url).hostname);
   hkpHost = reduceHosts([hkpHost]);
   hkpHost.forEach(host => {
     // add default schemes to key server hosts

--- a/src/lib/lib-mvelo.js
+++ b/src/lib/lib-mvelo.js
@@ -154,20 +154,7 @@ mvelo.util.text2autoLinkHtml = function(text) {
   return mvelo.util.sanitizeHTML(autoLink(text, {defaultProtocol: 'https', escapeFn: encodeHTML}));
 };
 
-mvelo.util.getHostname = function(url) {
-  const a = document.createElement('a');
-  a.href = url;
-  return a.hostname;
-};
-
-mvelo.util.getProtocol = function(url) {
-  const a = document.createElement('a');
-  a.href = url;
-  return a.protocol.replace(/:/g, '');
-};
-
-mvelo.util.getDomain = function(url) {
-  const hostname = mvelo.util.getHostname(url);
+mvelo.util.normalizeDomain = function(hostname) {
   // limit to 3 labels per domain
   return hostname.split('.').slice(-3).join('.');
 };


### PR DESCRIPTION
### Current behavior
Context: Roundcube instance on non-default port: `http://localhost:8000`.
1. Open Mailvelope popup and click "Authorize this domain"
2. Dialog is prefilled with `*.localhost` wildcard
3. Click Confirm
4. Reload Roundcube
5. Roundcube doesn't see Mailvelope

### Expected behavior
2. Dialog is prefilled with `*.localhost:8000` wildcard
...
5. Roundcube sees Mailvelope

Closes #734 