### PR TITLE
Fix: Normalize armored text in API decrypt to handle text before PGP message block

### DIFF
--- a/src/controller/decrypt.controller.js
+++ b/src/controller/decrypt.controller.js
@@ -5,7 +5,7 @@
 
 import mvelo from '../lib/lib-mvelo';
 import * as l10n from '../lib/l10n';
-import {getUUID, mapError} from '../lib/util';
+import {getUUID, mapError, normalizeArmored} from '../lib/util';
 import {DISPLAY_INLINE} from '../lib/constants';
 import {prefs} from '../modules/prefs';
 import {getKeyringWithPrivKey} from '../modules/keyring';
@@ -91,7 +91,13 @@ export default class DecryptController extends SubController {
     if (msg.keyringId ?? msg.allKeyrings) {
       this.keyringId = msg.keyringId;
     }
-    this.armored = msg.data;
+    // Normalize armored text to handle cases where PGP message block is not at the beginning
+    try {
+      this.armored = normalizeArmored(msg.data, /-----BEGIN PGP MESSAGE-----[\s\S]+?-----END PGP MESSAGE-----/);
+    } catch (error) {
+      // If normalization fails, fall back to original data
+      this.armored = msg.data;
+    }
     this.decryptReady.resolve();
     if (this.reconnect) {
       return;


### PR DESCRIPTION
## Issue Description
Fixes the "Unknown ASCII Armor Error" that occurs when using Roundcube webmail with Mailvelope API integration enabled. The error happens when encrypted emails contain explanatory text before the `-----BEGIN PGP MESSAGE-----` line, which is common in PGP/MIME messages.

## Root Cause
The API integration passes raw armored text directly to OpenPGP.js without normalization, while the manual decryption interface uses `normalizeArmored()` to extract the PGP message block.

## Solution
- Adds `normalizeArmored()` call in `onSetArmored()` method with regex to extract PGP message block
- Includes graceful fallback to original data if normalization fails
- Maintains compatibility with existing functionality

## Testing
- Tested with Chrome extension in Roundcube with API integration
- Successfully decrypts emails that previously failed with "Unknown ASCII Armor Error"
- Maintains compatibility with emails that work without the fix

## Technical Details
- Only modifies `src/controller/decrypt.controller.js`
- Uses existing `normalizeArmored` utility function
- Same pattern used in manual decryption interface (`src/app/decrypt/Decrypt.js`)
- Cross-browser compatible (Chrome/Firefox)

Fixes #865 and https://github.com/roundcube/roundcubemail/issues/9793