### PR TITLE
Experimental TypeScript Support

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -11,15 +11,17 @@ module.exports = function(grunt) {
     eslint: {
       options: {
         maxWarnings: 1,
-        overrideConfigFile: 'config/eslint.json',
+        overrideConfigFile: 'config/eslint.jsonc',
         cache: true,
         fix: grunt.option('fix'),
         reportUnusedDisableDirectives: 'warn'
       },
       target: [
         '*.js',
+        '*.ts',
         'config/*.js',
         'src/**/*.js',
+        'src/**/*.ts',
         '!src/modules/closure-library/**/*.js',
         'test/**/*.js'
       ]

--- a/config/eslint.jsonc
+++ b/config/eslint.jsonc
@@ -1,5 +1,5 @@
 {
-
+  "$schema": "https://json.schemastore.org/eslintrc.json",
   "parserOptions": {
     "ecmaVersion": 2021,
     "sourceType": "module",
@@ -84,6 +84,22 @@
     "prefer-template": 1, // require template literals instead of string concatenation
     "template-curly-spacing": ["warn", "never"], // require or disallow spacing around embedded expressions of template strings
     "no-template-curly-in-string": "warn"
-  }
+  },
 
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx"],
+      "parser": "@typescript-eslint/parser",
+      "plugins": ["@typescript-eslint"],
+      "extends": ["plugin:@typescript-eslint/recommended"],
+      "rules": {
+        "@typescript-eslint/no-explicit-any": "warn",
+        "@typescript-eslint/no-namespace": "error",
+        "@typescript-eslint/no-empty-interface": "error",
+        // "@typescript-eslint/no-restricted-types": [], // see https://typescript-eslint.io/rules/no-restricted-types        
+        "@typescript-eslint/no-redeclare": "error",
+        "indent": ["warn", 2, {"MemberExpression": 0, "SwitchCase": 1}] // enforce consistent indentation
+      }
+    }
+  ]
 }

--- a/config/eslint.jsonc
+++ b/config/eslint.jsonc
@@ -96,9 +96,14 @@
         "@typescript-eslint/no-explicit-any": "warn",
         "@typescript-eslint/no-namespace": "error",
         "@typescript-eslint/no-empty-interface": "error",
-        // "@typescript-eslint/no-restricted-types": [], // see https://typescript-eslint.io/rules/no-restricted-types        
         "@typescript-eslint/no-redeclare": "error",
-        "indent": ["warn", 2, {"MemberExpression": 0, "SwitchCase": 1}] // enforce consistent indentation
+        "no-restricted-syntax": [
+          "error",
+          {
+            "selector": "TSTypeParameterInstantiation", // AST query
+            "message": "Generics are not allowed."
+          }
+        ]
       }
     }
   ]

--- a/config/tsconfig.json
+++ b/config/tsconfig.json
@@ -1,0 +1,31 @@
+{
+    "extends": "@tsconfig/recommended/tsconfig.json",
+    "compilerOptions": {
+        "module": "ES6",
+        "moduleResolution": "Bundler",
+        "sourceMap": true,
+        "strict": false,
+        // Tells TypeScript to read JS files, as
+        // normally they are ignored as source files
+        "allowJs": true,
+        // // Generate d.ts files
+        // "declaration": true,
+        // // This compiler run should
+        // // only output d.ts files
+        // "emitDeclarationOnly": true,
+        // // Types should go into this directory.
+        // // Removing this would place the .d.ts files
+        // // next to the .js files
+        "outDir": "../dist",
+        // // go to js file when using IDE functions like
+        // // "Go to Definition" in VSCode
+        // "declarationMap": true
+    },
+    "include": [
+        "../src/**/*.ts",
+        "../src/**/*.js"
+    ],
+    "exclude": [
+        "node_modules"
+    ]
+}

--- a/config/tsconfig.json
+++ b/config/tsconfig.json
@@ -2,30 +2,26 @@
     "extends": "@tsconfig/recommended/tsconfig.json",
     "compilerOptions": {
         "module": "ES6",
-        "moduleResolution": "Bundler",
+        "moduleResolution": "bundler",
         "sourceMap": true,
         "strict": false,
         // Tells TypeScript to read JS files, as
         // normally they are ignored as source files
         "allowJs": true,
+
+        /** This block is responsible for generating d.ts files 
+        * We are keeping it commented until needed */
         // // Generate d.ts files
-        // "declaration": true,
-        // // This compiler run should
+        // "declaration": true,        
         // // only output d.ts files
         // "emitDeclarationOnly": true,
-        // // Types should go into this directory.
-        // // Removing this would place the .d.ts files
-        // // next to the .js files
-        "outDir": "../dist",
         // // go to js file when using IDE functions like
         // // "Go to Definition" in VSCode
         // "declarationMap": true
+
+        // a workaround for "cannot write file ..." tsc errors
+        "outDir": "../dist",
     },
