### PR TITLE
Fix send button state and CC field empty on Reply All 

### DIFF
--- a/src/components/editor/editor.js
+++ b/src/components/editor/editor.js
@@ -402,12 +402,18 @@ export default class Editor extends React.Component {
    * Compute whether the encrypt button should be disabled.
    */
   isEncryptDisabled() {
-    const {plainText, recipients, recipientsError, recipientsCcError, extraKey, extraKeysError} = this.state;
+    const {plainText, recipients, recipientsError, recipientsCcError, extraKey, extraKeys, extraKeysError} = this.state;
+    // If extraKey is checked, require at least one valid extra key and no error
+    if (extraKey) {
+      return !plainText
+        || !extraKeys.length
+        || extraKeysError;
+    }
+    // Otherwise, use the original logic for main recipients
     return !plainText
-      || (recipientsError && !extraKey)
+      || recipientsError
       || !recipients.length
-      || recipientsCcError
-      || (extraKey && extraKeysError);
+      || recipientsCcError;
   }
 
   handleChangeRecipients(recipients, recipientsError) {

--- a/src/controller/editor.controller.js
+++ b/src/controller/editor.controller.js
@@ -153,7 +153,6 @@ export default class EditorController extends SubController {
         // No local key found, mark it for resolution
         checkServer = true;
       }
-      // Safely return fingerprint only if key is found
       return {key, fingerprint: key ? key.fingerprint : undefined, checkServer};
     }
 

--- a/src/controller/editor.controller.js
+++ b/src/controller/editor.controller.js
@@ -153,7 +153,8 @@ export default class EditorController extends SubController {
         // No local key found, mark it for resolution
         checkServer = true;
       }
-      return {key, fingerprint: key.fingerprint, checkServer};
+      // Safely return fingerprint only if key is found
+      return {key, fingerprint: key ? key.fingerprint : undefined, checkServer};
     }
 
     let to = [];


### PR DESCRIPTION
- Ensure the send button only enables with a valid alternative key selection
- Reply all securly fills all recipients correctly, even if not present in keyring