### PR TITLE
Bootstrap update breaks recipient input

### DIFF
--- a/src/components/editor/components/RecipientInput.js
+++ b/src/components/editor/components/RecipientInput.js
@@ -161,7 +161,7 @@ export function RecipientInput({extraKey, hideErrorMsg, keys, recipients, onChan
   }));
 
   return (
-    <div id={idRef.current} className="input-group mb-0 d-block">
+    <div id={idRef.current} className="mb-0">
       <ReactTags
         tags={tags}
         suggestions={suggestions}


### PR DESCRIPTION
This is a fix for a regression after update to Bootstrap 4.6.2 causing issues to the RecipientInput