### PR TITLE
Prepend encrypted subject line to messages

### DIFF
--- a/src/lib/mail-reader.js
+++ b/src/lib/mail-reader.js
@@ -36,7 +36,7 @@ export function parse(bodyParts) {
 }
 
 // functions that return true/false if they were able to handle a certain kind of body part
-const mimeTreeMatchers = [matchEncrypted, matchSigned, matchAttachment, matchText, matchHtml];
+const mimeTreeMatchers = [matchSubject, matchEncrypted, matchSigned, matchAttachment, matchText, matchHtml];
 
 // do a depth-first traversal of the body part, check for each node if it matches
 // a certain type, then poke into its child nodes. not a pure inorder traversal b/c
@@ -58,6 +58,18 @@ function walkMimeTree(mimeNode, bodyPart) {
       walkMimeTree(childNode, bodyPart);
     });
   }
+}
+
+/**
+ * Matches the Subject header and sets it on the bodyPart
+ */
+function matchSubject(node, bodyPart) {
+  const subject = node.headers?.subject?.[0]?.value;
+  if (!subject) {
+    return false;
+  }
+  bodyPart.subject = subject;
+  return false; // don't stop the traversal, we want to check for other nodes
 }
 
 /**

--- a/src/lib/mail-reader.js
+++ b/src/lib/mail-reader.js
@@ -61,13 +61,14 @@ function walkMimeTree(mimeNode, bodyPart) {
 }
 
 /**
- * Matches the Subject header and sets it on the bodyPart
+ * Matches the Subject header and sets it on the bodyPart only if Content-Type `protected-headers` is = "v1"
  */
 function matchSubject(node, bodyPart) {
   const subject = node.headers?.subject?.[0]?.value;
-  if (!subject) {
+  const protectedHeaders = node.headers?.['content-type']?.[0]?.params?.['protected-headers'];
+  if (!subject || protectedHeaders !== 'v1') {
     return false;
-  }
+  }  
   bodyPart.subject = subject;
   return false; // don't stop the traversal, we want to check for other nodes
 }

--- a/src/lib/mail-reader.js
+++ b/src/lib/mail-reader.js
@@ -68,7 +68,7 @@ function matchSubject(node, bodyPart) {
   const protectedHeaders = node.headers?.['content-type']?.[0]?.params?.['protected-headers'];
   if (!subject || protectedHeaders !== 'v1') {
     return false;
-  }  
+  }
   bodyPart.subject = subject;
   return false; // don't stop the traversal, we want to check for other nodes
 }

--- a/src/modules/mime.js
+++ b/src/modules/mime.js
@@ -58,10 +58,10 @@ async function parseMIME(raw, encoding) {
     }
 
     // prepend subject line using i18n label
-    const subject = encodeHTML(parsed[0]?.subject);
+    const subject = parsed[0].subject;
     if (subject) {
       const subjectLabel = l10n.get('editor_label_subject');
-      message = `<strong>${subjectLabel}: </strong>${subject}\n<hr>\n${message}`;
+      message = `<strong>${subjectLabel}: </strong>${encodeHTML(subject)}\n<hr>\n${message}`;
     }
   }
   return {message, attachments, parsed};

--- a/src/modules/mime.js
+++ b/src/modules/mime.js
@@ -3,10 +3,11 @@
  * Licensed under the GNU Affero General Public License version 3
  */
 
-import mvelo from '../lib/lib-mvelo';
-import {html2text, encodeHTML, ab2str, byteCount, MvError, getUUID} from '../lib/util';
-import * as mailreader from '../lib/mail-reader';
 import MimeBuilder from 'emailjs-mime-builder';
+import * as l10n from '../lib/l10n';
+import mvelo from '../lib/lib-mvelo';
+import * as mailreader from '../lib/mail-reader';
+import {ab2str, byteCount, encodeHTML, getUUID, html2text, MvError} from '../lib/util';
 
 /**
  * Parse encrypted email content. Input content can be in MIME format or plain text.
@@ -54,6 +55,13 @@ async function parseMIME(raw, encoding) {
     for (const part of attachments) {
       part.filename = encodeHTML(part.filename);
       part.content = ab2str(part.content.buffer);
+    }
+
+    // prepend subject line using i18n label
+    const subject = encodeHTML(parsed[0]?.subject);
+    if (subject) {
+      const subjectLabel = l10n.get('editor_label_subject');
+      message = `<strong>${subjectLabel}: </strong>${subject}\n<hr>\n${message}`;
     }
   }
   return {message, attachments, parsed};


### PR DESCRIPTION
Add functionality to prepend the encrypted subject line to the message. 
It alignes with [Thunderbird's](https://searchfox.org/comm-central/source/mail/extensions/openpgp/content/modules/mime.sys.mjs#203) and [Thunderbird for Android (k9)](https://github.com/thunderbird/thunderbird-android/blob/main/legacy/core/src/main/java/com/fsck/k9/mailstore/MessageViewInfoExtractor.java#L105) implementations.