-    "include": [
-        "../src/**/*.ts",
-        "../src/**/*.js"
-    ],
-    "exclude": [
-        "node_modules"
-    ]
+    "include": ["../src/**/*.ts"],
+    "exclude": ["node_modules"]
 }

--- a/config/webpack.background.js
+++ b/config/webpack.background.js
@@ -13,6 +13,7 @@ const output = {
 };
 const resolve = {
   modules: ['node_modules'],
+  extensions: ['.ts', '.tsx', '.js'],
   alias: {
     'text-encoding': path.resolve('./src/lib/string-encoding'),
     'openpgp': path.resolve('./node_modules/openpgp/dist/openpgp.mjs')
@@ -25,7 +26,10 @@ const prod = {
   output,
   resolve,
   module: {
-    rules: [...common.module.replaceVersion(/defaults\.json$/, pjson.version)],
+    rules: [
+      ...common.module.replaceVersion(/defaults\.json$/, pjson.version),
+      ...common.module.typescript()
+    ],
     noParse: /openpgp\.js$/
   }
 };
@@ -35,7 +39,10 @@ const dev = {
   mode: 'development',
   devtool: 'inline-cheap-module-source-map',
   module: {
-    rules: [...common.module.replaceVersion(/defaults\.json$/, `${pjson.version} build: ${(new Date()).toISOString().slice(0, 19)}`)],
+    rules: [
+      ...common.module.replaceVersion(/defaults\.json$/, `${pjson.version} build: ${(new Date()).toISOString().slice(0, 19)}`),
+      ...common.module.typescript()
+    ],
     noParse: /openpgp\.js$/
   }
 };

--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -99,6 +99,21 @@ function react() {
   ];
 }
 
+function typescript() {
+  return  [
+    {
+      test: /\.tsx?$/,
+      use: {
+        loader: 'ts-loader',
+        options: {
+          configFile: 'config/tsconfig.json'
+        },
+      },
+      exclude: /node_modules/
+    }
+  ];
+}
+
 function replaceVersion(test, version) {
   return [
     {
@@ -119,9 +134,10 @@ function replaceVersion(test, version) {
 function resolve() {
   return {
     modules: ['node_modules'],
+    extensions: ['.ts', '.tsx', '.js']
   };
 }
 
 exports.prod = prod;
-exports.module = {css, css2str, scss, react, replaceVersion};
+exports.module = {css, css2str, scss, react, typescript, replaceVersion};
 exports.resolve = resolve;

--- a/package.json
+++ b/package.json
@@ -43,6 +43,9 @@
   "devDependencies": {
     "@babel/core": "^7.24.7",
     "@babel/preset-react": "^7.24.7",
+    "@tsconfig/recommended": "^1.0.7",
+    "@typescript-eslint/eslint-plugin": "^8.5.0",
+    "@typescript-eslint/parser": "^8.5.0",
     "angular-mocks": "1.8.3",
     "babel-loader": "^9.1.3",
     "babel-plugin-rewire": "^1.2.0",
@@ -81,6 +84,7 @@
     "sinon": "^18.0.0",
     "string-replace-loader": "^3.1.0",
     "style-loader": "^4.0.0",
+    "ts-loader": "^9.5.1",
     "web-ext": "^8.2.0",
     "webpack": "^5.93.0",
     "webpack-cli": "^5.1.4"

--- a/src/controller/encrypt.controller.ts
+++ b/src/controller/encrypt.controller.ts
@@ -9,9 +9,14 @@
  */
 
 import * as sub from './sub.controller';
+import type EditorController from './editor.controller';
 
 export default class EncryptController extends sub.SubController {
-  constructor(port) {
+  editorControl: EditorController;
+
+  editorContentModified: boolean;
+
+  constructor(port: any) {
     super(port);
     this.editorControl = null;
     this.editorContentModified = false;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,3 @@
+{
+    "extends": "./config/tsconfig.json",
+}


### PR DESCRIPTION
We want to consider using TypeScript for larger new projects like Outlook API integration.

This PR adds gradual Typescript support without strict checks and requirements for `.d.ts` files. 

It also contains an experimental tentative convertion of `encrypt.controller.js` to ``encrypt.controller.ts` to proove the setup can successfuly yield typescript code into bundles. 

This is a Draft and is going to stay so until evaluated if and how we'd like to continue:
1. Shall we keep `strict: false`
2. Shall we generate `d.ts` declarations for files that interact with fresh typescript

The setup is functional in a way that it produces a build that works, encryption functinality seem to be uneffected. 