### PR TITLE
Fix Gmail content script injection startup race

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -26,9 +26,9 @@ async function main() {
   initBrowserRuntime();
   initController();
   initAuthRequestApi();
-  initScriptInjection();
   initAnalytics();
   await initModel();
+  await initScriptInjection();
   await initKeyring();
 }
 

--- a/src/lib/inject.js
+++ b/src/lib/inject.js
@@ -46,8 +46,8 @@ async function getWatchListFilterURLs() {
   } else {
     watchList = await getWatchListCache();
   }
-  if (!watchList) {
-    window?.location.reload();
+  if (!Array.isArray(watchList) || watchList.length === 0) {
+    return [];
   }
   const schemes = ['http', 'https'];
   let result = [];


### PR DESCRIPTION
Fixes #908

Initialize script injection after model init so the watch list is available.
If the watch list is missing/empty, skip injection setup instead of trying to reload from the service worker.