### PR TITLE
Migrate to dart-sass

### DIFF
--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -1,6 +1,6 @@
 /* eslint strict: 0 */
 
-const jsonImporter  = require('node-sass-json-importer');
+import jsonImporter from '@blakedarlin/sass-json-importer';
 
 const prod = {
   mode: 'production',
@@ -57,7 +57,7 @@ function scss(loader = 'style-loader', css = false) {
         // Apply the JSON importer via sass-loader's options.
         options: {
           sassOptions: {
-            importer: jsonImporter()
+            importers: [jsonImporter()]
           }
         }
       }]
@@ -122,6 +122,5 @@ function resolve() {
   };
 }
 
-exports.prod = prod;
-exports.module = {css, css2str, scss, react, replaceVersion};
-exports.resolve = resolve;
+export {prod, resolve};
+export const module = {css, css2str, scss, react, replaceVersion};

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "license": "AGPL",
   "readmeFilename": "Readme.md",
   "dependencies": {
+    "@blakedarlin/sass-json-importer": "^1.1.0",
     "@openpgp/web-stream-tools": "0.1.3",
     "autocrypt": "0.10.0",
     "bootstrap": "4.6.2",
@@ -72,8 +73,7 @@
     "karma-webpack": "^5.0.1",
     "mini-css-extract-plugin": "^2.9.2",
     "mocha": "^11.2.2",
-    "node-sass": "^9.0.0",
-    "node-sass-json-importer": "^4.3.0",
+    "sass": "^1.88.0",
     "sass-loader": "^16.0.5",
     "sinon": "^20.0.0",
     "string-replace-loader": "^3.1.0",

--- a/src/res/styles/_mixins.scss
+++ b/src/res/styles/_mixins.scss
@@ -15,10 +15,10 @@
     @if $color == primary {
       $disabled-opacity: $btn-primary-disabled-opacity;
     }
-    color: scale-color(color-yiq($background), $lightness: ((1 - $disabled-opacity) * 100));
-    background-color: scale-color($background, $lightness: ((1 - $disabled-opacity) * 100));
-    border-color: scale-color($border-color, $lightness: ((1 - $disabled-opacity) * 100));
-    @include box-shadow(inset 0 -1px 0 scale-color($border-color, $lightness: ((1 - $disabled-opacity) * 100)));
+    color: scale-color(color-yiq($background), $lightness: ((1 - $disabled-opacity) * 100%));
+    background-color: scale-color($background, $lightness: ((1 - $disabled-opacity) * 100%));
+    border-color: scale-color($border-color, $lightness: ((1 - $disabled-opacity) * 100%));
+    @include box-shadow(inset 0 -1px 0 scale-color($border-color, $lightness: ((1 - $disabled-opacity) * 100%)));
   }
 
   &:not(:disabled):not(.disabled):active,


### PR DESCRIPTION
* Use `@blakedarlin/sass-json-importer` instead of `node-sass-json-importer`
* Fixed deprecation errors in `_mixins.scss`
* Because `@blakedarlin/sass-json-importer` has ESM export, convert `webpack.common.js` to ESM. This was the easiest solution, otherwise webpack produced an error.

The only place we use json import is `src\app\settings\SecurityBackground.scss`, which is used in settings only. I tested it, it works. So, we should not expect any other side effects from migrating to `@blakedarlin/sass-json-importer`. 

Not sure about Dart Sass itself, but I did some smoke testing, looks ok. 