### PR TITLE
USB keystore for more secure handling of public and private keys

### DIFF
--- a/doc/usb-keystore-plan.md
+++ b/doc/usb-keystore-plan.md
@@ -1,0 +1,597 @@
+# USB-Resident Keystore — Implementation Plan
+
+Branch: `feature/usb-keystore`
+
+## 1. Goal
+
+Mailvelope should be able to keep **all** OpenPGP key material on a removable USB device:
+
+1. Detect whether the USB keystore device is present and whether the files it needs are readable/writable.
+2. When the device becomes unavailable, say so clearly and stop all crypto operations.
+3. Store **no** crypto information anywhere except the USB device.
+4. When no USB keystore is configured, offer an option to add one.
+
+### Constraint: the branch must track upstream `master`
+
+Changes are kept **minimal and additive**, with all logic in new files and existing files
+touched only at small hook points. Diff footprint is treated as a first-class design criterion,
+not a tidiness preference — see §4 and §7. As built, the footprint is +31/-2 lines across
+11 files, all additive.
+
+### Priority ordering
+
+Keeping key material — **especially private keys** — off the laptop/desktop outranks key
+durability. **If the USB device is lost, losing the keys with it is an acceptable outcome.**
+
+This is not a neutral trade-off to be balanced later; it decides every design question below.
+No local copy, no remote copy, no backup stick. Where a choice exists between "less residue on
+the machine" and "less chance of losing keys", the former always wins.
+
+## 2. Platform constraints (this shapes everything)
+
+A browser extension cannot open an arbitrary filesystem path such as `/media/usb0`. The
+options available to an MV3 extension are:
+
+| Mechanism | Read | Write | Chrome | Firefox | Verdict |
+|---|---|---|---|---|---|
+| **File System Access API** (`showDirectoryPicker`) | yes | yes | yes (86+) | **no** | Primary backend |
+| **Native messaging host** | yes | yes | yes | yes | Secondary backend (required for Firefox) |
+| `<input type="file" webkitdirectory>` | yes | **no** | yes | yes | Insufficient — no writes |
+| **WebUSB** (`navigator.usb`) | — | — | yes | no | Rejected: the OS kernel claims mass-storage devices, so WebUSB cannot see or read a USB stick's filesystem |
+| `chrome.fileSystem` | yes | yes | ChromeOS apps only | no | Not available to extensions |
+
+Consequences that drive the design:
+
+- **The directory picker only runs in a document.** `showDirectoryPicker()` lives on `Window`;
+  the MV3 service worker cannot call it, and `requestPermission()` needs a user gesture.
+  So provisioning and permission re-grants happen in the app page (`app/app.html`), never in
+  the background.
+- **A `FileSystemDirectoryHandle` cannot be sent over `chrome.runtime` messaging.** Runtime
+  messages are JSON-serialized, not structured-cloned. The handle is therefore persisted to
+  **IndexedDB by the app page**, and the service worker reads it back from IndexedDB — both
+  live on the same `chrome-extension://<id>` origin. The port message only carries a signal
+  ("a handle is stored"), not the handle.
+- **Firefox has no File System Access API** (only OPFS, which is not the USB stick). Firefox
+  support therefore requires the native messaging host, which is scoped as a separate phase.
+  Until it exists, Firefox reports state `UNSUPPORTED` with an explanatory message rather than
+  silently falling back to local storage.
+- **There is no filesystem "device removed" event.** Presence is determined by *actively
+  probing* a marker file, on a timer and before every operation.
+
+### Phase 0 — de-risking spike (do this first, it is small)
+
+Two assumptions must be confirmed empirically before building on them:
+
+1. A `FileSystemDirectoryHandle` retrieved from IndexedDB **inside the MV3 service worker** can
+   be used for `getFileHandle()` / `getFile()` / `createWritable()`.
+2. Whether a `readwrite` grant on a `chrome-extension://` origin **survives a browser restart**.
+
+If (1) fails, all USB I/O is routed through the existing offscreen document instead
+(`mvelo.util.sendOffscreenMessage` already establishes that pattern in
+[lib-mvelo.js:130](../src/lib/lib-mvelo.js#L130)); the rest of the design is unchanged.
+
+If (2) fails, the UX gains one required click per browser session ("Unlock USB keystore"),
+handled by the existing `PERMISSION_REQUIRED` state — no redesign, but it must be planned for
+rather than discovered late.
+
+## 3. Where key material lives today
+
+Audit of every persistence site (from `grep` over `src/`), and what happens to each in USB mode:
+
+| Location | Contents | Action |
+|---|---|---|
+| `mvelo.keyring.<id>.publicKeys` / `.privateKeys` — [KeyStoreLocal.js](../src/modules/KeyStoreLocal.js) | armored public + private keys | **Move to USB**, delete local copy after verified migration |
+| `mvelo.keyring.attributes` — [keyring.js:26](../src/modules/keyring.js#L26) | `default_key`, `primary_key`, `sync_data` (fingerprint changelog), `key_binding` (email→fingerprint) | **Move to USB** per-keyring `attributes.json` |
+| `mvelo.autocrypt.<id>` — [autocryptWrapper.js:152](../src/modules/autocryptWrapper.js#L152) | public keys harvested from Autocrypt headers | **Move to USB** `autocrypt.json` |
+| `pwdCache` → `chrome.storage.session` — [pwdCache.js:92](../src/modules/pwdCache.js#L92) | **decrypted private keys and passphrases** | Memory-backed only; **purge on every transition to absent**. Confirm `storage.session` is never written to disk on both browsers |
+| Sync server — [sync.controller.js:167](../src/controller/sync.controller.js#L167) | encrypted keyring + changelog uploaded to a remote server | **Block** for USB-backed keyrings |
+| Key backup — [privateKey.controller.js:164](../src/controller/privateKey.controller.js#L164) (`sync.backup({backup})`) | **encrypted private key backup uploaded off-device** | **Block** for USB-backed keyrings |
+| `mveloKeyServer.upload` — [app.controller.js:184](../src/controller/app.controller.js#L184) | own *public* key, explicit user action | Keep; public-only and user-initiated. Called out in the settings UI |
+| GnuPG keyring — [KeyStoreGPG.js](../src/modules/KeyStoreGPG.js) | keys in the OS GnuPG home directory | **Open decision — see §9** |
+| `mvelo.oauth.*`, Gmail tokens — [gmail.js:232](../src/modules/gmail.js#L232) | OAuth tokens (not PGP material) | Out of scope, documented |
+| `mvelo.preferences`, `mvelo.watchlist`, `localStorage` watchlist cache | settings only | Unaffected |
+
+### 3.1 Deleting from `chrome.storage.local` does not erase the bytes from disk
+
+This matters more than anything else in this section, given the priority ordering in §1. To be
+unambiguous: **this is data written to persistent storage, not a memory artifact.**
+
+**Chrome.** `storage.local` is a LevelDB database at
+`<profile>/Local Extension Settings/<extension-id>/` (`MANIFEST-*`, `*.log`, `*.ldb`).
+
+- `set()` appends the value to the write-ahead log (`.log`) and a memtable; when the memtable
+  fills it is flushed to an immutable sorted table (`.ldb`). Both are on disk.
+- `remove()` erases nothing. LevelDB is log-structured and append-only, so deletion appends a
+  *tombstone*. Reads see the tombstone and report "not found" while the original value record
+  remains in whichever `.log` / `.ldb` file it landed in.
+- Those bytes go away only when **compaction** rewrites that file without them. Compaction is
+  driven by write pressure, and a keyring is a *low-write* store — so a rarely-updated keyring
+  may not be compacted for a very long time, or in practice never. The low write volume makes
+  this worse, not better.
+- Armored keys are plain ASCII with distinctive headers, so recovery requires no sophistication:
+  `strings` plus a grep for `-----BEGIN PGP PRIVATE KEY BLOCK-----` over the profile directory.
+
+**Firefox.** `storage.local` is backed by IndexedDB over SQLite, where `DELETE` releases pages
+to the freelist and content persists until those pages are reused or the database is `VACUUM`ed.
+Different substrate, same class of problem.
+
+**Second layer, beyond reach.** Once compaction does unlink the old `.ldb`, the bytes sit in
+unallocated space; on an SSD, wear-levelling means even an explicit overwrite may not touch the
+original physical cells. No extension can address this.
+
+So a migration that moves local private keys to the stick and calls `storage.remove()` leaves
+those keys **recoverable from disk by anyone with filesystem access**, for an indeterminate
+period. That is precisely the outcome the feature exists to prevent.
+
+Mitigations, honestly ranked:
+
+1. **Never write the keys locally in the first place.** In USB mode, key generation writes
+   straight to the device (`KeyStoreUsb.generateKey` → USB), never through the local store. For
+   a user setting up fresh, nothing is ever written locally and the problem does not arise.
+   This is the only mitigation that is actually complete.
+2. **Tell the truth in the UI.** Migration of pre-existing local keys must state plainly that
+   copies may remain recoverable from the browser profile on disk, and that the durable fix is
+   to generate a fresh key onto the device and revoke the old one.
+3. **Overwrite-before-delete — weak, and partly counterproductive.** Because the store is
+   append-only, re-`set()`ing a key to junk *appends* records rather than scrubbing old ones,
+   so in the interim it **increases** the number of on-disk copies. It helps only indirectly, by
+   adding write pressure that may trigger compaction sooner. It raises a probability and
+   guarantees nothing. Include it only if measurement (below) shows it actually helps.
+
+**Design rule.** `chrome.storage.session` *is* memory-only. If key material ever has to be
+staged outside the USB device, session storage is the only acceptable place — never
+`storage.local`.
+
+**Recommendation:** offer migration, but make "generate a fresh key onto the USB device" the
+primary path in the setup flow, with the residue caveat stated in the UI rather than buried
+here. Given that key loss is acceptable but local residue is not, a fresh key costs nothing the
+user has said they value.
+
+#### Private browsing does not help
+
+A natural question, worth answering in writing: no, running in a Firefox private window does not
+make the keystore ephemeral.
+
+- **`storage.local` has no private-browsing partition.** It is a single store per extension.
+  An extension running in a private window reads and writes the *same* `storage.local` as normal
+  browsing, and the data survives the window closing. Private browsing gives memory-only storage
+  to **web content** (the visited origins' cookies, cache, `localStorage`, IndexedDB); it does
+  not extend to an extension's own store. There is also one background context per extension,
+  shared across normal and private windows.
+- **Firefox disables extensions in private windows by default**, so Mailvelope would not run
+  there at all without the user explicitly enabling "Run in Private Windows".
+- **The residue is historical anyway.** The bytes at issue were written during earlier
+  normal-mode use. How the browser is used *later* cannot unwrite them.
+
+The one real (unrelated) benefit: private windows do make *webmail page* data more ephemeral —
+cached message bodies, or decrypted plaintext a page stashes in its own storage. That concerns
+message content, not key material.
+
+What does address bytes already on disk:
+
+- **Revoke the migrated key.** The strongest available response. Its limit must be stated:
+  revocation prevents future use, but whoever recovers the private key can still decrypt
+  *previously intercepted* ciphertext encrypted to it. It bounds future damage, not past.
+- **Full-disk encryption.** The honest answer for the layer no extension can reach (unallocated
+  blocks, SSD wear-levelled cells). FDE plus a USB keystore is genuine defence in depth for the
+  threat model in §1, and the settings UI should say so.
+- **A fresh browser profile** after migrating: deleting the old profile destroys the whole
+  LevelDB and clears the logical layer, though unlinked blocks persist until overwritten.
+
+#### Measure it, don't assume it (Phase 0)
+
+The mechanism above is established LevelDB behaviour, but its *practical* severity here — how
+long the residue actually survives for a keyring-sized, low-write store — should be measured,
+not asserted. On a throwaway browser profile:
+
+1. install the extension, generate a private key, confirm it is in `storage.local`
+2. run the migration (or plain `storage.remove()`)
+3. `grep -rl "BEGIN PGP PRIVATE KEY" "<profile>/Local Extension Settings/<id>/"`
+4. repeat after forcing write pressure, and after a browser restart, to see whether and when
+   compaction clears it
+5. repeat step 3 with the overwrite-before-delete heuristic enabled, to establish whether
+   mitigation 3 earns its place
+
+This is cheap, definitive, and decides how strongly the UI has to warn.
+
+### 3.2 The clean path: a new user generating straight onto the device
+
+This is the primary supported scenario — fresh install, no keys to bring along, generate onto
+the USB device. Traced through the code, **no armored private key ever touches
+`chrome.storage.local`** on this path:
+
+- `KeyringBase.generateKey` ([KeyringBase.js:319](../src/modules/KeyringBase.js#L319)) calls
+  `keystore.generateKey()` (openpgp.js, pure in-memory computation), pushes the result into the
+  in-memory `privateKeys` array, and optionally uploads the **public** key only.
+  `KeyStoreUsb.store()` is then the sole act of persistence → the device.
+- `uiLog` ([uiLog.js:9](../src/modules/uiLog.js#L9)) is an in-process array, never persisted,
+  and records i18n event types rather than key material.
+- `pwdCache` uses `chrome.storage.session`, which is memory-only.
+
+So there is no residue, nothing to revoke, and no warning to show. The full-disk-encryption
+advice in §3.1 becomes belt-and-braces rather than a necessity. Three conditions make this
+guarantee real rather than incidental:
+
+1. **Sequencing.** On a fresh install `keystore.backend` defaults to `local`, so the main
+   keyring is built with `KeyStoreLocal`. A user who generates *before* provisioning the device
+   writes locally and lands straight in the §3.1 residue case. The setup flow must therefore be
+   *provision device → then generate*, and the UI must enforce that ordering rather than
+   offering both as equal choices. In [KeyringSetup.js](../src/app/keyring/KeyringSetup.js), when
+   USB mode is enabled but no device is configured, the generate and import cards are gated
+   behind device setup.
+2. **Generation must fail closed.** If the device is not `READY` when generation is requested,
+   refuse with `USB_KEYSTORE_UNAVAILABLE`. Never fall back to `KeyStoreLocal` silently — that
+   fallback is the difference between "clean by construction" and "clean if nothing goes wrong".
+3. **Block the externally-triggered backup path.** Verified: `createKeyBackupContainer` is a
+   **client-API** method ([client-api.js:403](../src/client-API/client-api.js#L403)) that a
+   webmail provider page can invoke; it encrypts the private key and uploads it via
+   `sync.backup()`. It is *not* part of the app's own generate flow, so a new user generating
+   from the Mailvelope UI will not hit it — but because the trigger is external, the refusal has
+   to live in `PrivateKeyController`, not in our UI.
+
+#### What the USB device does and does not protect
+
+Worth being precise, because "on a USB stick for secrecy" invites an overestimate: the device
+provides **separation and portability, not confidentiality**. A private key written there is
+protected only by its OpenPGP passphrase. With no passphrase, the stick holds a plaintext
+private key and anyone who picks it up has the identity.
+
+Consequences for the UI:
+
+- In USB mode, key generation should **require** a passphrase and encourage a strong one — it is
+  the only thing standing between a lost stick and a compromised key.
+- Offering an encrypted volume on the device (LUKS, VeraCrypt, BitLocker To Go) is worth
+  mentioning in the settings text as the way to get at-rest confidentiality. It is transparent
+  to this feature: the picker simply targets the mounted volume, and `ABSENT` covers "present
+  but not unlocked" with no extra code.
+- One residual caveat that no design here removes: key material is in service-worker memory
+  while in use, and the OS may swap those pages to disk. Encrypted swap or full-disk encryption
+  is the only answer, which is a second reason to recommend FDE.
+
+## 4. Core design decision: intercept the storage layer
+
+**Overriding constraint: this branch must track upstream `master`.** Every line changed in an
+existing file is a future rebase conflict, so the design is judged on diff footprint as much as
+on correctness. All logic lives in new files; existing files get the smallest possible hook.
+
+Three ways to attach a USB store, in increasing order of how little they disturb the tree:
+
+1. **A new keyring** (`localhost|#|usb`) beside the main one. Rejected: the main keyring still
+   exists locally (violating requirement 3 unless emptied anyway), and `MAIN_KEYRING_ID` is
+   threaded through much of the app.
+2. **A `KeyStoreUsb` class selected in `buildKeyring()`.** Workable — `buildKeyring()`
+   ([keyring.js:182](../src/modules/keyring.js#L182)) already picks a keystore class per keyring,
+   so it is a two-line hook there. But key *metadata* does not go through the keystore:
+   `KeyringAttrMap` and `autocryptWrapper.Store` write straight to `mvelo.storage`, so this
+   still requires edits in `keyring.js` and `autocryptWrapper.js`, and a new pref means touching
+   `prefs.js` and `defaults.json`.
+3. **Intercept `mvelo.storage` itself.** Every crypto persistence path in the audit of §3 —
+   keys, keyring attributes, Autocrypt records — funnels through the three functions
+   `mvelo.storage.{get,set,remove}` in [lib-mvelo.js:26](../src/lib/lib-mvelo.js#L26). Wrapping
+   those at install time routes crypto keys to the device and passes everything else through to
+   `chrome.storage.local`.
+
+**Chosen: option 3.** `KeyStoreLocal`, `KeyringAttrMap` and `autocryptWrapper.Store` then work
+**verbatim, unmodified** — they ask `mvelo.storage` for armored keys and get them, unaware of
+the source. There is no `KeyStoreUsb` class, and no change at all to `keyring.js`,
+`KeyStoreLocal.js`, `autocryptWrapper.js`, `prefs.js`, `defaults.json` or `constants.js`.
+
+Two properties beyond the smaller diff make this the better design and not merely the cheaper
+one:
+
+- **Central enforcement.** Requirement 3 becomes one function deciding what is crypto and where
+  it goes, rather than a rule re-implemented at each call site. The router **default-denies**:
+  a key matching a crypto pattern goes to the device or fails, and only an explicit allowlist
+  (`mvelo.preferences`, `mvelo.watchlist`, `mvelo.oauth.*`) passes through to local storage. A
+  future upstream commit that adds a new crypto storage key is then caught by the router instead
+  of silently writing to disk.
+- **Fail-closed for free.** When the device is not `READY` the wrapper rejects, so every caller
+  inherits the §3.2 fail-closed requirement without individually implementing it.
+
+The cost is that the redirection is implicit — someone reading `KeyStoreLocal` sees no sign of
+it. That is mitigated by a comment at the single install site and by this document, and is a
+fair trade for a branch whose main risk is rebase friction.
+
+The same technique covers the badge conflict from §6: the module also wraps
+`mvelo.action.state`, so badge arbitration needs no edit to `uiLog.js`.
+
+Configuration lives under its own storage key (`mvelo.usb.config`, on the allowlist and holding
+no key material) rather than in `prefs`, which keeps `prefs.js`, `defaults.json` and the prefs
+UI untouched.
+
+### 4.2 On-device representation
+
+The interceptor sees storage keys and values, so the router maps them to device files:
+
+| Storage key | Device file | Format |
+|---|---|---|
+| `mvelo.keyring.<id>.publicKeys` | `keyrings/<enc>/public.asc` | value is an array of armored strings — join on write, split on read |
+| `mvelo.keyring.<id>.privateKeys` | `keyrings/<enc>/private.asc` | as above |
+| `mvelo.keyring.attributes` | `keyrings/attributes.json` | JSON verbatim |
+| `mvelo.autocrypt.<id>` | `keyrings/<enc>/autocrypt.json` | JSON verbatim |
+
+Keeping the key files as real `.asc` files is a deliberate choice: it costs a `join`/`split` and
+means the stick stays usable for recovery with `gpg --import` if Mailvelope is unavailable.
+
+### 4.1 The crypto library is orthogonal — with one exception
+
+Mailvelope has two independent abstractions. This work touches only the first:
+
+| Axis | Selector | Implementations | Question |
+|---|---|---|---|
+| Keystore | `KeyStoreBase` subclass, chosen in `buildKeyring()` | `KeyStoreLocal`, `KeyStoreGPG` | *Where do the key bytes live?* |
+| PGP backend | `keyring.getPgpBackend()`, consumed only in [pgpModel.js](../src/modules/pgpModel.js) | [openpgpjs.js](../src/modules/openpgpjs.js), [gnupg.js](../src/modules/gnupg.js) | *Who does the crypto math?* |
+
+The question that matters for a USB keystore is not "which library" but **does the library own
+key storage, or does the caller hand it keys as data?**
+
+- **openpgp.js is data-in/data-out.** It receives key objects from the keystore
+  (`keyring.getPrivateKeyByIds()`, `keyring.keystore.getAllKeys()`) and never touches storage:
+  armored text in via `readKey()`, `key.armor()` back out. `KeyStoreUsb` is therefore a drop-in
+  — the library is unaware of where the bytes came from. Any equivalent library (openpgp.js v6,
+  a WASM Sequoia/rPGP build) would work the same way. Swapping libraries is an unrelated
+  migration and should not be bundled into this branch.
+- **GnuPG owns its keyring, which is why it cannot be redirected.** [gnupg.js](../src/modules/gnupg.js)
+  passes *fingerprints* to GPGME; keys never leave `~/.gnupg`. `KeyStoreGPG.store()` throws by
+  design. There is no seam to point at a USB device from inside an extension — hence the
+  decision to hide that keyring in USB mode (§9.2).
+
+**The exception:** GnuPG *can* be pointed at removable media via `GNUPGHOME`. An extension
+cannot set it, but the Phase 5 native messaging host could launch gpg with
+`GNUPGHOME=<usb>/mailvelope-keystore/gnupg`, yielding real GnuPG-on-USB and Firefox support in
+one move. Deliberately out of scope: it means shipping a native binary, and it inherits
+`gpg-agent`'s lifecycle — a running agent caches unlocked secret keys in memory and keeps its
+socket under `GNUPGHOME`, which complicates the "device removed" guarantees this plan is built
+on. Revisit only if GnuPG parity becomes a requirement.
+
+## 5. On-device layout
+
+```
+<user-picked directory>/
+  mailvelope-keystore/
+    keystore.json                 # {version, keystoreId (UUID), created, label}
+    keyrings/
+      <encoded-keyring-id>/
+        meta.json                 # the real keyring id
+        public.asc                # concatenated armored public keys
+        private.asc               # concatenated armored private keys
+        attributes.json           # default_key, sync_data, key_binding, sanitized
+        autocrypt.json            # Autocrypt-discovered public keys
+```
+
+Notes:
+
+- Keyring IDs contain `|#|` (`KEYRING_DELIMITER`), and `|` is not a legal filename character on
+  Windows/FAT/exFAT — the most likely filesystems on a USB stick. Directory names are therefore
+  an encoding of the id, with the true id recorded in `meta.json`.
+- **Use hex or base32 for that encoding, not base64.** FAT32 and exFAT are *case-insensitive*.
+  URL-safe base64 is case-sensitive, so two distinct keyring IDs can encode to names differing
+  only in case and then collide on the device — silently mapping two keyrings onto one
+  directory. Hex and base32 are single-case and immune to this.
+- **Pick a subdirectory, not the volume root.** Chrome's File System Access blocklist rejects
+  various sensitive locations, and a subdirectory keeps the picker predictable. The layout above
+  already nests everything under `mailvelope-keystore/`.
+- `keystore.json` carries a random `keystoreId`. The extension keeps a copy of that UUID in
+  `chrome.storage.local` so it can distinguish "my keystore device" from "some other stick
+  mounted at the same place" (state `WRONG_DEVICE`). The UUID is a random label, not key
+  material, so keeping it locally does not violate requirement 3.
+
+### Device formatting — a user choice, not a code concern
+
+The File System Access API goes through the OS and exposes nothing about the underlying
+filesystem: `FileSystemHandle` has no filesystem, label, or UUID accessor. **The extension
+therefore cannot detect the format and should not try to enforce one.** Any volume the OS mounts
+read-write works. Guidance belongs in the settings help text, not in code.
+
+| Filesystem | Portability | Journaled | POSIX perms | Notes |
+|---|---|---|---|---|
+| **exFAT** | Windows, macOS, Linux (kernel 5.7+) | no | no | Best default — universal, no size limits |
+| **FAT32** | universal, including old systems | no | no | Fine; 4 GB file limit is irrelevant at keyring sizes |
+| **ext4** | Linux only in practice | **yes** | **yes** | Journaling and `chmod 600` on the private key, at the cost of portability |
+| **NTFS** | Windows native, Linux ntfs3, macOS read-only | yes | partial | No advantage here |
+
+Recommendation: **exFAT** if the stick will move between machines — portability is the reason to
+use a USB keystore in the first place. **ext4** only for a Linux-only setup, where journaling
+(better tolerance of a mid-write yank) and permission bits are worth losing portability for.
+Note the extension cannot set permissions either way — FSA has no `chmod` — so POSIX perms only
+help if the user sets them up.
+
+**The format is the wrong layer to optimise for secrecy.** No filesystem in that table provides
+confidentiality; on FAT32/exFAT everything is world-readable once mounted. Per §3.2, the key on
+the device is protected only by its OpenPGP passphrase. For real at-rest protection, use an
+encrypted volume — **VeraCrypt** for cross-platform, **LUKS** for Linux-only — and this is
+entirely transparent to the implementation: the picker targets the mounted volume, and
+"present but not unlocked" surfaces as `ABSENT` with no extra code.
+
+**One detail this settles about presence detection.** Automounters differ in what they leave
+behind on removal: the mount point may vanish (so the handle throws `NotFoundError`) or may
+persist as an empty directory (so the handle still resolves and only the *contents* are gone).
+Probing for `keystore.json` rather than merely resolving the directory handle covers both cases —
+which is why §6 probes a marker file. It is also the only device-identity mechanism available,
+since FSA exposes no volume UUID.
+
+### Write integrity
+
+A USB stick can be pulled mid-write, which would otherwise corrupt a keyring. Every write:
+
+1. writes `private.asc.tmp`,
+2. re-reads and parses it to confirm the expected key count,
+3. rotates the previous generation to `private.asc.bak`,
+4. `move()`s the temp file into place (`FileSystemFileHandle.move()`, Chrome 111+; fall back to
+   write-and-swap where unavailable).
+
+On load, a missing or unparsable primary file falls back to `.bak` and surfaces a warning.
+
+## 6. Availability state machine
+
+```
+NOT_CONFIGURED   no USB keystore set up            → offer "Add USB keystore"
+UNSUPPORTED      no usable backend (Firefox today) → explain, offer native host
+PERMISSION_REQUIRED  handle stored, grant missing  → one-click re-grant in app page
+ABSENT           handle + grant, marker unreadable → "USB keystore not available"
+WRONG_DEVICE     readable, keystoreId mismatch     → "This is not your keystore device"
+ERROR            I/O failure or corrupt keystore   → diagnostics
+READY            everything usable
+```
+
+Probing (there is no removal event, so presence is always actively checked):
+
+- read `mailvelope-keystore/keystore.json`; `NotFoundError` / `NotReadableError` → `ABSENT`
+- a `chrome.alarms` periodic probe (Chrome MV3 floor is 0.5 min; use 1 min, configurable)
+- a probe **before every keystore operation** — a single small file read
+- a probe on app-page focus/`visibilitychange` and on action-menu open
+
+On transition **to** `ABSENT` / `WRONG_DEVICE` / `ERROR`:
+
+1. `keystore.clear()` — drop all key material from service-worker memory
+2. purge `pwdCache` — it holds decrypted private keys and passphrases
+3. red badge via the existing `mvelo.action.state({badge, badgeColor})` — **note the conflict:**
+   [uiLog.js:42](../src/modules/uiLog.js#L42) already owns the badge, setting a green `Ok` on any
+   user interaction and unconditionally clearing it 2s later, which would silently wipe the USB
+   warning. Badge ownership needs arbitration: USB state takes priority, and `uiLog`'s
+   `clearBadge()` must restore the USB badge rather than blanking it
+4. broadcast `usb-status-changed` to every connected port (app, action menu, editor,
+   decrypt/encrypt frames)
+5. every crypto entry point rejects with `MvError(..., 'USB_KEYSTORE_UNAVAILABLE')`, mapped to
+   a clear localized message in the existing error surfaces
+
+On transition **to** `READY`: reload the keystore from the device and re-broadcast.
+
+## 7. New and changed files
+
+Everything self-contained lives under `src/modules/usb/` and `src/components/usb/`. Existing
+files are touched only at the hook sites in the second table.
+
+**New files** (all of the logic)
+
+| File | Responsibility |
+|---|---|
+| `src/modules/usb/install.js` | `installUsbKeystore()` — wraps `mvelo.storage.{get,set,remove}` and `mvelo.action.state`; the single entry point |
+| `src/modules/usb/guard.js` | refusal for the two paths that bypass storage entirely and upload key material remotely |
+| `src/modules/usb/router.js` | storage-key → device-file mapping, crypto-pattern matching, allowlist default-deny (§4.2) |
+| `src/modules/usb/state.js` | state machine, marker-file probing, `chrome.alarms`, transition broadcast, pwdCache purge |
+| `src/modules/usb/backend.js` | backend interface: `probe()`, `readFile()`, `writeFile()`, `removeFile()`, `listDir()` |
+| `src/modules/usb/FsaBackend.js` | File System Access implementation |
+| `src/modules/usb/NativeBackend.js` | native messaging implementation (Phase 5) |
+| `src/modules/usb/handleStore.js` | IndexedDB persistence of the directory handle — written by the app page, read by the service worker (§2) |
+| `src/modules/usb/provision.js` | device setup, `keystore.json` creation, migration with verify-then-delete |
+| `src/modules/usb/constants.js` | states, `USB_KEYSTORE_UNAVAILABLE`, storage keys — *not* `lib/constants.js` |
+| `src/modules/usb/strings.js` | English UI strings — see the l10n note below |
+| `src/modules/usb/handlers.js` | `registerUsbHandlers(controller)` — attaches all `this.on(...)` port events |
+| `src/components/usb/KeyStorageSettings.js` | settings page, framed as a storage-location choice: this computer (default) or USB device, plus status, re-grant, migrate, disable, diagnostics |
+| `src/components/usb/usbStatus.js` | status subscription with local fan-out, plus the `useUsbStatus` hook |
+| `src/components/usb/UsbStatusBadge.js` | ambient "stored on …" indicator for the keyring page |
+| `src/components/usb/UsbSetupCard.js` | the "Set up USB keystore" card (requirement 4) |
+| `src/components/usb/UsbStatusBanner.js` | banner shown whenever state is not `READY` |
+| `src/components/usb/UsbActionMenuRow.js` | action-menu warning row |
+
+**Hook sites** (the complete diff against upstream)
+
+| File | Change | Lines |
+|---|---|---|
+| [src/background.js](../src/background.js) | import + `await installUsbKeystore()` before `initKeyring()` | 2 |
+| [src/controller/app.controller.js](../src/controller/app.controller.js) | import + `registerUsbHandlers(this)` in the constructor | 2 |
+| [src/modules/pwdCache.js](../src/modules/pwdCache.js) | `export function clear() { cache.clear(); }` — the instance method exists, it is just not exported | 3 |
+| [src/controller/privateKey.controller.js](../src/controller/privateKey.controller.js) | guard in `createPrivateKeyBackup` (§3.2 item 3) | 2 |
+| [src/controller/sync.controller.js](../src/controller/sync.controller.js) | guard in `triggerSync` | 2 |
+| [src/app/settings/Settings.js](../src/app/settings/Settings.js) | import + `NavPill` + `Route` for `/settings/key-storage` | 4 |
+| [src/app/app.js](../src/app/app.js) | import + `<UsbStatusBanner />` so an unavailable device is noted on every page | 2 |
+| [src/app/keyring/Keyring.js](../src/app/keyring/Keyring.js) | import + `<UsbStatusBadge />` in the page title | 2 |
+| [src/components/action-menu/components/ActionMenuWrapper.js](../src/components/action-menu/components/ActionMenuWrapper.js) | pass `port` to `ActionMenuBase` | 1 |
+| [src/app/keyring/KeyringSetup.js](../src/app/keyring/KeyringSetup.js) | import + `<UsbSetupCard />` | 2 |
+| [src/components/action-menu/components/ActionMenuBase.js](../src/components/action-menu/components/ActionMenuBase.js) | import + `<UsbActionMenuRow />` | 2 |
+
+**Actual footprint as built: +31/-2 lines across 11 files**, every hook additive, which is what
+keeps rebases cheap. Deliberately **not** touched:
+`keyring.js`, `KeyStoreLocal.js`, `keyStore.js`, `autocryptWrapper.js`, `prefs.js`,
+`defaults.json`, `lib/constants.js`, `lib-mvelo.js`, `uiLog.js`, `locales/`.
+
+**l10n note.** New strings stay in `src/modules/usb/strings.js` rather than
+`locales/en/messages.json`. That file is large, shared, and *regenerated* upstream — recent
+history (`Normalize l10n files to Weblate format`, `drop orphan and untranslated keys`) shows it
+is rewritten wholesale, so added keys are a recurring conflict. English-only strings in our own
+module cost nothing now; if the feature is ever upstreamed, moving them into `messages.json` is
+mechanical.
+
+## 8. Phasing
+
+| Phase | Content | Reviewable output |
+|---|---|---|
+| **0** | Spike: FSA handle usable from the service worker; permission persistence across restart; **LevelDB residue measurement (§3.1)** | Findings, `go`/adjust decision |
+| **1** | `UsbBackend` + `FsaBackend` + `handleStore` + state machine + probing + alarms | Status observable via a dev command; no keystore change yet |
+| **2** | `KeyStoreUsb`, `buildKeyring()` wiring, atomic writes, migration with verify-then-delete | Keys actually live on the stick |
+| **3** | Settings page, setup card, banner, badge, action-menu row, l10n | Full UX for requirements 1, 2, 4 |
+| **4** | Enforcement: purge on absent, block sync/backup, `USB_KEYSTORE_UNAVAILABLE` plumbing, **storage-audit test** | Requirement 3 becomes testable |
+| **5** | Native messaging host → Firefox support | Cross-browser parity |
+
+### The requirement-3 audit test (Phase 4)
+
+"No crypto anywhere else" should be a test, not a claim. A unit/integration test enumerates
+every key in `chrome.storage.local` and `chrome.storage.session` after a scripted session
+(generate key → import key → decrypt → remove key) and asserts:
+
+- no key matches `^mvelo\.keyring\..*\.(public|private)Keys$`
+- no key matches `^mvelo\.autocrypt\.`
+- no serialized value anywhere contains `-----BEGIN PGP`
+- `mvelo.keyring.attributes` contains no `default_key` / `sync_data` / `key_binding` entries
+
+Jest already runs unit and integration projects ([jest.config.js](../jest.config.js)), so this
+fits the existing harness.
+
+## 9. Decisions
+
+### Resolved
+
+1. **Single point of failure — accepted.** Losing the stick means losing the keys, and that is
+   acceptable. No clone-to-second-stick action, no local or remote backup copy of private keys.
+   The USB `.bak` generation described in §5 stays, because it guards against a *torn write*
+   (stick pulled mid-save) — a corruption failure on the device itself, not a second copy
+   anywhere else.
+2. **GnuPG keyring — hidden/disabled in USB mode.** GnuPG keeps secret keys in `~/.gnupg` on the
+   machine, which is exactly what this feature exists to avoid. `prefer_gnupg` is ignored and
+   the keyring is excluded from `getPreferredKeyringQueue()` while the USB backend is active.
+3. **Migration — move and delete locally, but prefer generating fresh.** Local copies are
+   deleted after a verified write to the stick. Because deletion does not erase the bytes from
+   LevelDB (§3.1), the setup flow presents "generate a new key onto the device" as the
+   recommended path, and the migration path carries an explicit residue warning.
+4. **Remote sync and key backup — blocked in USB mode.** `createPrivateKeyBackup` →
+   `sync.backup()` uploads an encrypted private key off-device; keyring sync uploads the
+   keyring. Both are disabled for USB-backed keyrings. Note this goes beyond "nothing on the
+   local machine" to "nothing outside the stick", per the original requirement 3.
+
+5. **UI framing — a storage location, not a feature toggle.** Settings presents a
+   radio choice, *This computer (default)* or *USB device*, so where keys live is
+   always legible rather than implied by whether a feature is on. Selecting
+   "USB device" only reveals the setup panel; nothing moves until a directory is
+   chosen, so a mis-click cannot relocate key material. Status surfaces in four
+   places: the settings panel, an app-wide banner, a badge on the keyring page, and
+   the toolbar badge plus action-menu row when no Mailvelope page is open.
+
+### Still open
+
+6. **Probe interval.** 1 minute is the practical Chrome MV3 alarm floor. Because every keystore
+   operation also probes, the timer only affects how fast a *passive* UI notices removal.
+7. **Firefox timing.** Ship Phases 1–4 as Chrome-only with an explicit `UNSUPPORTED` state in
+   Firefox, or hold the feature until the native host exists? **Recommendation: ship Chrome
+   first** — the native host is a separate deliverable with its own install story.
+8. **Password cache in USB mode.** `pwdCache` holds decrypted private keys and passphrases in
+   `chrome.storage.session`. That store is documented as memory-only, but given the priority
+   ordering it is worth deciding whether USB mode should force `security.password_cache` off
+   rather than merely purging the cache when the device is removed.
+
+## 10. Security notes
+
+- The threat model deliberately trades away durability: it improves "attacker with the disk at
+  rest" and accepts total key loss if the stick is lost. That is the stated intent (§1), and the
+  settings UI should say so rather than imply the keys are safe.
+- Key material is unavoidably in service-worker memory while in use. The design minimizes the
+  window by clearing memory and the passphrase cache the moment the device goes away.
+- `pwdCache` holds decrypted private keys. Confirming that `chrome.storage.session` is
+  memory-only on both browsers is a Phase 4 verification item, not an assumption — see also
+  open decision 7.
+- **LevelDB residue (§3.1) is the weakest point in the whole design.** Everything else here is
+  enforceable in code; that one is not fully fixable from inside an extension. Generating keys
+  directly onto the device is the only path that avoids it completely.
+- Blocking the remote sync/backup paths is essential: `createPrivateKeyBackup` currently
+  uploads an encrypted private key backup to a sync server, which is exactly the off-device
+  copy requirement 3 forbids.

--- a/doc/usb-keystore-plan.md
+++ b/doc/usb-keystore-plan.md
@@ -567,17 +567,45 @@ fits the existing harness.
    places: the settings panel, an app-wide banner, a badge on the keyring page, and
    the toolbar badge plus action-menu row when no Mailvelope page is open.
 
-### Still open
+### Resolved during implementation
 
-6. **Probe interval.** 1 minute is the practical Chrome MV3 alarm floor. Because every keystore
-   operation also probes, the timer only affects how fast a *passive* UI notices removal.
-7. **Firefox timing.** Ship Phases 1–4 as Chrome-only with an explicit `UNSUPPORTED` state in
-   Firefox, or hold the feature until the native host exists? **Recommendation: ship Chrome
-   first** — the native host is a separate deliverable with its own install story.
-8. **Password cache in USB mode.** `pwdCache` holds decrypted private keys and passphrases in
-   `chrome.storage.session`. That store is documented as memory-only, but given the priority
-   ordering it is worth deciding whether USB mode should force `security.password_cache` off
-   rather than merely purging the cache when the device is removed.
+6. **Probe interval.** 30 seconds (`periodInMinutes: 0.5`) is the alarm floor, with 1-second
+   polling while a page is visible and a probe before every keystore operation. So the timer only
+   governs how fast a *passive* UI notices removal.
+7. **Firefox timing.** Both ship. The native host landed in the same branch, and one keystore has
+   been read by Chrome through the File System Access API and by Firefox through the host, with no
+   key material in either profile.
+8. **Password cache in USB mode.** **Forced off** while a keystore is configured. The reason turned
+   out not to be the one anticipated here: `chrome.storage.session` is indeed memory-only, so no
+   passphrase reaches disk. But caching an entry makes `chrome.alarms` hold an alarm named
+   `PWD_ALARM_<fingerprint>`, and Chrome persists alarm names to `Extension State/` with
+   `persistAcrossSessions` — writing the fingerprint of a device-resident key into the local
+   profile, where LevelDB's append-only log kept it readable seven hours after the alarm had
+   fired. Gated in `pwdCache.set()` rather than at the `active` check in `unlock()`, because
+   `privateKey.controller` calls `set()` directly.
+
+### Known limitation, accepted
+
+9. **`hasPrivateKey` reports `false` while the device is detached.** The client API's
+   `hasPrivateKey` (`api.controller.js`) reads the in-memory keystore, which is empty when the
+   device is gone, so a webmail provider asking whether the user has a private key cannot tell
+   "detached" from "never had one".
+
+   **Decision: leave it.** `false` is true in the sense the caller acts on — there is no usable
+   private key, and encryption cannot proceed. The contract is a boolean, and raising a
+   device-unavailable code would land in third-party error handlers written long before this
+   feature, which is likely to behave worse than a truthful `false`. The harmful reaction is
+   already prevented: a provider that responds by prompting key generation gets a fail-closed
+   write with a clear device error, and the UI gate blocks generate and import before the form
+   appears.
+
+   What it costs: a provider may conclude the user does not use encryption and stop offering it
+   until the device is reconnected. Recoverable and self-correcting, which is why it is not worth
+   changing a published API shape over.
+
+   Deliberately **not** documented in `client-api.js`'s JSDoc: that is upstream's published API
+   documentation, and a caveat that applies only to builds with this feature would be diff carried
+   through every rebase.
 
 ## 10. Security notes
 

--- a/doc/usb-keystore-status.md
+++ b/doc/usb-keystore-status.md
@@ -197,13 +197,14 @@ Weak spots, in the order worth addressing:
 - `UsbErrorToast.js` **5%**, `UsbStatusBanner.js` **17%** — the global rejection
   listener is worth a test; it is the only thing reporting several failures.
 
-## 6. Open decisions
+## 6. Decisions
 
-- **client-API `hasPrivateKey`** reports `false` to a webmail page while the device is
-  detached. Recommendation: **leave it**, and note in the JSDoc that these queries
-  reflect currently-reachable keys. The dangerous outcome is already prevented — a
-  provider that responds by prompting key generation gets a fail-closed write and a
-  clear device error.
+- ~~**client-API `hasPrivateKey`**~~ **Decided: leave it**, documented in
+  [usb-keystore-plan.md](usb-keystore-plan.md) §9 rather than in `client-api.js`'s
+  JSDoc, which is upstream's published API documentation. It reports `false` while the
+  device is detached, so a provider cannot tell "detached" from "never had a key" —
+  but `false` is what the caller acts on, and the harmful reaction is already
+  fail-closed.
 - ~~**`password_cache` in USB mode.**~~ **Decided: off while a keystore is
   configured.** An earlier recommendation to leave it on was made before checking what
   caching writes to disk -- it names an alarm after the key fingerprint, which Chrome

--- a/doc/usb-keystore-status.md
+++ b/doc/usb-keystore-status.md
@@ -1,169 +1,218 @@
 # USB Keystore — Status and Handoff
 
-Updated 2026-08-22 after a full browser-testing session. Companion to
-[usb-keystore-plan.md](usb-keystore-plan.md), which holds the design and its rationale.
+Paused 2026-08-23, mid-way through Firefox support. Companion to
+[usb-keystore-plan.md](usb-keystore-plan.md), which holds the original design.
 
-**Both Phase 0 unknowns are now settled and every requirement from the original ask is
-verified in a real browser.** What remains is a real USB stick, one API decision, and the
-things a tmpfs test directory structurally cannot exercise.
+**Chrome/Chromium is done and verified on real hardware. Firefox is half-built** —
+the native messaging host works and is tested; the extension side is wired but has
+never been run.
 
-Branch `feature/usb-keystore`, 16 commits ahead of `master` (`ffaa27af`), working tree clean.
-45 files, +5,465/-30. Unit suite: **597 tests, 31 suites**. `grunt eslint` clean. All bundles
-build.
+Branch `feature/usb-keystore`, **25 commits** ahead of `master` (`ffaa27af`).
+Unit suite: **611 tests, 33 suites**. Native host: **17 tests**. `grunt eslint`
+clean. Both browser bundles build.
 
-The first two commits are split so that `fd2450c6` (all new files) can never conflict on a
-rebase and only `6a5330e7` needs attention. That split has since been diluted — later fixes
-touched `keyring.js`, `pgpModel.js`, `menu.controller.js`, `Keyring.js` and `GenerateKey.js` —
-so the hook footprint is now larger than the original +31/-2. Still worth keeping new-file and
-hook-site changes in separate commits going forward.
+## 1. Uncommitted work — read this first
 
-## 1. Settled: the two Phase 0 questions
+```
+ M src/modules/usb/handlers.js          usb-list-devices, usb-select-device
+ M src/modules/usb/provision.js         listDevices(), selectDevice()
+ M src/modules/usb/state.js             backend selection, usesNativeHost(), devicePath
+ M test/unit/modules/usb/handlers.test.js
+?? native-host/                          the host, its tests, install script
+?? src/modules/usb/NativeBackend.js
+```
 
-**An FSA `FileSystemDirectoryHandle` stored in IndexedDB by the app page IS usable from the MV3
-service worker.** Proven by provisioning writing `/tmp/mailvelope-keystore/keystore.json` from
-the background using a handle the page stored. **The planned offscreen-document fallback is not
-needed — do not build it.**
+All of it passes tests and lints, but **none of the extension-side Firefox code has
+ever executed**. Commit it as a work-in-progress or keep it in the tree; either way
+do not mistake "tests pass" for "it works".
 
-**A `readwrite` grant CAN survive a browser restart**, if the user takes Chrome's persistent
-option in the permission prompt ("allow on every visit" or similar). Confirmed by quitting and
-reopening Chromium and finding the state still `READY`.
+## 2. Chrome — verified on a real USB stick
 
-It does **not** survive an extension *reload*, which matters only during development. Because
-that is the common case while working on this, `Reconnect` re-prompts for the stored handle
-(one dialog) rather than reopening the directory picker.
+SanDisk Cruzer Blade, **FAT32, confirmed case-insensitive**, mounted at
+`/run/media/noamr/5AE6-4898`. Chromium `151.0.7922.173` (native, not flatpak —
+flatpak's portal sandbox can hide `/run/media`). Extension ID
+`ifmmgibjjcicnmfdkgbjbnkebofjdabc`, unpacked from `build/chrome`.
 
-## 2. Verified in a real browser
-
-Chromium `151.0.7922.173`, native via pacman — deliberately not flatpak, whose portal sandbox
-can hide `/run/media/…`. Extension ID `ifmmgibjjcicnmfdkgbjbnkebofjdabc`, loaded unpacked from
-`build/chrome`. Test keystore on `/tmp`, `keystoreId 431ae6d3…`.
-
-| Requirement | Evidence |
+| Verified | Detail |
 |---|---|
-| Detect device presence and file accessibility | all states reached: `READY`, `ABSENT`, `PERMISSION_REQUIRED`, `WRONG_DEVICE` |
-| Note when the device is unavailable | red `!` badge, amber banner, key list clears, all unprompted within the probe interval |
-| Refuse to operate without the device | encryption refused with "The USB keystore is not available. Connect the device to use your keys." |
-| **No crypto stored anywhere but the device** | a real key generated onto the device: `private.asc` 6,825 bytes / 1 block, `attributes.json` holding `default_key`. Profile grep for `BEGIN PGP` clean throughout; zero occurrences of `default_key` or the key fingerprint locally |
-| Offer to add a keystore when absent | setup card plus the Key Storage settings page |
-| Atomic writes | `.bak` rotation observed against the real File System Access API, not just the fake |
-| Recovery | key returns on its own after reconnect, via the periodic probe |
+| Keys stored only on the device | profile grep for `BEGIN PGP` clean throughout; no `default_key`, not even the fingerprint |
+| **Encrypt and decrypt with a device-resident key** | round-trips |
+| Provisioning | fresh, and adopt-over-existing via the override |
+| Physical removal | detected; both removal modes — contents gone, and mount point vanishing entirely |
+| Reconnect | keys return automatically, page lands on the key list |
+| Refusal when absent | clear "USB keystore is not available" |
+| **Hex directory names on a case-insensitive filesystem** | `6c6f63616c…` decodes to `localhost\|#\|mailvelope`; validates choosing hex over base64 |
+| `FileSystemFileHandle.move()` on FAT32 | works — no stray `.tmp` across many cycles |
+| Permission across a browser restart | **survives**, if the user takes Chrome's persistent option in the prompt |
+| Detection latency | ~1 s while a page is visible, 30 s alarm otherwise |
 
-## 3. Nine bugs found by running it
+### Not verified on Chrome
 
-None were caught by 597 passing tests or by review. Recording them because the ratio stayed
-roughly constant across the session, which suggests more remain.
+- **Torn write.** Literally yanking the stick inside a ~7 KB write is not achievable
+  by hand. Use the reproducible stand-in instead: `sudo mount -o remount,ro <mount>`,
+  attempt a key operation, confirm `private.asc` survives intact. Then remount `rw`.
+- **The `pwdCache` purge.** Unplug, replug, decrypt: it should *ask* for the
+  passphrase. Asserted in code, never observed.
+- **Migration.** `migrateLocalKeyMaterial()` deletes local keys after writing to the
+  device. Only ever tested against a fake backend. The riskiest untested code left.
+- **`WRONG_DEVICE`.** Needs a second stick or an edited `keystore.json`.
 
-1. **Destructive read.** A read that threw when the device was absent propagated into
-   `init()`'s catch, which *deletes the keyring from the attribute map*. Reads now degrade to
-   an empty keyring; writes still fail closed.
-2. **Destructive write, same consequence.** `sanitizeKeyring()` writes the keyring back, and
-   that write fails when the device is absent — reaching the same deletion by another route.
-   Now deferred until the device is attached.
-3. **No reload on return.** Nothing re-read the device when it came back, so the warning
-   cleared while the UI still showed no keys — indistinguishable from data loss.
-4. **Stale key list.** The keyring page only refreshed when the device returned, not when it
-   went away, so it kept listing keys it could no longer use.
-5. **The adopt flag defeated by a click event.** `onClick={this.handleChooseDirectory}` passed
-   React's event into a parameter named `adopt`, making it truthy on every pick and silently
-   disabling the identity guard added hours earlier. Now strictly coerced, in the component
-   *and* in the background, which is the actual security boundary.
-6. **The periodic probe never ran.** Its alarm listener was registered inside `state.init()`
-   after an `await`. An MV3 service worker only receives events whose listeners were added
-   during the initial synchronous evaluation of the script, so removal was only ever noticed at
-   startup or when the user forced a check. Now registered at module scope in `install.js`.
-   **No test can catch this** — jest's `chrome.alarms` mock accepts a late listener happily.
-7. **"key not found" instead of "device disconnected."** Honest at the keyring layer, badly
-   misleading at the user layer: for a keystore that is the only copy, it is the message most
-   likely to make someone believe the key is gone, or generate a replacement.
-8. **"Get started" in the toolbar menu** whenever the device was detached, inviting a user
-   whose key was safe on the device to generate a replacement.
-9. **Nested keystore.** Selecting the `mailvelope-keystore` folder itself — the only folder a
-   user can actually see when reconnecting — created a second keystore inside the first, and
-   provisioning silently minted a new identity, orphaning the original device.
+## 3. Firefox — host done, extension side untested
 
-### The pattern worth remembering
+Firefox has no File System Access API, no directory picker, and OPFS is not the
+device. A native messaging host is the only route.
 
-Bugs 1, 2, 4, 7 and 8 are all the same mistake: **an unreadable keystore being treated as an
-empty one.** That is the inherent cost of making reads degrade to empty rather than throw —
-which was the right call, since throwing deleted the keyring registry — but it pushes the
-burden onto every consumer that asks "do I have keys?". An audit fixed the known cases;
-`hasUsablePrivateKey`, the onboarding flow and the editor's recipient lookup are where to look
-next.
+### Done and tested
 
-## 4. Test coverage
+`native-host/mailvelope_usb_keystore.py` — Python 3, dependency-free, ~300 lines.
+Chosen for auditability: it runs outside the browser sandbox with the user's
+filesystem authority and handles private keys, so being readable in one sitting
+matters more than elegance.
 
-`src/modules/usb`: **80.8% statements**, `guard.js` and `handlers.js` at 100%, `router.js` 98%,
-`state.js` 91%, `install.js` 80%, `provision.js` 81%, `FsaBackend.js` 84%.
+Operations: `hello`, `listDevices`, `probe`, `read`, `write`, `remove`, `list`.
 
-`handleStore.js` is at 0% — testing IndexedDB needs a `fake-indexeddb` dependency that is not
-installed. It is however runtime-proven: the whole feature depends on it working.
+**`listDevices` is the answer to Firefox's missing picker** — the host enumerates
+mounted removable media and the UI offers a list. Arguably better than Chrome's
+picker, and it means the full device path is available to display, which the File
+System Access API deliberately withholds.
 
-Notable gaps: the *wiring* of the crypto gate is untested (`guard.test.js` covers the function,
-nothing asserts `pgpModel`'s five call sites invoke it), and `GenerateKey.js`'s upload default
-has no test — a component test there needs the port, keyring context and six children mocked.
+`native-host/test_host.py` — 17 tests, no dependencies, run with
+`python3 native-host/test_host.py`. Verified working against the real stick:
+read, write, remove, list, backup rotation, no staging files left behind.
 
-**Discipline that paid off:** every new test was checked by reverting the production change and
-confirming it fails. The first attempt at the GnuPG-exclusion tests passed while asserting
-nothing, because the module mocks made `gpgme` unavailable so `initGPG()` deleted that keyring
-regardless of USB mode. A new test that goes green on the first run deserves the revert check.
+**Security model.** The host is the most dangerous component here, so confinement is
+enforced *in the host*, not in the extension:
 
-## 5. Remaining work
+- a `root` must be under `/run/media`, `/media`, `/mnt` or `/Volumes` **and be an
+  actual mount point**
+- relative paths only, resolved through `realpath`, then checked to still be inside
+  the root — so `..` and symlinks cannot escape
+- writes restricted to seven known keystore filenames
+- reads and writes size-capped
 
-### Needs a real USB stick
+All confinement tests are load-bearing (disabling a check fails them).
 
-`/tmp` is tmpfs: RAM-backed, case-sensitive, fast, wiped on reboot. It cannot exercise:
+**The finding worth remembering:** the first version accepted `/run/media/<user>` —
+under an allowed prefix but *not* a mount point, and on local tmpfs. A keystore
+provisioned there would have left the keys on the machine while appearing to be on
+the device: this feature's central promise, inverted. Only the adversarial test
+caught it.
 
-- torn writes from pulling a device mid-save (the `.tmp` → verify → `.bak` → `move` path)
-- real removal timing and slow-media latency
-- case-insensitive filesystems (FAT32/exFAT) — the reason directory names are hex, not base64
-- the "mount point disappears entirely" removal mode (`/tmp` itself was picked, so only
-  "contents gone" is reachable — re-provision against a subdirectory to test both)
+`native-host/install.sh` — user-level only, no sudo. `--status`, `--uninstall`,
+`--chrome-id <id>` to also register for Chromium. Already installed on this machine
+for Firefox and Chromium.
 
-### One open decision
+### Built but never run
 
-`api.controller.hasPrivateKey` answers the **client API**, so a webmail provider asking "does
-this user have a key?" gets `false` while the device is detached. Recommendation after review:
-**leave it**, and note in the client-API JSDoc that these queries reflect currently-reachable
-keys. The dangerous outcome is already prevented — a provider that responds by prompting key
-generation gets a fail-closed write and a clear device error, so no replacement key can be
-created. Throwing instead would be more honest but would change behaviour for third-party
-integrations that cannot be tested from here.
+- `src/modules/usb/NativeBackend.js` — the five-method interface over
+  `chrome.runtime.sendNativeMessage`. One-shot rather than a long-lived
+  `connectNative` port: each operation is self-contained, and a process spawn is
+  inconsequential next to a USB read. Distinguishes "no helper installed" from "no
+  device", since those need different messages.
+- Backend selection in `state.js`: File System Access first, native host second.
+- `usb-list-devices` / `usb-select-device` port events, `listDevices()` /
+  `selectDevice()` in provision.
 
-### Not implemented
+### Firefox work still to do
 
-- Generate/import ordering is a nudge, not a gate. Nothing prevents generating a key *before*
-  provisioning a device, which lands in the §3.1 residue case. The background fails closed once
-  a keystore is configured, so this is UX rather than correctness.
-- LevelDB residue is unmeasured, so the overwrite-before-delete heuristic remains unjustified.
-- Phase 5: the Firefox native messaging host. Firefox reports `UNSUPPORTED` today.
+1. **Nothing calls the new events.** `KeyStorageSettings` still offers only the
+   directory picker, which does not exist in Firefox. It needs a device-list UI
+   driven by `usb-list-devices` + `usb-select-device` when `status.native` is true.
+2. **`nativeMessaging` permission is optional** and never requested. `General.js`
+   already has the request pattern (`chrome.permissions.request`) — copy it.
+3. **`isSupported()` in `FsaBackend` returns false on Firefox** (correct), so the
+   native backend is selected — but the Key Storage page still shows "this browser
+   cannot access a USB keystore", which will now be wrong once the UI is finished.
+4. **`NativeBackend` has 8% coverage.** Untested apart from what the host tests
+   cover on the other side of the protocol.
+5. **Then actually run it in Firefox**, which has never happened.
 
-### Still-open plan decisions
+### Firefox baseline, already verified
 
-- Probe interval — 1 min is the practical Chrome MV3 alarm floor.
-- Firefox: ship Chromium-only, or wait for the native host?
-- Should USB mode force `security.password_cache` off rather than only purging on removal?
+The current build loads cleanly in Firefox 154 with an **empty console**, correctly
+disables the USB option, and ordinary local-storage operation is unaffected. So the
+feature degrades safely today; the work above is additive.
 
-## 6. Working practices for the next session
+Load with a throwaway profile:
+`firefox --no-remote --profile /tmp/mvelo-ff-profile &` then
+`about:debugging#/runtime/this-firefox` → Load Temporary Add-on →
+`build/firefox/manifest.json`. (`web-ext run` does **not** work with Firefox 154 —
+`ECONNREFUSED` on the debugging port.)
 
-**Verify the build actually loaded.** `config/webpack.background.js:38` stamps dev builds with
-`${version} build: ${ISO timestamp}`, shown in the **footer, bottom-right of any Mailvelope
-Options page** (UTC). Reload, check the stamp matches, *then* test. Several rounds were wasted
-reasoning about behaviour from a stale bundle.
+## 4. Coverage
 
-**Never run `grunt` while the extension is loaded.** The default task runs `clean`, which
-deletes `build/`, invalidating the unpacked extension — Chromium then shows
-`ERR_FILE_NOT_FOUND` and the extension has to be reloaded or re-added. Use `grunt webpack:dev`
-mid-testing, or rebuild only between tests.
+`src/modules/usb`: 76% statements. `guard.js`, `constants.js`, `handlers.js` at
+100%, `router.js` 98%, `debugLog.js` 94%, `state.js` 90%, `FsaBackend.js` 85%,
+`install.js` 80%, `provision.js` 75%.
 
-**Grep for the field, not for a pattern you assume contains it.** Time was lost hunting a
-non-existent bug because `grep -rc` skipped LevelDB's `.log` as binary, and because the
-extraction pattern assumed a JSON key order that Chrome does not preserve.
+Weak spots: `NativeBackend.js` 8% (new, untested), `handleStore.js` 0% (IndexedDB,
+needs a `fake-indexeddb` dependency that is not installed — but runtime-proven,
+since the whole Chrome path depends on it).
 
-## 7. Environment gotcha for a fresh clone
+## 5. Bugs found by running it, not by testing it
 
-`npm ci` fails with `EALLOWGIT`: **npm 12 defaults `allow-git=none`**, and this project has two
-git dependencies (`gpgmejs`, `emailjs-mime-builder`) that the lockfile pins to `git+ssh://`.
-With no SSH keys present, both the policy and the transport need handling:
+Around a dozen, none caught by the test suite or by review. Several clustered into
+two families worth knowing about, because more probably remain:
+
+**"Unreadable read as empty."** Reads deliberately degrade to an empty keyring
+rather than throwing — because throwing made `keyring.init()` *delete the keyring
+from the attribute map*. That pushes the burden onto every consumer that asks "do I
+have keys?", and each one got it wrong differently: "key not found" instead of
+"device disconnected"; the toolbar menu offering "Get started"; the keyring page
+claiming no key pair; `hasAnyPrivateKey` mis-answering. Same root, four symptoms.
+
+**"UI trusting a status that arrived too early."** `transition()` notifies listeners
+synchronously, so anything asynchronous it triggers has not finished when a view
+reacts. Symptoms: the keyring page showing no keys after reconnect, the stale key
+list, and a sticky `/keyring/setup` route that no key arrival could clear.
+
+Two others worth singling out:
+
+- **The periodic probe never ran.** Its alarm listener was registered inside
+  `state.init()` after an `await`. An MV3 service worker only receives events whose
+  listeners were registered during the initial synchronous evaluation. **No test can
+  catch this** — jest's `chrome.alarms` mock accepts a late listener happily.
+- **A test that enforced a bug.** `usb-provision` dropped the `adopt` flag, making
+  the "use this folder anyway" override impossible, and the test asserted
+  `toHaveBeenCalledWith({label})` — passing *because* of the bug. A revert check
+  does not catch a wrong assertion, only a missing one.
+
+## 6. Open decisions
+
+- **client-API `hasPrivateKey`** reports `false` to a webmail page while the device
+  is detached. Recommendation after review: **leave it**, and note in the JSDoc that
+  these queries reflect currently-reachable keys. The dangerous outcome is already
+  prevented — a provider that responds by prompting key generation gets a
+  fail-closed write and a clear device error.
+- **`password_cache` in USB mode.** Recommendation, revised after seeing it in use:
+  **leave it on**. The USB-specific risk is already handled by the purge on removal;
+  what remains is the ordinary cache tradeoff, which USB storage does not change.
+- **Probe interval** — 30 s is Chrome's floor; 1 s polling while a page is visible.
+  Cost: a visible page keeps the device from idling.
+
+## 7. Working practices that cost time
+
+- **Check the build stamp before trusting behaviour.**
+  `config/webpack.background.js:38` stamps dev builds; it shows in the footer,
+  bottom-right of any Options page (UTC). Several rounds were spent reasoning about
+  a stale bundle.
+- **Never run `grunt` while the extension is loaded.** The default task runs `clean`,
+  which deletes `build/` and invalidates the unpacked extension —
+  Chromium then shows `ERR_FILE_NOT_FOUND`. Use `grunt webpack:dev tmp2browser`
+  mid-testing.
+- **Do not disable a security guard against a real device.** Verifying the host's
+  confinement tests were load-bearing wrote a file to the user's stick, because the
+  test that was supposed to be blocked then succeeded. Use a scratch mount.
+- **Grep for the field, not for a pattern you assume contains it.** Time was lost
+  hunting a non-existent bug because `grep -rc` skipped LevelDB's `.log` as binary,
+  and because an extraction pattern assumed a JSON key order Chrome does not
+  preserve.
+
+## 8. Environment
+
+`npm ci` fails with `EALLOWGIT`: **npm 12 defaults `allow-git=none`**, and two
+dependencies (`gpgmejs`, `emailjs-mime-builder`) are pinned to `git+ssh://` with no
+SSH keys present:
 
 ```
 GIT_CONFIG_COUNT=2 \
@@ -172,6 +221,9 @@ GIT_CONFIG_KEY_1=url.https://github.com/.insteadOf GIT_CONFIG_VALUE_1=git+ssh://
 npm ci --allow-git=root
 ```
 
-`allow-git=root` permits only git deps declared in this project's own `package.json`, narrower
-than `all`. `.npmrc` is gitignored (line 98), so it can be made permanent there without
-touching the repo.
+`.npmrc` is gitignored, so `allow-git=root` can be made permanent there.
+
+Also note the kernel-module trap that stopped USB detection entirely: a
+`linux-cachyos` upgrade removed the running kernel's module tree, so `usb-storage`
+could not load and no `/dev/sd*` appeared. A reboot fixed it. If a stick enumerates
+in `dmesg` but no block device appears, check `/lib/modules/$(uname -r)` exists.

--- a/doc/usb-keystore-status.md
+++ b/doc/usb-keystore-status.md
@@ -8,9 +8,9 @@ device through the File System Access API; Firefox reaches the same device throu
 native messaging host. The same physical keystore has been read by both, and neither
 browser profile holds key material.
 
-Branch `feature/usb-keystore`, **37 commits** ahead of `master` (`ffaa27af`), working
-tree clean. Unit suite: **659 tests, 38 suites**. Native host: **17 tests**.
-`grunt eslint` clean. Both bundles build.
+Branch `feature/usb-keystore`, **37 commits** ahead of `master` (`ffaa27af`). Unit
+suite: **671 tests, 40 suites**. Native host: **35 tests**. `grunt eslint` clean. Both
+bundles build.
 
 ## 1. What has been verified on real hardware
 
@@ -57,11 +57,22 @@ share. No install step.
 
 **Firefox** has no picker, and OPFS is not the device, so a native messaging host is
 the only route. `native-host/mailvelope_usb_keystore.py` — Python 3,
-dependency-free, ~300 lines, chosen for auditability: it runs outside the browser
+dependency-free, ~400 lines, chosen for auditability: it runs outside the browser
 sandbox with the user's filesystem authority and handles private keys, so being
 readable in one sitting matters more than elegance.
 
-Operations: `hello`, `listDevices`, `probe`, `read`, `write`, `remove`, `list`.
+Operations: `hello`, `listDevices`, `probe`, `read`, `write`, `remove`, `list`. The
+host lives in this repo and the manifest points at the checkout, so it and the
+extension always ship together — the protocol has no compatibility story and needs
+none.
+
+**Both directions are chunked**, because a browser drops a message *from* a native
+host that exceeds 1 MB before the extension sees it. That cap is the browser's, not
+the host's: it cannot be raised, only stayed under. A whole keyring is one file here,
+so `read` takes a byte offset and returns one 384 KB chunk plus `nextOffset`/`eof`,
+and `write` takes a byte offset and a `final` flag, appending chunks to one staging
+file that is fsynced and renamed into place on the last one. The atomicity guarantee
+is unchanged, and a write small enough to fit in one message still sends one message.
 
 Two things the host path does *better* than the in-browser one:
 
@@ -84,7 +95,7 @@ enforced *in the host*, never in the extension:
 - relative paths only, resolved through `realpath`, then re-checked to be inside the
   root — so `..` and symlinks cannot escape
 - writes restricted to seven known keystore filenames
-- reads and writes size-capped
+- reads and writes size-capped: 16 MB per file, 4 MB per inbound message
 
 All confinement tests are load-bearing.
 
@@ -142,7 +153,20 @@ heading said "Set up the device first" in every case it could render, though
 `isUnavailable()` requires an enabled keystore — so a profile without one never
 reaches it. Both now derive their text from `describeState()`.
 
-Four singular ones worth keeping:
+Singular ones worth keeping:
+
+- **A keyring larger than one native message could be neither saved nor read.**
+  Importing a public keyring exported with `gpg --export --armor` failed with
+  `message of 1392580 bytes exceeds the limit`: the whole keyring is a single
+  `public.asc`, rewritten in full on every change, and it went to the host in one
+  message. Splitting the import would only have deferred it — and the read direction
+  was worse, since the *browser* discards a host message over 1 MB, so a keyring that
+  size could never have been read back even if it had been written. Both directions
+  are chunked now. The same request also desynchronised the host for the rest of the
+  session: the refused message's body was left in the pipe, so the next read took
+  message bytes for a length header and every later request failed for an
+  unrelated-looking reason. Neither half was reachable in testing, because every test
+  keyring held one or two keys.
 
 - **Migration overwrote an existing keystore.** Migrating local keys onto a device
   that already held a keystore replaced it. Recovered by union from `.bak`; both keys
@@ -190,8 +214,10 @@ Weak spots, in the order worth addressing:
 
 - `KeyStorageSettings.js` **2%** — the largest untested component, and the one that
   performs provisioning. Runtime-exercised heavily, but a regression here is silent.
-- `NativeBackend.js` **55%** — the file operations are covered from the host side
-  only, so the two halves of the protocol are never tested against each other.
+- `NativeBackend.js` — the chunked read and write paths are now driven against a fake
+  host that implements the offset protocol (`NativeBackend.chunking.test.js`), so the
+  two halves finally meet. `probe`, `listDevices` and the absence codes are still
+  covered from the host side only.
 - `handleStore.js` **0%** — IndexedDB, needs a `fake-indexeddb` dependency that is
   not installed. Runtime-proven, since the whole Chrome path depends on it.
 - `UsbErrorToast.js` **5%**, `UsbStatusBanner.js` **17%** — the global rejection

--- a/doc/usb-keystore-status.md
+++ b/doc/usb-keystore-status.md
@@ -9,7 +9,7 @@ native messaging host. The same physical keystore has been read by both, and nei
 browser profile holds key material.
 
 Branch `feature/usb-keystore`, **42 commits** ahead of `master` (`ffaa27af`). Unit
-suite: **682 tests, 43 suites**. Native host: **35 tests**. `grunt eslint` clean. Both
+suite: **682 tests, 43 suites**. Native host: **37 tests**. `grunt eslint` clean. Both
 bundles build.
 
 ## 1. What has been verified on real hardware
@@ -129,6 +129,11 @@ sudo mount -t tmpfs -o size=16M,uid=$(id -u),gid=$(id -g) tmpfs /run/media/$USER
 It satisfies the host's mount-point requirement, `umount` simulates removal, and
 remounting `-o ro` simulates write protection.
 
+`native-host/test_host.py` needs one of these: its device tests write and delete
+files on whatever removable device it finds, so it skips any device that already
+holds a `mailvelope-keystore` directory rather than treating someone's keys as a
+fixture.
+
 ## 4. Bugs found by running it, not by testing it
 
 Around twenty, almost none caught by the test suite or by review. They cluster, and
@@ -155,6 +160,23 @@ heading said "Set up the device first" in every case it could render, though
 reaches it. Both now derive their text from `describeState()`.
 
 Singular ones worth keeping:
+
+- **A new helper and an old extension truncated a keyring in silence.** The helper is
+  a file on disk that the manifest points at, so pulling the branch updates it
+  immediately; the extension is a bundle that only changes when someone runs `grunt`.
+  For a while both were true at once, and the pair degraded quietly in both
+  directions: the old bundle's write sent a whole 1.3 MB keyring in one message,
+  which the new helper accepted because its inbound cap had been raised — so the
+  import error disappeared *without a rebuild*, which is exactly what makes the state
+  hard to notice. Its read then asked for the whole file and got the first 384 KiB
+  chunk, and 412 keys showed up as 132. The reported symptom was "keys from after
+  2018 are missing", because a `gpg --export` is roughly chronological and the cut
+  fell mid-keyring. The helper now refuses a whole-file request for a file that needs
+  chunks (`needs_chunked_read`) rather than answering with a prefix: never hand back
+  part of a file to a caller that asked for all of it. **The protocol-version check
+  exists for exactly this and was deliberately not used**, on the reasoning that host
+  and extension ship together from one repo — true of the source, not of the built
+  bundle.
 
 - **A reloaded keyring was visible while it was still filling up.** Reloading a
   keyring means `keystore.clear()` then `keystore.load()`, at both call sites. With

--- a/doc/usb-keystore-status.md
+++ b/doc/usb-keystore-status.md
@@ -8,8 +8,8 @@ device through the File System Access API; Firefox reaches the same device throu
 native messaging host. The same physical keystore has been read by both, and neither
 browser profile holds key material.
 
-Branch `feature/usb-keystore`, **37 commits** ahead of `master` (`ffaa27af`). Unit
-suite: **671 tests, 40 suites**. Native host: **35 tests**. `grunt eslint` clean. Both
+Branch `feature/usb-keystore`, **42 commits** ahead of `master` (`ffaa27af`). Unit
+suite: **678 tests, 42 suites**. Native host: **35 tests**. `grunt eslint` clean. Both
 bundles build.
 
 ## 1. What has been verified on real hardware
@@ -190,7 +190,11 @@ Singular ones worth keeping:
   this machine used, not the key -- but the requirement is that no crypto information
   lives outside the device. The cache is now refused while a keystore is configured.
   Found by grepping the profile *after* believing the work was finished, which is the
-  argument for doing that at the end of every session rather than at the start.
+  argument for doing that at the end of every session rather than at the start. The
+  Security page was taught to disable the setting and explain why, but the passphrase
+  dialog's own "remember password" box was missed and kept offering itself, checked,
+  while caching nothing — the same class of bug as the one the fix set out to avoid,
+  one surface further on. Both now read the same answer from the controller.
 - **Errors thrown into nothing.** The keyring UI's shape for key operations is
   "swallow a cancelled password dialog, rethrow the rest", and in an async handler a
   rethrow is an unhandled rejection. Eight call sites do this. Harmless while writes

--- a/doc/usb-keystore-status.md
+++ b/doc/usb-keystore-status.md
@@ -9,7 +9,7 @@ native messaging host. The same physical keystore has been read by both, and nei
 browser profile holds key material.
 
 Branch `feature/usb-keystore`, **42 commits** ahead of `master` (`ffaa27af`). Unit
-suite: **682 tests, 43 suites**. Native host: **37 tests**. `grunt eslint` clean. Both
+suite: **684 tests, 43 suites**. Native host: **37 tests**. `grunt eslint` clean. Both
 bundles build.
 
 ## 1. What has been verified on real hardware
@@ -177,6 +177,15 @@ Singular ones worth keeping:
   exists for exactly this and was deliberately not used**, on the reasoning that host
   and extension ship together from one repo — true of the source, not of the built
   bundle.
+
+  The other half of the lesson is that nothing in the UI could have shown it. A
+  keyring that arrives in part looks like a smaller keyring: the key list, the badge
+  and the device status were all consistent with it. Key Storage now reports the keys
+  on the device beside the keys the extension actually loaded, and says so in red when
+  they differ — the one number that makes a truncated read self-evident. It costs a
+  full read of the key files, so the settings page asks for it when the device state
+  changes rather than on its one-second poll (which had been re-running the whole
+  diagnostics panel, and the local-storage scan with it, every second).
 
 - **A reloaded keyring was visible while it was still filling up.** Reloading a
   keyring means `keystore.clear()` then `keystore.load()`, at both call sites. With

--- a/doc/usb-keystore-status.md
+++ b/doc/usb-keystore-status.md
@@ -1,0 +1,162 @@
+# USB Keystore — Status and Handoff
+
+Re-verified 2026-08-22 from primary evidence (git, test runs, on-disk artefacts) rather than
+from recollection. That round found and fixed a destructive bug and closed three of the five
+implementation gaps — see §4. Companion to [usb-keystore-plan.md](usb-keystore-plan.md), which
+holds the design and its rationale.
+
+Branch `feature/usb-keystore`, 2 commits ahead of `master` (`ffaa27af`):
+
+| Commit | Contents |
+|---|---|
+| `fd2450c6` | Add USB-resident keystore modules, UI and tests — 19 new files, +2,874 |
+| `6a5330e7` | Wire the USB keystore into existing entry points — 11 files, +31/-2 |
+
+Split so the first can never conflict on a rebase onto upstream (all new paths) and only the
+second needs attention. Keep that split. **Uncommitted work from 2026-08-22 sits on top** (§4);
+the hook footprint has grown beyond +31/-2 because `keyring.js` is now touched.
+
+17 source files (11 in `src/modules/usb`, 6 in `src/components/usb`) and 4 test files.
+
+## 1. Verified — automated and reproducible
+
+| What | Evidence |
+|---|---|
+| Unit tests | 519 tests, 26 suites, 0 failures (`jest --selectProjects unit`) |
+| No regression | count includes every pre-existing suite |
+| Router enforcement | `router.test.js`, 20 assertions: classification, hex encoding, attribute split/merge, leak safety net, serialization |
+| Availability state machine | `state.test.js`, 21 assertions against a fake backend: every transition, `assertUsable` re-probe semantics, listeners, recovery to READY |
+| Storage interception | `install.test.js`, 19 assertions: device vs local routing, attribute splitting, fail-closed writes, degraded reads, leak block, purge on device loss, badge arbitration |
+| **Requirement 3 as a test** | `install.test.js` "storage audit": after a scripted session, no armored key and no crypto attribute field (`default_key`, `primary_key`, `sync_data`, `key_binding`) appears in local storage — and it is all on the device instead |
+| Guards | `guard.test.js`, 10 assertions: remote-upload refusal, passphrase requirement, error codes |
+| GnuPG exclusion | 3 assertions in `keyring.test.js`, proven non-vacuous by reverting the production change and watching them fail |
+| Lint | `grunt eslint` exits `Done.` |
+| Compiles | app, background and all 11 component webpack bundles build |
+| No SW-illegal code | background bundle emits no extra chunks and contains no `importScripts`, so no dynamic-import splitting survived |
+
+## 2. Verified — runtime, from on-disk artefacts
+
+| What | Evidence |
+|---|---|
+| **An FSA handle from IndexedDB works in the MV3 service worker** | `/tmp/mailvelope-keystore/keystore.json` exists (`keystoreId 431ae6d3…`, version 1, label `tmp`), written by `provision()` in the background using a handle the app page stored in IndexedDB. Build timestamp 17:42 precedes the file's 17:53, so this was current code. **The planned offscreen-document fallback is not needed.** |
+| Provisioning end-to-end | same artefact: picker → IndexedDB → port message → background write |
+| Handle persists in IndexedDB | `chrome-extension_ifmmgibjjcicnmfdkgbjbnkebofjdabc_0.indexeddb.leveldb`, 28K |
+| USB mode still active | `mvelo.usb.config` holds `keystoreId 431ae6d3…`, no key material |
+| Opt-in gating | local store holds `mvelo.keyring.…{public,private}Keys` as `[]`, written during keyring init *before* provisioning: until a keystore is configured the wrapper passes through to local, as intended |
+| Attribute split | local `mvelo.keyring.attributes` is `{"localhost|#|mailvelope":{"sanitized":true}}` — registry and non-crypto flags only |
+| **No key material on local disk** | `grep -rl "BEGIN PGP"` across the whole `Local Extension Settings` tree: clean |
+
+Environment: Chromium `151.0.7922.173` (native via pacman — deliberately not flatpak, whose
+portal sandbox can hide `/run/media/…` and would confound results). Extension ID
+`ifmmgibjjcicnmfdkgbjbnkebofjdabc`, loaded unpacked from `build/chrome`.
+
+## 3. Not verified
+
+### Covered by unit tests, never seen in a real browser
+
+`/tmp/mailvelope-keystore` holds 1 file and 0 keyring directories, so **no key has ever been
+written to the device.** These behaviours are asserted against a fake backend but have never
+run against the real File System Access API:
+
+- key generation onto the device — nothing has ever written `private.asc`
+- transition to `ABSENT` on removal, and the badge, banner and refusal that follow
+- purge of in-memory keyrings and the passphrase cache
+- return to `READY`, and `WRONG_DEVICE`
+- fail-closed writes
+- badge arbitration against `uiLog`
+
+### Not covered at all
+
+- **Permission persistence across a browser restart** — Phase 0's second question, still open.
+  Cannot be told from disk: config and handle both persist, but whether the *grant* does needs
+  the UI. Restart Chromium only, never the machine: `/tmp` is tmpfs.
+- **`provision.js`** — `provision()`, `migrateLocalKeyMaterial()`, `inspectLocalKeyMaterial()`
+  and `diagnostics()` have no unit tests. Provisioning is known to work from the manual run;
+  migration is entirely unexercised.
+- **UI components** — no rendering tests for any of `src/components/usb/`.
+
+### Cannot be tested on `/tmp` at all
+
+`/tmp` is tmpfs: RAM-backed, case-sensitive, fast, wiped on reboot. It cannot exercise torn
+writes from pulling a device mid-save (the `.tmp` → verify → `.bak` → `move` path), real removal
+timing, case-insensitive filesystems (FAT32/exFAT — the reason for hex rather than base64
+directory names), or the "mount point disappears entirely" removal mode (`/tmp` itself was
+picked, so only "contents gone" is reachable — re-provision against `/tmp/usbtest` for both).
+
+**A real USB stick is required before this feature can be called done.**
+
+### Still not implemented
+
+| Gap | Plan ref | Consequence |
+|---|---|---|
+| Generate/import not gated behind device setup | §3.2.1 | `UsbSetupCard` offers the option but nothing enforces ordering: generating *before* provisioning writes a key locally and lands in the §3.1 residue case. `strings.generate_first_*` exists and is unused. The background now fails closed, so this is a UX ordering problem rather than a correctness hole |
+| LevelDB residue not measured | §3.1 | migration residue severity unquantified; the overwrite-before-delete heuristic is unjustified either way |
+
+## 4. Changed on 2026-08-22 (uncommitted)
+
+### Bug found and fixed: a destructive read path
+
+`wrappedGet` threw when the device was absent. `keyring.init()` wraps `buildKeyring()` in a
+`try/catch` that **deletes the keyring from the attribute map** on failure
+([keyring.js:116](../src/modules/keyring.js#L116)), so starting the browser with the device
+unplugged would deregister the keyring — recoverable for the main keyring, permanent for
+client-API keyrings, whose keys would then be stranded on the device.
+
+`readDevice` now degrades to `undefined` (an empty keyring) instead of throwing, which is what
+the plan intended and what the SPLIT branch already did. Writes still fail closed, so reading
+empty and storing it back cannot destroy anything. Two tests in `install.test.js` cover it.
+
+Found by writing the test, not by review — none of that code had ever executed.
+
+### Gaps closed
+
+- **Passphrase required in USB mode** (§3.2). Enforced in the background at *both* entry points,
+  `app.controller.generateKey` and the client-API-driven `privateKey.controller.generateKey`, so
+  a webmail page cannot bypass it. Code `USB_KEYSTORE_PASSPHRASE_REQUIRED`. `GenerateKey.js`
+  already required a non-empty password, but that was UI-only validation.
+- **GnuPG keyring hidden in USB mode** (§9.2). Excluded from `getPreferredKeyringQueue()`,
+  `getAll()` and `getAllKeyringAttr()`, so it leaves key selection *and* the keyring selector.
+  This required touching `keyring.js`, previously untouched on purpose.
+- **Storage-audit test** (Phase 4). Requirement 3 is now asserted rather than claimed.
+
+### A note on the first attempt at the GnuPG tests
+
+They passed while asserting nothing: the module-level mocks make `gpgme` unavailable, so
+`initGPG()` deleted the GnuPG keyring regardless of USB mode. Rewritten with per-case
+`jest.doMock` (including `__esModule: true`, without which babel's interop breaks `new`), and
+with `chrome.storage.session` seeded so `init()` *awaits* `initGPG()` instead of firing and
+forgetting it. Then verified by reverting the production change and confirming they fail.
+
+Worth remembering as a pattern: a new test that passes immediately against code it is supposed
+to be exercising deserves the revert check.
+
+## 5. Still-open decisions (plan §9)
+
+- Probe interval — 1 min is the practical Chrome MV3 alarm floor.
+- Firefox: ship Chromium-only with `UNSUPPORTED`, or wait for the Phase 5 native host?
+- Should USB mode force `security.password_cache` off rather than only purging on removal?
+  Leaning yes: caching decrypted keys undercuts the point of removing the device.
+
+## 6. Minor
+
+Stale empty `mvelo.keyring.*.{public,private}Keys` entries remain in local storage after
+switching to USB. Harmless (`[]`) but `inspectLocalKeyMaterial()` will report them; decide
+whether provisioning should clean them up.
+
+## 7. Environment gotcha for a fresh clone
+
+`npm ci` fails with `EALLOWGIT`: **npm 12 defaults `allow-git=none`**, and this project has two
+git dependencies (`gpgmejs`, `emailjs-mime-builder`) that the lockfile pins to `git+ssh://`.
+There are no SSH keys on this machine, so both the policy and the transport need handling:
+
+```
+GIT_CONFIG_COUNT=2 \
+GIT_CONFIG_KEY_0=url.https://github.com/.insteadOf GIT_CONFIG_VALUE_0=ssh://git@github.com/ \
+GIT_CONFIG_KEY_1=url.https://github.com/.insteadOf GIT_CONFIG_VALUE_1=git+ssh://git@github.com/ \
+npm ci --allow-git=root
+```
+
+`allow-git=root` permits only git deps declared in this project's own `package.json`, narrower
+than `all`. `.npmrc` is gitignored (line 98), so it can be made permanent there without touching
+the repo. `allow-remote` is not a problem — all 1,353 other packages resolve to
+`registry.npmjs.org`.

--- a/doc/usb-keystore-status.md
+++ b/doc/usb-keystore-status.md
@@ -20,7 +20,7 @@ flatpak's portal sandbox can hide `/run/media`) and Firefox `154`.
 
 | Verified | Detail |
 |---|---|
-| Keys stored only on the device | profile grep for `BEGIN PGP` clean throughout; no `default_key`, not even the fingerprint |
+| Keys stored only on the device | no private key bytes in either profile, checked by grepping both for 40-char slices of the real armored keys; no passphrase on disk |
 | Encrypt and decrypt with a device-resident key | round-trips, both browsers |
 | Provisioning | fresh, and adopt-over-existing via the override |
 | **Cross-browser portability** | one keystore, read by Chrome via FSA and by Firefox via the host, no key material in either profile |
@@ -156,6 +156,17 @@ Four singular ones worth keeping:
   "use this folder anyway" override impossible, and the test asserted
   `toHaveBeenCalledWith({label})` — passing *because* of the bug. A revert check does
   not catch a wrong assertion, only a missing one.
+- **The passphrase cache wrote a key fingerprint to disk.** Caching an entry makes
+  `chrome.alarms` hold an alarm named `PWD_ALARM_<full fingerprint>`, and Chrome
+  persists alarm names to `Extension State/` with `persistAcrossSessions`. Both our
+  purge and upstream's own timeout clear the alarm correctly, but LevelDB is
+  append-only, so the fingerprint stayed readable in the log seven hours after the
+  alarm had fired. Upstream behaviour, and `password_cache` defaults to `true`, so it
+  affected every USB user. Metadata rather than key material -- it records which key
+  this machine used, not the key -- but the requirement is that no crypto information
+  lives outside the device. The cache is now refused while a keystore is configured.
+  Found by grepping the profile *after* believing the work was finished, which is the
+  argument for doing that at the end of every session rather than at the start.
 - **Errors thrown into nothing.** The keyring UI's shape for key operations is
   "swallow a cancelled password dialog, rethrow the rest", and in an async handler a
   rethrow is an unhandled rejection. Eight call sites do this. Harmless while writes
@@ -193,10 +204,14 @@ Weak spots, in the order worth addressing:
   reflect currently-reachable keys. The dangerous outcome is already prevented — a
   provider that responds by prompting key generation gets a fail-closed write and a
   clear device error.
-- **`password_cache` in USB mode.** Recommendation, now that the purge has been
-  observed working: **leave it on**. Cached material does not survive removal, so it
-  cannot outlive the device; what remains is the ordinary cache tradeoff, which USB
-  storage does not change.
+- ~~**`password_cache` in USB mode.**~~ **Decided: off while a keystore is
+  configured.** An earlier recommendation to leave it on was made before checking what
+  caching writes to disk -- it names an alarm after the key fingerprint, which Chrome
+  persists. `pwdCache.set()` now returns early when a keystore is configured, gated
+  there rather than at the `active` check in `unlock()` because
+  `privateKey.controller` calls `set()` directly and would bypass that. The stored
+  preference is deliberately left as the user set it, so disabling the USB keystore
+  restores their own choice; the Security page disables the control and says why.
 - **Probe interval** — 30 s is Chrome's alarm floor; 1 s polling while a page is
   visible. Cost: a visible page keeps the device from idling.
 
@@ -217,6 +232,12 @@ Weak spots, in the order worth addressing:
   and because an extraction pattern assumed a JSON key order Chrome does not preserve.
 - **A passing test can be enforcing the bug.** Read the assertion, not just the
   result.
+- **Grep the browser profile before calling it done, not just after a change.** The
+  fingerprint leak was found by a final sweep, hours after the feature was believed
+  finished. It also produces false alarms worth knowing about: `BEGIN PGP PRIVATE`
+  matches in `Service Worker/ScriptCache` are openpgp.js armor constants inside our own
+  bundled script, not stored keys. Distinguish them by grepping for slices of the
+  actual key material, which is the only check that answers the question.
 
 ## 8. Environment
 

--- a/doc/usb-keystore-status.md
+++ b/doc/usb-keystore-status.md
@@ -1,96 +1,92 @@
 # USB Keystore — Status and Handoff
 
-Paused 2026-08-23, mid-way through Firefox support. Companion to
-[usb-keystore-plan.md](usb-keystore-plan.md), which holds the original design.
+Companion to [usb-keystore-plan.md](usb-keystore-plan.md), which holds the original
+design and the reasoning behind it. This file is the state of the work.
 
-**Chrome/Chromium is done and verified on real hardware. Firefox is half-built** —
-the native messaging host works and is tested; the extension side is wired but has
-never been run.
+**Both browsers are done and verified on real hardware.** Chrome/Chromium reaches the
+device through the File System Access API; Firefox reaches the same device through a
+native messaging host. The same physical keystore has been read by both, and neither
+browser profile holds key material.
 
-Branch `feature/usb-keystore`, **25 commits** ahead of `master` (`ffaa27af`).
-Unit suite: **611 tests, 33 suites**. Native host: **17 tests**. `grunt eslint`
-clean. Both browser bundles build.
+Branch `feature/usb-keystore`, **37 commits** ahead of `master` (`ffaa27af`), working
+tree clean. Unit suite: **659 tests, 38 suites**. Native host: **17 tests**.
+`grunt eslint` clean. Both bundles build.
 
-## 1. Uncommitted work — read this first
-
-```
- M src/modules/usb/handlers.js          usb-list-devices, usb-select-device
- M src/modules/usb/provision.js         listDevices(), selectDevice()
- M src/modules/usb/state.js             backend selection, usesNativeHost(), devicePath
- M test/unit/modules/usb/handlers.test.js
-?? native-host/                          the host, its tests, install script
-?? src/modules/usb/NativeBackend.js
-```
-
-All of it passes tests and lints, but **none of the extension-side Firefox code has
-ever executed**. Commit it as a work-in-progress or keep it in the tree; either way
-do not mistake "tests pass" for "it works".
-
-## 2. Chrome — verified on a real USB stick
+## 1. What has been verified on real hardware
 
 SanDisk Cruzer Blade, **FAT32, confirmed case-insensitive**, mounted at
 `/run/media/noamr/5AE6-4898`. Chromium `151.0.7922.173` (native, not flatpak —
-flatpak's portal sandbox can hide `/run/media`). Extension ID
-`ifmmgibjjcicnmfdkgbjbnkebofjdabc`, unpacked from `build/chrome`.
+flatpak's portal sandbox can hide `/run/media`) and Firefox `154`.
 
 | Verified | Detail |
 |---|---|
 | Keys stored only on the device | profile grep for `BEGIN PGP` clean throughout; no `default_key`, not even the fingerprint |
-| **Encrypt and decrypt with a device-resident key** | round-trips |
+| Encrypt and decrypt with a device-resident key | round-trips, both browsers |
 | Provisioning | fresh, and adopt-over-existing via the override |
+| **Cross-browser portability** | one keystore, read by Chrome via FSA and by Firefox via the host, no key material in either profile |
 | Physical removal | detected; both removal modes — contents gone, and mount point vanishing entirely |
 | Reconnect | keys return automatically, page lands on the key list |
-| Refusal when absent | clear "USB keystore is not available" |
-| **Hex directory names on a case-insensitive filesystem** | `6c6f63616c…` decodes to `localhost\|#\|mailvelope`; validates choosing hex over base64 |
+| Refusal when absent | clear "USB keystore is not available", raised *before* any passphrase prompt |
+| **Passphrase and unlocked-key purge on removal** | unplug, replug, decrypt → prompts again, so neither outlives the device |
+| **`WRONG_DEVICE`** | keys physically present and readable stay hidden; identity gates access, not readability |
+| **`READ_ONLY`** | write-protected device keeps keys readable and decryption working, refuses changes, disables the controls that would make them |
+| Hex directory names on a case-insensitive filesystem | `6c6f63616c…` decodes to `localhost\|#\|mailvelope`; validates hex over base64 |
 | `FileSystemFileHandle.move()` on FAT32 | works — no stray `.tmp` across many cycles |
 | Permission across a browser restart | **survives**, if the user takes Chrome's persistent option in the prompt |
 | Detection latency | ~1 s while a page is visible, 30 s alarm otherwise |
+| Migration of local keys onto a device that already has a keystore | merges both key sets; see §4 |
 
-### Not verified on Chrome
+### Still not verified
 
-- **Torn write.** Literally yanking the stick inside a ~7 KB write is not achievable
-  by hand. Use the reproducible stand-in instead: `sudo mount -o remount,ro <mount>`,
-  attempt a key operation, confirm `private.asc` survives intact. Then remount `rw`.
-- **The `pwdCache` purge.** Unplug, replug, decrypt: it should *ask* for the
-  passphrase. Asserted in code, never observed.
-- **Migration.** `migrateLocalKeyMaterial()` deletes local keys after writing to the
-  device. Only ever tested against a fake backend. The riskiest untested code left.
-- **`WRONG_DEVICE`.** Needs a second stick or an edited `keystore.json`.
+- **Torn write.** Yanking the stick inside a ~7 KB write is not achievable by hand.
+  The read-only stand-in (`mount -o remount,ro`) was run and found five bugs, but it
+  exercises *refused* writes, not *interrupted* ones. The atomic-write path —
+  stage, fsync, rotate to `.bak`, rename — is therefore reasoned about rather than
+  observed. A scripted `usbreset` or a QEMU passthrough device could close this.
+- **A genuinely second device.** `WRONG_DEVICE` was reached by editing the marker's
+  `keystoreId`, which is what the extension actually checks, so the state machine is
+  covered. Untested is the surrounding case: two sticks whose keystores are both
+  real, and switching between them.
 
-## 3. Firefox — host done, extension side untested
+## 2. How each browser reaches the device
 
-Firefox has no File System Access API, no directory picker, and OPFS is not the
-device. A native messaging host is the only route.
+**Chromium** uses the File System Access API. `showDirectoryPicker()` for setup, and
+the handle is persisted in IndexedDB — it is structured-cloneable but cannot cross
+`chrome.runtime` messaging, so IndexedDB is what the app page and the service worker
+share. No install step.
 
-### Done and tested
-
-`native-host/mailvelope_usb_keystore.py` — Python 3, dependency-free, ~300 lines.
-Chosen for auditability: it runs outside the browser sandbox with the user's
-filesystem authority and handles private keys, so being readable in one sitting
-matters more than elegance.
+**Firefox** has no picker, and OPFS is not the device, so a native messaging host is
+the only route. `native-host/mailvelope_usb_keystore.py` — Python 3,
+dependency-free, ~300 lines, chosen for auditability: it runs outside the browser
+sandbox with the user's filesystem authority and handles private keys, so being
+readable in one sitting matters more than elegance.
 
 Operations: `hello`, `listDevices`, `probe`, `read`, `write`, `remove`, `list`.
 
-**`listDevices` is the answer to Firefox's missing picker** — the host enumerates
-mounted removable media and the UI offers a list. Arguably better than Chrome's
-picker, and it means the full device path is available to display, which the File
-System Access API deliberately withholds.
+Two things the host path does *better* than the in-browser one:
 
-`native-host/test_host.py` — 17 tests, no dependencies, run with
-`python3 native-host/test_host.py`. Verified working against the real stick:
-read, write, remove, list, backup rotation, no staging files left behind.
+- **`listDevices` replaces the missing picker** by enumerating mounted removable
+  media, so the UI offers a list of actual devices rather than a file dialog.
+- **The real path is available to display.** The File System Access API deliberately
+  withholds it, so Chrome can only show the folder name.
+- **`probe` reports writability directly**, which is the only way to know a device is
+  write-protected *before* attempting a write. The FSA path can only discover it by
+  failing, so there `READ_ONLY` is reached reactively.
+
+Install with `native-host/install.sh` — user-level, no sudo. `--status`,
+`--uninstall`, `--chrome-id <id>` to also register for Chromium.
 
 **Security model.** The host is the most dangerous component here, so confinement is
-enforced *in the host*, not in the extension:
+enforced *in the host*, never in the extension:
 
 - a `root` must be under `/run/media`, `/media`, `/mnt` or `/Volumes` **and be an
   actual mount point**
-- relative paths only, resolved through `realpath`, then checked to still be inside
-  the root — so `..` and symlinks cannot escape
+- relative paths only, resolved through `realpath`, then re-checked to be inside the
+  root — so `..` and symlinks cannot escape
 - writes restricted to seven known keystore filenames
 - reads and writes size-capped
 
-All confinement tests are load-bearing (disabling a check fails them).
+All confinement tests are load-bearing.
 
 **The finding worth remembering:** the first version accepted `/run/media/<user>` —
 under an allowed prefix but *not* a mount point, and on local tmpfs. A keystore
@@ -98,115 +94,129 @@ provisioned there would have left the keys on the machine while appearing to be 
 the device: this feature's central promise, inverted. Only the adversarial test
 caught it.
 
-`native-host/install.sh` — user-level only, no sudo. `--status`, `--uninstall`,
-`--chrome-id <id>` to also register for Chromium. Already installed on this machine
-for Firefox and Chromium.
+## 3. Testing either browser
 
-### Built but never run
+Chromium: load `build/chrome` unpacked. Firefox, with a throwaway profile:
 
-- `src/modules/usb/NativeBackend.js` — the five-method interface over
-  `chrome.runtime.sendNativeMessage`. One-shot rather than a long-lived
-  `connectNative` port: each operation is self-contained, and a process spawn is
-  inconsequential next to a USB read. Distinguishes "no helper installed" from "no
-  device", since those need different messages.
-- Backend selection in `state.js`: File System Access first, native host second.
-- `usb-list-devices` / `usb-select-device` port events, `listDevices()` /
-  `selectDevice()` in provision.
+```
+firefox --no-remote --profile /tmp/mvelo-ff-profile &
+```
 
-### Firefox work still to do
-
-1. **Nothing calls the new events.** `KeyStorageSettings` still offers only the
-   directory picker, which does not exist in Firefox. It needs a device-list UI
-   driven by `usb-list-devices` + `usb-select-device` when `status.native` is true.
-2. **`nativeMessaging` permission is optional** and never requested. `General.js`
-   already has the request pattern (`chrome.permissions.request`) — copy it.
-3. **`isSupported()` in `FsaBackend` returns false on Firefox** (correct), so the
-   native backend is selected — but the Key Storage page still shows "this browser
-   cannot access a USB keystore", which will now be wrong once the UI is finished.
-4. **`NativeBackend` has 8% coverage.** Untested apart from what the host tests
-   cover on the other side of the protocol.
-5. **Then actually run it in Firefox**, which has never happened.
-
-### Firefox baseline, already verified
-
-The current build loads cleanly in Firefox 154 with an **empty console**, correctly
-disables the USB option, and ordinary local-storage operation is unaffected. So the
-feature degrades safely today; the work above is additive.
-
-Load with a throwaway profile:
-`firefox --no-remote --profile /tmp/mvelo-ff-profile &` then
-`about:debugging#/runtime/this-firefox` → Load Temporary Add-on →
+then `about:debugging#/runtime/this-firefox` → Load Temporary Add-on →
 `build/firefox/manifest.json`. (`web-ext run` does **not** work with Firefox 154 —
 `ECONNREFUSED` on the debugging port.)
 
-## 4. Coverage
+A disposable stand-in device, for anything destructive — this is where guard-disabling
+checks belong, not on a real stick:
 
-`src/modules/usb`: 76% statements. `guard.js`, `constants.js`, `handlers.js` at
-100%, `router.js` 98%, `debugLog.js` 94%, `state.js` 90%, `FsaBackend.js` 85%,
-`install.js` 80%, `provision.js` 75%.
+```
+sudo mkdir -p /run/media/$USER/SCRATCH
+sudo mount -t tmpfs -o size=16M,uid=$(id -u),gid=$(id -g) tmpfs /run/media/$USER/SCRATCH
+```
 
-Weak spots: `NativeBackend.js` 8% (new, untested), `handleStore.js` 0% (IndexedDB,
-needs a `fake-indexeddb` dependency that is not installed — but runtime-proven,
-since the whole Chrome path depends on it).
+It satisfies the host's mount-point requirement, `umount` simulates removal, and
+remounting `-o ro` simulates write protection.
 
-## 5. Bugs found by running it, not by testing it
+## 4. Bugs found by running it, not by testing it
 
-Around a dozen, none caught by the test suite or by review. Several clustered into
-two families worth knowing about, because more probably remain:
+Around twenty, almost none caught by the test suite or by review. They cluster, and
+the clusters are the useful part because more probably remain.
 
-**"Unreadable read as empty."** Reads deliberately degrade to an empty keyring
-rather than throwing — because throwing made `keyring.init()` *delete the keyring
-from the attribute map*. That pushes the burden onto every consumer that asks "do I
-have keys?", and each one got it wrong differently: "key not found" instead of
-"device disconnected"; the toolbar menu offering "Get started"; the keyring page
-claiming no key pair; `hasAnyPrivateKey` mis-answering. Same root, four symptoms.
+**"Unreadable read as empty."** Reads deliberately degrade to an empty keyring rather
+than throwing — because throwing made `keyring.init()` *delete the keyring from the
+attribute map*. That pushes the burden onto every consumer that asks "do I have
+keys?", and each one got it wrong differently: "key not found" instead of "device
+disconnected"; the toolbar menu offering "Get started"; the keyring page claiming no
+key pair; `hasAnyPrivateKey` mis-answering. Same root, four symptoms.
 
-**"UI trusting a status that arrived too early."** `transition()` notifies listeners
-synchronously, so anything asynchronous it triggers has not finished when a view
-reacts. Symptoms: the keyring page showing no keys after reconnect, the stale key
-list, and a sticky `/keyring/setup` route that no key arrival could clear.
+**"UI trusting a status that arrived before the work behind it finished."**
+`transition()` notifies listeners synchronously, so anything asynchronous it triggers
+has not finished when a view reacts. Symptoms: the keyring page showing no keys after
+reconnect, a stale key list, and a sticky `/keyring/setup` route that no key arrival
+could clear.
 
-Two others worth singling out:
+**"One message for every failure state."** Components explained an unreachable
+keystore with wording fixed at *not configured* or *not connected*, which names the
+wrong remedy for most states that reach them. Worst case: the key-action gate's
+heading said "Set up the device first" in every case it could render, though
+`isUnavailable()` requires an enabled keystore — so a profile without one never
+reaches it. Both now derive their text from `describeState()`.
 
+Four singular ones worth keeping:
+
+- **Migration overwrote an existing keystore.** Migrating local keys onto a device
+  that already held a keystore replaced it. Recovered by union from `.bak`; both keys
+  survived, but only because the atomic write keeps one generation. `mergeForDevice()`
+  now merges, and device content wins conflicts.
 - **The periodic probe never ran.** Its alarm listener was registered inside
   `state.init()` after an `await`. An MV3 service worker only receives events whose
-  listeners were registered during the initial synchronous evaluation. **No test can
+  listeners were registered during initial synchronous evaluation. **No test can
   catch this** — jest's `chrome.alarms` mock accepts a late listener happily.
-- **A test that enforced a bug.** `usb-provision` dropped the `adopt` flag, making
-  the "use this folder anyway" override impossible, and the test asserted
-  `toHaveBeenCalledWith({label})` — passing *because* of the bug. A revert check
-  does not catch a wrong assertion, only a missing one.
+- **A test that enforced a bug.** `usb-provision` dropped the `adopt` flag, making the
+  "use this folder anyway" override impossible, and the test asserted
+  `toHaveBeenCalledWith({label})` — passing *because* of the bug. A revert check does
+  not catch a wrong assertion, only a missing one.
+- **Errors thrown into nothing.** The keyring UI's shape for key operations is
+  "swallow a cancelled password dialog, rethrow the rest", and in an async handler a
+  rethrow is an unhandled rejection. Eight call sites do this. Harmless while writes
+  never failed; routine once the keystore is removable. Caught centrally by
+  `UsbErrorToast` rather than by patching each site.
+
+The read-only exercise was the single most productive test of the project: five
+distinct bugs, none of them about the fail-safe it set out to check, which worked from
+the start. Worth repeating for any state that is reachable but not exercised.
+
+## 5. Coverage
+
+`src/modules/usb` and `src/components/usb`: **71% statements**, 61% branch.
+
+100%: `constants.js`, `guard.js`, `handlers.js`, `UsbKeyActionGate.js`,
+`UsbSetupCard.js`, `UsbStatusBadge.js`. Then `router.js` 95%, `debugLog.js` 94%,
+`state.js` 91%, `UsbDevicePicker.js` 89%, `FsaBackend.js` 85%, `install.js` 82%,
+`provision.js` 76%, `usbStatus.js` 75%.
+
+Weak spots, in the order worth addressing:
+
+- `KeyStorageSettings.js` **2%** — the largest untested component, and the one that
+  performs provisioning. Runtime-exercised heavily, but a regression here is silent.
+- `NativeBackend.js` **55%** — the file operations are covered from the host side
+  only, so the two halves of the protocol are never tested against each other.
+- `handleStore.js` **0%** — IndexedDB, needs a `fake-indexeddb` dependency that is
+  not installed. Runtime-proven, since the whole Chrome path depends on it.
+- `UsbErrorToast.js` **5%**, `UsbStatusBanner.js` **17%** — the global rejection
+  listener is worth a test; it is the only thing reporting several failures.
 
 ## 6. Open decisions
 
-- **client-API `hasPrivateKey`** reports `false` to a webmail page while the device
-  is detached. Recommendation after review: **leave it**, and note in the JSDoc that
-  these queries reflect currently-reachable keys. The dangerous outcome is already
-  prevented — a provider that responds by prompting key generation gets a
-  fail-closed write and a clear device error.
-- **`password_cache` in USB mode.** Recommendation, revised after seeing it in use:
-  **leave it on**. The USB-specific risk is already handled by the purge on removal;
-  what remains is the ordinary cache tradeoff, which USB storage does not change.
-- **Probe interval** — 30 s is Chrome's floor; 1 s polling while a page is visible.
-  Cost: a visible page keeps the device from idling.
+- **client-API `hasPrivateKey`** reports `false` to a webmail page while the device is
+  detached. Recommendation: **leave it**, and note in the JSDoc that these queries
+  reflect currently-reachable keys. The dangerous outcome is already prevented — a
+  provider that responds by prompting key generation gets a fail-closed write and a
+  clear device error.
+- **`password_cache` in USB mode.** Recommendation, now that the purge has been
+  observed working: **leave it on**. Cached material does not survive removal, so it
+  cannot outlive the device; what remains is the ordinary cache tradeoff, which USB
+  storage does not change.
+- **Probe interval** — 30 s is Chrome's alarm floor; 1 s polling while a page is
+  visible. Cost: a visible page keeps the device from idling.
 
 ## 7. Working practices that cost time
 
 - **Check the build stamp before trusting behaviour.**
   `config/webpack.background.js:38` stamps dev builds; it shows in the footer,
-  bottom-right of any Options page (UTC). Several rounds were spent reasoning about
-  a stale bundle.
-- **Never run `grunt` while the extension is loaded.** The default task runs `clean`,
-  which deletes `build/` and invalidates the unpacked extension —
-  Chromium then shows `ERR_FILE_NOT_FOUND`. Use `grunt webpack:dev tmp2browser`
-  mid-testing.
+  bottom-right of any Options page (UTC). Several rounds were spent reasoning about a
+  stale bundle.
+- **Never run bare `grunt` while the extension is loaded.** The default task runs
+  `clean`, which deletes `build/` and invalidates the unpacked extension — Chromium
+  then shows `ERR_FILE_NOT_FOUND`. Use `grunt webpack:dev tmp2browser` mid-testing.
 - **Do not disable a security guard against a real device.** Verifying the host's
   confinement tests were load-bearing wrote a file to the user's stick, because the
-  test that was supposed to be blocked then succeeded. Use a scratch mount.
+  test that was supposed to block it then succeeded. Use the scratch mount in §3.
 - **Grep for the field, not for a pattern you assume contains it.** Time was lost
   hunting a non-existent bug because `grep -rc` skipped LevelDB's `.log` as binary,
-  and because an extraction pattern assumed a JSON key order Chrome does not
-  preserve.
+  and because an extraction pattern assumed a JSON key order Chrome does not preserve.
+- **A passing test can be enforcing the bug.** Read the assertion, not just the
+  result.
 
 ## 8. Environment
 
@@ -223,7 +233,12 @@ npm ci --allow-git=root
 
 `.npmrc` is gitignored, so `allow-git=root` can be made permanent there.
 
-Also note the kernel-module trap that stopped USB detection entirely: a
-`linux-cachyos` upgrade removed the running kernel's module tree, so `usb-storage`
-could not load and no `/dev/sd*` appeared. A reboot fixed it. If a stick enumerates
-in `dmesg` but no block device appears, check `/lib/modules/$(uname -r)` exists.
+Two hardware traps that stopped USB detection entirely:
+
+- A `linux-cachyos` upgrade removed the running kernel's module tree, so
+  `usb-storage` could not load and no `/dev/sd*` appeared. A reboot fixed it. If a
+  stick enumerates in `dmesg` but no block device appears, check
+  `/lib/modules/$(uname -r)` exists.
+- FAT mounts here carry `errors=remount-ro`, so a filesystem error silently turns
+  the stick read-only mid-session. This is why `READ_ONLY` is a modelled state and
+  not merely a failed write.

--- a/doc/usb-keystore-status.md
+++ b/doc/usb-keystore-status.md
@@ -1,153 +1,169 @@
 # USB Keystore — Status and Handoff
 
-Re-verified 2026-08-22 from primary evidence (git, test runs, on-disk artefacts) rather than
-from recollection. That round found and fixed a destructive bug and closed three of the five
-implementation gaps — see §4. Companion to [usb-keystore-plan.md](usb-keystore-plan.md), which
-holds the design and its rationale.
+Updated 2026-08-22 after a full browser-testing session. Companion to
+[usb-keystore-plan.md](usb-keystore-plan.md), which holds the design and its rationale.
 
-Branch `feature/usb-keystore`, 2 commits ahead of `master` (`ffaa27af`):
+**Both Phase 0 unknowns are now settled and every requirement from the original ask is
+verified in a real browser.** What remains is a real USB stick, one API decision, and the
+things a tmpfs test directory structurally cannot exercise.
 
-| Commit | Contents |
+Branch `feature/usb-keystore`, 16 commits ahead of `master` (`ffaa27af`), working tree clean.
+45 files, +5,465/-30. Unit suite: **597 tests, 31 suites**. `grunt eslint` clean. All bundles
+build.
+
+The first two commits are split so that `fd2450c6` (all new files) can never conflict on a
+rebase and only `6a5330e7` needs attention. That split has since been diluted — later fixes
+touched `keyring.js`, `pgpModel.js`, `menu.controller.js`, `Keyring.js` and `GenerateKey.js` —
+so the hook footprint is now larger than the original +31/-2. Still worth keeping new-file and
+hook-site changes in separate commits going forward.
+
+## 1. Settled: the two Phase 0 questions
+
+**An FSA `FileSystemDirectoryHandle` stored in IndexedDB by the app page IS usable from the MV3
+service worker.** Proven by provisioning writing `/tmp/mailvelope-keystore/keystore.json` from
+the background using a handle the page stored. **The planned offscreen-document fallback is not
+needed — do not build it.**
+
+**A `readwrite` grant CAN survive a browser restart**, if the user takes Chrome's persistent
+option in the permission prompt ("allow on every visit" or similar). Confirmed by quitting and
+reopening Chromium and finding the state still `READY`.
+
+It does **not** survive an extension *reload*, which matters only during development. Because
+that is the common case while working on this, `Reconnect` re-prompts for the stored handle
+(one dialog) rather than reopening the directory picker.
+
+## 2. Verified in a real browser
+
+Chromium `151.0.7922.173`, native via pacman — deliberately not flatpak, whose portal sandbox
+can hide `/run/media/…`. Extension ID `ifmmgibjjcicnmfdkgbjbnkebofjdabc`, loaded unpacked from
+`build/chrome`. Test keystore on `/tmp`, `keystoreId 431ae6d3…`.
+
+| Requirement | Evidence |
 |---|---|
-| `fd2450c6` | Add USB-resident keystore modules, UI and tests — 19 new files, +2,874 |
-| `6a5330e7` | Wire the USB keystore into existing entry points — 11 files, +31/-2 |
+| Detect device presence and file accessibility | all states reached: `READY`, `ABSENT`, `PERMISSION_REQUIRED`, `WRONG_DEVICE` |
+| Note when the device is unavailable | red `!` badge, amber banner, key list clears, all unprompted within the probe interval |
+| Refuse to operate without the device | encryption refused with "The USB keystore is not available. Connect the device to use your keys." |
+| **No crypto stored anywhere but the device** | a real key generated onto the device: `private.asc` 6,825 bytes / 1 block, `attributes.json` holding `default_key`. Profile grep for `BEGIN PGP` clean throughout; zero occurrences of `default_key` or the key fingerprint locally |
+| Offer to add a keystore when absent | setup card plus the Key Storage settings page |
+| Atomic writes | `.bak` rotation observed against the real File System Access API, not just the fake |
+| Recovery | key returns on its own after reconnect, via the periodic probe |
 
-Split so the first can never conflict on a rebase onto upstream (all new paths) and only the
-second needs attention. Keep that split. **Uncommitted work from 2026-08-22 sits on top** (§4);
-the hook footprint has grown beyond +31/-2 because `keyring.js` is now touched.
+## 3. Nine bugs found by running it
 
-17 source files (11 in `src/modules/usb`, 6 in `src/components/usb`) and 4 test files.
+None were caught by 597 passing tests or by review. Recording them because the ratio stayed
+roughly constant across the session, which suggests more remain.
 
-## 1. Verified — automated and reproducible
+1. **Destructive read.** A read that threw when the device was absent propagated into
+   `init()`'s catch, which *deletes the keyring from the attribute map*. Reads now degrade to
+   an empty keyring; writes still fail closed.
+2. **Destructive write, same consequence.** `sanitizeKeyring()` writes the keyring back, and
+   that write fails when the device is absent — reaching the same deletion by another route.
+   Now deferred until the device is attached.
+3. **No reload on return.** Nothing re-read the device when it came back, so the warning
+   cleared while the UI still showed no keys — indistinguishable from data loss.
+4. **Stale key list.** The keyring page only refreshed when the device returned, not when it
+   went away, so it kept listing keys it could no longer use.
+5. **The adopt flag defeated by a click event.** `onClick={this.handleChooseDirectory}` passed
+   React's event into a parameter named `adopt`, making it truthy on every pick and silently
+   disabling the identity guard added hours earlier. Now strictly coerced, in the component
+   *and* in the background, which is the actual security boundary.
+6. **The periodic probe never ran.** Its alarm listener was registered inside `state.init()`
+   after an `await`. An MV3 service worker only receives events whose listeners were added
+   during the initial synchronous evaluation of the script, so removal was only ever noticed at
+   startup or when the user forced a check. Now registered at module scope in `install.js`.
+   **No test can catch this** — jest's `chrome.alarms` mock accepts a late listener happily.
+7. **"key not found" instead of "device disconnected."** Honest at the keyring layer, badly
+   misleading at the user layer: for a keystore that is the only copy, it is the message most
+   likely to make someone believe the key is gone, or generate a replacement.
+8. **"Get started" in the toolbar menu** whenever the device was detached, inviting a user
+   whose key was safe on the device to generate a replacement.
+9. **Nested keystore.** Selecting the `mailvelope-keystore` folder itself — the only folder a
+   user can actually see when reconnecting — created a second keystore inside the first, and
+   provisioning silently minted a new identity, orphaning the original device.
 
-| What | Evidence |
-|---|---|
-| Unit tests | 519 tests, 26 suites, 0 failures (`jest --selectProjects unit`) |
-| No regression | count includes every pre-existing suite |
-| Router enforcement | `router.test.js`, 20 assertions: classification, hex encoding, attribute split/merge, leak safety net, serialization |
-| Availability state machine | `state.test.js`, 21 assertions against a fake backend: every transition, `assertUsable` re-probe semantics, listeners, recovery to READY |
-| Storage interception | `install.test.js`, 19 assertions: device vs local routing, attribute splitting, fail-closed writes, degraded reads, leak block, purge on device loss, badge arbitration |
-| **Requirement 3 as a test** | `install.test.js` "storage audit": after a scripted session, no armored key and no crypto attribute field (`default_key`, `primary_key`, `sync_data`, `key_binding`) appears in local storage — and it is all on the device instead |
-| Guards | `guard.test.js`, 10 assertions: remote-upload refusal, passphrase requirement, error codes |
-| GnuPG exclusion | 3 assertions in `keyring.test.js`, proven non-vacuous by reverting the production change and watching them fail |
-| Lint | `grunt eslint` exits `Done.` |
-| Compiles | app, background and all 11 component webpack bundles build |
-| No SW-illegal code | background bundle emits no extra chunks and contains no `importScripts`, so no dynamic-import splitting survived |
+### The pattern worth remembering
 
-## 2. Verified — runtime, from on-disk artefacts
+Bugs 1, 2, 4, 7 and 8 are all the same mistake: **an unreadable keystore being treated as an
+empty one.** That is the inherent cost of making reads degrade to empty rather than throw —
+which was the right call, since throwing deleted the keyring registry — but it pushes the
+burden onto every consumer that asks "do I have keys?". An audit fixed the known cases;
+`hasUsablePrivateKey`, the onboarding flow and the editor's recipient lookup are where to look
+next.
 
-| What | Evidence |
-|---|---|
-| **An FSA handle from IndexedDB works in the MV3 service worker** | `/tmp/mailvelope-keystore/keystore.json` exists (`keystoreId 431ae6d3…`, version 1, label `tmp`), written by `provision()` in the background using a handle the app page stored in IndexedDB. Build timestamp 17:42 precedes the file's 17:53, so this was current code. **The planned offscreen-document fallback is not needed.** |
-| Provisioning end-to-end | same artefact: picker → IndexedDB → port message → background write |
-| Handle persists in IndexedDB | `chrome-extension_ifmmgibjjcicnmfdkgbjbnkebofjdabc_0.indexeddb.leveldb`, 28K |
-| USB mode still active | `mvelo.usb.config` holds `keystoreId 431ae6d3…`, no key material |
-| Opt-in gating | local store holds `mvelo.keyring.…{public,private}Keys` as `[]`, written during keyring init *before* provisioning: until a keystore is configured the wrapper passes through to local, as intended |
-| Attribute split | local `mvelo.keyring.attributes` is `{"localhost|#|mailvelope":{"sanitized":true}}` — registry and non-crypto flags only |
-| **No key material on local disk** | `grep -rl "BEGIN PGP"` across the whole `Local Extension Settings` tree: clean |
+## 4. Test coverage
 
-Environment: Chromium `151.0.7922.173` (native via pacman — deliberately not flatpak, whose
-portal sandbox can hide `/run/media/…` and would confound results). Extension ID
-`ifmmgibjjcicnmfdkgbjbnkebofjdabc`, loaded unpacked from `build/chrome`.
+`src/modules/usb`: **80.8% statements**, `guard.js` and `handlers.js` at 100%, `router.js` 98%,
+`state.js` 91%, `install.js` 80%, `provision.js` 81%, `FsaBackend.js` 84%.
 
-## 3. Not verified
+`handleStore.js` is at 0% — testing IndexedDB needs a `fake-indexeddb` dependency that is not
+installed. It is however runtime-proven: the whole feature depends on it working.
 
-### Covered by unit tests, never seen in a real browser
+Notable gaps: the *wiring* of the crypto gate is untested (`guard.test.js` covers the function,
+nothing asserts `pgpModel`'s five call sites invoke it), and `GenerateKey.js`'s upload default
+has no test — a component test there needs the port, keyring context and six children mocked.
 
-`/tmp/mailvelope-keystore` holds 1 file and 0 keyring directories, so **no key has ever been
-written to the device.** These behaviours are asserted against a fake backend but have never
-run against the real File System Access API:
+**Discipline that paid off:** every new test was checked by reverting the production change and
+confirming it fails. The first attempt at the GnuPG-exclusion tests passed while asserting
+nothing, because the module mocks made `gpgme` unavailable so `initGPG()` deleted that keyring
+regardless of USB mode. A new test that goes green on the first run deserves the revert check.
 
-- key generation onto the device — nothing has ever written `private.asc`
-- transition to `ABSENT` on removal, and the badge, banner and refusal that follow
-- purge of in-memory keyrings and the passphrase cache
-- return to `READY`, and `WRONG_DEVICE`
-- fail-closed writes
-- badge arbitration against `uiLog`
+## 5. Remaining work
 
-### Not covered at all
+### Needs a real USB stick
 
-- **Permission persistence across a browser restart** — Phase 0's second question, still open.
-  Cannot be told from disk: config and handle both persist, but whether the *grant* does needs
-  the UI. Restart Chromium only, never the machine: `/tmp` is tmpfs.
-- **`provision.js`** — `provision()`, `migrateLocalKeyMaterial()`, `inspectLocalKeyMaterial()`
-  and `diagnostics()` have no unit tests. Provisioning is known to work from the manual run;
-  migration is entirely unexercised.
-- **UI components** — no rendering tests for any of `src/components/usb/`.
+`/tmp` is tmpfs: RAM-backed, case-sensitive, fast, wiped on reboot. It cannot exercise:
 
-### Cannot be tested on `/tmp` at all
+- torn writes from pulling a device mid-save (the `.tmp` → verify → `.bak` → `move` path)
+- real removal timing and slow-media latency
+- case-insensitive filesystems (FAT32/exFAT) — the reason directory names are hex, not base64
+- the "mount point disappears entirely" removal mode (`/tmp` itself was picked, so only
+  "contents gone" is reachable — re-provision against a subdirectory to test both)
 
-`/tmp` is tmpfs: RAM-backed, case-sensitive, fast, wiped on reboot. It cannot exercise torn
-writes from pulling a device mid-save (the `.tmp` → verify → `.bak` → `move` path), real removal
-timing, case-insensitive filesystems (FAT32/exFAT — the reason for hex rather than base64
-directory names), or the "mount point disappears entirely" removal mode (`/tmp` itself was
-picked, so only "contents gone" is reachable — re-provision against `/tmp/usbtest` for both).
+### One open decision
 
-**A real USB stick is required before this feature can be called done.**
+`api.controller.hasPrivateKey` answers the **client API**, so a webmail provider asking "does
+this user have a key?" gets `false` while the device is detached. Recommendation after review:
+**leave it**, and note in the client-API JSDoc that these queries reflect currently-reachable
+keys. The dangerous outcome is already prevented — a provider that responds by prompting key
+generation gets a fail-closed write and a clear device error, so no replacement key can be
+created. Throwing instead would be more honest but would change behaviour for third-party
+integrations that cannot be tested from here.
 
-### Still not implemented
+### Not implemented
 
-| Gap | Plan ref | Consequence |
-|---|---|---|
-| Generate/import not gated behind device setup | §3.2.1 | `UsbSetupCard` offers the option but nothing enforces ordering: generating *before* provisioning writes a key locally and lands in the §3.1 residue case. `strings.generate_first_*` exists and is unused. The background now fails closed, so this is a UX ordering problem rather than a correctness hole |
-| LevelDB residue not measured | §3.1 | migration residue severity unquantified; the overwrite-before-delete heuristic is unjustified either way |
+- Generate/import ordering is a nudge, not a gate. Nothing prevents generating a key *before*
+  provisioning a device, which lands in the §3.1 residue case. The background fails closed once
+  a keystore is configured, so this is UX rather than correctness.
+- LevelDB residue is unmeasured, so the overwrite-before-delete heuristic remains unjustified.
+- Phase 5: the Firefox native messaging host. Firefox reports `UNSUPPORTED` today.
 
-## 4. Changed on 2026-08-22 (uncommitted)
-
-### Bug found and fixed: a destructive read path
-
-`wrappedGet` threw when the device was absent. `keyring.init()` wraps `buildKeyring()` in a
-`try/catch` that **deletes the keyring from the attribute map** on failure
-([keyring.js:116](../src/modules/keyring.js#L116)), so starting the browser with the device
-unplugged would deregister the keyring — recoverable for the main keyring, permanent for
-client-API keyrings, whose keys would then be stranded on the device.
-
-`readDevice` now degrades to `undefined` (an empty keyring) instead of throwing, which is what
-the plan intended and what the SPLIT branch already did. Writes still fail closed, so reading
-empty and storing it back cannot destroy anything. Two tests in `install.test.js` cover it.
-
-Found by writing the test, not by review — none of that code had ever executed.
-
-### Gaps closed
-
-- **Passphrase required in USB mode** (§3.2). Enforced in the background at *both* entry points,
-  `app.controller.generateKey` and the client-API-driven `privateKey.controller.generateKey`, so
-  a webmail page cannot bypass it. Code `USB_KEYSTORE_PASSPHRASE_REQUIRED`. `GenerateKey.js`
-  already required a non-empty password, but that was UI-only validation.
-- **GnuPG keyring hidden in USB mode** (§9.2). Excluded from `getPreferredKeyringQueue()`,
-  `getAll()` and `getAllKeyringAttr()`, so it leaves key selection *and* the keyring selector.
-  This required touching `keyring.js`, previously untouched on purpose.
-- **Storage-audit test** (Phase 4). Requirement 3 is now asserted rather than claimed.
-
-### A note on the first attempt at the GnuPG tests
-
-They passed while asserting nothing: the module-level mocks make `gpgme` unavailable, so
-`initGPG()` deleted the GnuPG keyring regardless of USB mode. Rewritten with per-case
-`jest.doMock` (including `__esModule: true`, without which babel's interop breaks `new`), and
-with `chrome.storage.session` seeded so `init()` *awaits* `initGPG()` instead of firing and
-forgetting it. Then verified by reverting the production change and confirming they fail.
-
-Worth remembering as a pattern: a new test that passes immediately against code it is supposed
-to be exercising deserves the revert check.
-
-## 5. Still-open decisions (plan §9)
+### Still-open plan decisions
 
 - Probe interval — 1 min is the practical Chrome MV3 alarm floor.
-- Firefox: ship Chromium-only with `UNSUPPORTED`, or wait for the Phase 5 native host?
+- Firefox: ship Chromium-only, or wait for the native host?
 - Should USB mode force `security.password_cache` off rather than only purging on removal?
-  Leaning yes: caching decrypted keys undercuts the point of removing the device.
 
-## 6. Minor
+## 6. Working practices for the next session
 
-Stale empty `mvelo.keyring.*.{public,private}Keys` entries remain in local storage after
-switching to USB. Harmless (`[]`) but `inspectLocalKeyMaterial()` will report them; decide
-whether provisioning should clean them up.
+**Verify the build actually loaded.** `config/webpack.background.js:38` stamps dev builds with
+`${version} build: ${ISO timestamp}`, shown in the **footer, bottom-right of any Mailvelope
+Options page** (UTC). Reload, check the stamp matches, *then* test. Several rounds were wasted
+reasoning about behaviour from a stale bundle.
+
+**Never run `grunt` while the extension is loaded.** The default task runs `clean`, which
+deletes `build/`, invalidating the unpacked extension — Chromium then shows
+`ERR_FILE_NOT_FOUND` and the extension has to be reloaded or re-added. Use `grunt webpack:dev`
+mid-testing, or rebuild only between tests.
+
+**Grep for the field, not for a pattern you assume contains it.** Time was lost hunting a
+non-existent bug because `grep -rc` skipped LevelDB's `.log` as binary, and because the
+extraction pattern assumed a JSON key order that Chrome does not preserve.
 
 ## 7. Environment gotcha for a fresh clone
 
 `npm ci` fails with `EALLOWGIT`: **npm 12 defaults `allow-git=none`**, and this project has two
 git dependencies (`gpgmejs`, `emailjs-mime-builder`) that the lockfile pins to `git+ssh://`.
-There are no SSH keys on this machine, so both the policy and the transport need handling:
+With no SSH keys present, both the policy and the transport need handling:
 
 ```
 GIT_CONFIG_COUNT=2 \
@@ -157,6 +173,5 @@ npm ci --allow-git=root
 ```
 
 `allow-git=root` permits only git deps declared in this project's own `package.json`, narrower
-than `all`. `.npmrc` is gitignored (line 98), so it can be made permanent there without touching
-the repo. `allow-remote` is not a problem — all 1,353 other packages resolve to
-`registry.npmjs.org`.
+than `all`. `.npmrc` is gitignored (line 98), so it can be made permanent there without
+touching the repo.

--- a/doc/usb-keystore-status.md
+++ b/doc/usb-keystore-status.md
@@ -9,7 +9,7 @@ native messaging host. The same physical keystore has been read by both, and nei
 browser profile holds key material.
 
 Branch `feature/usb-keystore`, **42 commits** ahead of `master` (`ffaa27af`). Unit
-suite: **678 tests, 42 suites**. Native host: **35 tests**. `grunt eslint` clean. Both
+suite: **682 tests, 43 suites**. Native host: **35 tests**. `grunt eslint` clean. Both
 bundles build.
 
 ## 1. What has been verified on real hardware
@@ -35,6 +35,7 @@ flatpak's portal sandbox can hide `/run/media`) and Firefox `154`.
 | Permission across a browser restart | **survives**, if the user takes Chrome's persistent option in the prompt |
 | Detection latency | ~1 s while a page is visible, 30 s alarm otherwise |
 | Migration of local keys onto a device that already has a keystore | merges both key sets; see §4 |
+| **A large keyring** | a 426-key `gpg --export --armor` dump imports and persists whole: 411 public keys, 15 that the profile holds privately, plus the one key already there — and the chunked read returns the 1.3 MB file byte-for-byte |
 
 ### Still not verified
 
@@ -154,6 +155,18 @@ heading said "Set up the device first" in every case it could render, though
 reaches it. Both now derive their text from `describeState()`.
 
 Singular ones worth keeping:
+
+- **A reloaded keyring was visible while it was still filling up.** Reloading a
+  keyring means `keystore.clear()` then `keystore.load()`, at both call sites. With
+  two keys the gap between them is invisible; with 400 read off a device it lasts
+  seconds, and anything reading in that window gets a *fraction* of the keyring. A
+  key list missing most of its rows is the visible symptom, and it sticks: the page
+  re-reads when the list is empty, because an empty list is obviously wrong, but a
+  short one is not. Worse than the display bug is what it means for crypto — a
+  decryption during that window cannot find a key that is present. `KeyStoreBase`
+  now has a `reload()` that loads into a detached store and swaps the result in, so a
+  reader sees one whole generation or the other. Only a keyring big enough to make
+  the window observable brings it out; every test keyring here had two keys.
 
 - **A keyring larger than one native message could be neither saved nor read.**
   Importing a public keyring exported with `gpg --export --armor` failed with

--- a/native-host/install.sh
+++ b/native-host/install.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# Copyright (C) 2026 Noam Rathaus
+# Licensed under the GNU Affero General Public License version 3
+#
+# Registers the Mailvelope USB keystore native messaging host with Firefox and,
+# optionally, Chromium/Chrome.
+#
+# User-level only: everything is written under $HOME and no sudo is needed or
+# accepted. A native messaging host runs with the user's authority, so installing
+# one system-wide would extend that to every account on the machine for no benefit.
+#
+# Usage:
+#   ./install.sh                          Firefox only
+#   ./install.sh --chrome-id <extension>  also register for Chromium/Chrome
+#   ./install.sh --uninstall              remove every manifest this wrote
+#   ./install.sh --status                 show what is currently registered
+
+set -euo pipefail
+
+HOST_NAME='mailvelope_usb_keystore'
+FIREFOX_EXT_ID='jid1-AQqSMBYb0a8ADg@jetpack'
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+HOST_PATH="$SCRIPT_DIR/$HOST_NAME.py"
+
+# Firefox reads from one directory; the Chromium family has one per build.
+FIREFOX_DIR="$HOME/.mozilla/native-messaging-hosts"
+CHROMIUM_DIRS=(
+  "$HOME/.config/chromium/NativeMessagingHosts"
+  "$HOME/.config/google-chrome/NativeMessagingHosts"
+  "$HOME/.config/google-chrome-unstable/NativeMessagingHosts"
+  "$HOME/.config/BraveSoftware/Brave-Browser/NativeMessagingHosts"
+)
+# macOS puts them elsewhere.
+if [[ "$(uname -s)" == 'Darwin' ]]; then
+  FIREFOX_DIR="$HOME/Library/Application Support/Mozilla/NativeMessagingHosts"
+  CHROMIUM_DIRS=(
+    "$HOME/Library/Application Support/Chromium/NativeMessagingHosts"
+    "$HOME/Library/Application Support/Google/Chrome/NativeMessagingHosts"
+  )
+fi
+
+mode='install'
+chrome_id=''
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --uninstall) mode='uninstall'; shift ;;
+    --status)    mode='status'; shift ;;
+    --chrome-id) chrome_id="${2:-}"; shift 2 ;;
+    -h|--help)   sed -n '5,20p' "${BASH_SOURCE[0]}"; exit 0 ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+manifest_paths() {
+  echo "$FIREFOX_DIR/$HOST_NAME.json"
+  for dir in "${CHROMIUM_DIRS[@]}"; do
+    echo "$dir/$HOST_NAME.json"
+  done
+}
+
+case "$mode" in
+status)
+  echo "host script: $HOST_PATH"
+  [[ -x "$HOST_PATH" ]] && echo "  executable: yes" || echo "  executable: NO (run chmod +x)"
+  echo
+  echo "registered manifests:"
+  found=0
+  while read -r path; do
+    if [[ -f "$path" ]]; then
+      echo "  $path"
+      found=1
+    fi
+  done < <(manifest_paths)
+  [[ $found -eq 0 ]] && echo "  (none)"
+  exit 0
+  ;;
+
+uninstall)
+  while read -r path; do
+    if [[ -f "$path" ]]; then
+      rm -f "$path"
+      echo "removed $path"
+    fi
+  done < <(manifest_paths)
+  echo "done. The host script itself was left in place."
+  exit 0
+  ;;
+esac
+
+# --- install ---------------------------------------------------------------
+
+if [[ ! -f "$HOST_PATH" ]]; then
+  echo "host script not found at $HOST_PATH" >&2
+  exit 1
+fi
+chmod +x "$HOST_PATH"
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "python3 is required but was not found on PATH" >&2
+  exit 1
+fi
+
+# Firefox: bound by extension id. Mailvelope declares browser_specific_settings.
+# gecko.id, so a temporary add-on loaded through about:debugging gets this same id
+# rather than a random one -- which is why testing an unsigned build works.
+mkdir -p "$FIREFOX_DIR"
+cat > "$FIREFOX_DIR/$HOST_NAME.json" <<EOF
+{
+  "name": "$HOST_NAME",
+  "description": "Mailvelope USB keystore file access",
+  "path": "$HOST_PATH",
+  "type": "stdio",
+  "allowed_extensions": ["$FIREFOX_EXT_ID"]
+}
+EOF
+echo "installed for Firefox: $FIREFOX_DIR/$HOST_NAME.json"
+
+# Chromium family: bound by origin, so it needs the extension id, which differs
+# between an unpacked load and a store install. Opt-in via --chrome-id, since
+# guessing it would silently authorise the wrong extension.
+if [[ -n "$chrome_id" ]]; then
+  for dir in "${CHROMIUM_DIRS[@]}"; do
+    parent="$(dirname "$dir")"
+    [[ -d "$parent" ]] || continue
+    mkdir -p "$dir"
+    cat > "$dir/$HOST_NAME.json" <<EOF
+{
+  "name": "$HOST_NAME",
+  "description": "Mailvelope USB keystore file access",
+  "path": "$HOST_PATH",
+  "type": "stdio",
+  "allowed_origins": ["chrome-extension://$chrome_id/"]
+}
+EOF
+    echo "installed for $(basename "$parent"): $dir/$HOST_NAME.json"
+  done
+fi
+
+echo
+echo "Restart the browser so it picks up the new host."
+echo "Verify with: $0 --status"

--- a/native-host/mailvelope_usb_keystore.py
+++ b/native-host/mailvelope_usb_keystore.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+# Copyright (C) 2026 Noam Rathaus
+# Licensed under the GNU Affero General Public License version 3
+"""Native messaging host for the Mailvelope USB keystore.
+
+Firefox has no File System Access API, so an extension there cannot reach a
+removable device at all. This host provides the same small set of operations the
+in-browser backend offers -- probe, read, write, remove, list -- over the browser's
+native messaging protocol.
+
+Written in Python, and deliberately kept short and dependency-free, because this is
+a program with the user's full filesystem authority that handles private keys. Being
+readable in one sitting is worth more here than being clever.
+
+SECURITY MODEL
+--------------
+A native host is the most dangerous component of this feature: the browser can ask
+it to touch the filesystem as the user. The protocol therefore does not accept
+arbitrary paths.
+
+  * Every operation is confined to a `root` that must be BOTH under one of
+    ALLOWED_ROOT_PREFIXES and an actual mount point. A root anywhere else --
+    $HOME, /etc, / -- is refused, and so is a directory that merely sits under a
+    prefix without being a mount, such as /run/media/<user>. That last case
+    matters for correctness as much as security: it lives on local tmpfs, so a
+    keystore written there would leave the keys on this machine while appearing
+    to be on the device.
+  * Relative paths are resolved and then checked to still be inside that root, so
+    '..' cannot escape it, and symlinks are resolved before the check.
+  * Only the file names this feature uses are writable; see SAFE_NAME.
+  * Reads and writes are size-capped, so a hostile request cannot exhaust memory.
+
+None of this defends against a user who is already running malicious code as
+themselves. It defends against the realistic case: a bug or a compromise in the
+extension turning into arbitrary file access.
+"""
+
+import json
+import os
+import struct
+import sys
+import tempfile
+
+VERSION = 1
+
+# Native messaging caps a single message at 1 MB in each direction. Stay well under
+# it: a keyring of any sane size is far smaller, and the cap is a useful bound on
+# what a single request can cost.
+MAX_MESSAGE = 768 * 1024
+MAX_FILE = 512 * 1024
+
+# Roots must live directly under one of these. Removable media only: this is what
+# stops the browser asking for $HOME or /etc.
+ALLOWED_ROOT_PREFIXES = (
+    '/run/media',      # udisks2, most current Linux desktops
+    '/media',          # older Linux conventions
+    '/mnt',            # manual mounts
+    '/Volumes',        # macOS
+)
+
+# File names this host will create or overwrite. Anything else is refused, so a
+# request cannot use the write path to drop a file of its choosing.
+SAFE_NAME = ('keystore.json', 'README.txt', 'public.asc', 'private.asc',
+             'attributes.json', 'autocrypt.json', 'meta.json')
+
+
+class ProtocolError(Exception):
+    """A request that will not be served, with a stable code for the extension."""
+
+    def __init__(self, code, message):
+        super().__init__(message)
+        self.code = code
+
+
+def read_message():
+    """Read one native message, or None at end of stream."""
+    header = sys.stdin.buffer.read(4)
+    if len(header) < 4:
+        return None
+    length = struct.unpack('=I', header)[0]
+    if length > MAX_MESSAGE:
+        raise ProtocolError('too_large', f'message of {length} bytes exceeds the limit')
+    payload = sys.stdin.buffer.read(length)
+    return json.loads(payload.decode('utf-8'))
+
+
+def write_message(message):
+    """Write one native message."""
+    encoded = json.dumps(message).encode('utf-8')
+    if len(encoded) > MAX_MESSAGE:
+        encoded = json.dumps({
+            'error': 'too_large',
+            'message': 'response exceeds the native messaging limit'
+        }).encode('utf-8')
+    sys.stdout.buffer.write(struct.pack('=I', len(encoded)))
+    sys.stdout.buffer.write(encoded)
+    sys.stdout.buffer.flush()
+
+
+def check_root(root):
+    """Validate a root directory and return its real path.
+
+    A root must be under one of ALLOWED_ROOT_PREFIXES and be a mount point.
+    """
+    if not isinstance(root, str) or not root:
+        raise ProtocolError('bad_root', 'root must be a non-empty string')
+    real = os.path.realpath(root)
+    under_prefix = any(real.startswith(prefix + os.sep) for prefix in ALLOWED_ROOT_PREFIXES)
+    if not under_prefix:
+        raise ProtocolError(
+            'root_not_allowed',
+            'root must be on removable media '
+            f'(under one of {", ".join(ALLOWED_ROOT_PREFIXES)})'
+        )
+    if not os.path.isdir(real):
+        raise ProtocolError('not_found', f'{root} is not a directory')
+    # Must be an actual mount point, not merely a directory beneath the prefix.
+    # /run/media/<user> is the container of a user's mount points and lives on local
+    # tmpfs; accepting it would let a keystore be written there, leaving the keys on
+    # this machine while appearing to be on the device -- the exact failure this
+    # feature exists to prevent. Being a mount point is what makes a path a device.
+    if not os.path.ismount(real):
+        raise ProtocolError(
+            'root_not_mounted',
+            f'{root} is not a mounted device'
+        )
+    return real
+
+
+def resolve(root, path):
+    """Resolve a relative path inside root, refusing anything that escapes it."""
+    if not isinstance(path, str) or not path:
+        raise ProtocolError('bad_path', 'path must be a non-empty string')
+    if os.path.isabs(path):
+        raise ProtocolError('bad_path', 'path must be relative to the root')
+    target = os.path.realpath(os.path.join(root, path))
+    # realpath has resolved any symlinks, so this check also catches a link inside
+    # the device pointing somewhere outside it.
+    if target != root and not target.startswith(root + os.sep):
+        raise ProtocolError('bad_path', 'path escapes the keystore root')
+    return target
+
+
+def op_hello(_request):
+    return {
+        'version': VERSION,
+        'platform': sys.platform,
+        'allowedRootPrefixes': list(ALLOWED_ROOT_PREFIXES)
+    }
+
+
+def op_list_devices(_request):
+    """Removable media currently mounted.
+
+    Firefox has no directory picker, so the extension cannot ask the user to choose
+    a folder the way Chrome does. Enumerating the mounted devices here lets it offer
+    a list instead, which needs no picker and is arguably clearer.
+    """
+    devices = []
+    for prefix in ALLOWED_ROOT_PREFIXES:
+        if not os.path.isdir(prefix):
+            continue
+        for entry in sorted(os.listdir(prefix)):
+            path = os.path.join(prefix, entry)
+            # udisks2 nests per-user: /run/media/<user>/<label>
+            candidates = [path]
+            if os.path.isdir(path) and prefix in ('/run/media', '/media'):
+                try:
+                    candidates += [os.path.join(path, sub)
+                                   for sub in sorted(os.listdir(path))
+                                   if os.path.isdir(os.path.join(path, sub))]
+                except OSError:
+                    pass
+            for candidate in candidates:
+                if not os.path.ismount(candidate):
+                    continue
+                devices.append({
+                    'path': candidate,
+                    'label': os.path.basename(candidate),
+                    'writable': os.access(candidate, os.W_OK)
+                })
+    return {'devices': devices}
+
+
+def op_probe(request):
+    root = check_root(request.get('root'))
+    return {'available': True, 'writable': os.access(root, os.W_OK)}
+
+
+def op_read(request):
+    root = check_root(request.get('root'))
+    target = resolve(root, request.get('path'))
+    if not os.path.isfile(target):
+        raise ProtocolError('not_found', 'no such file')
+    if os.path.getsize(target) > MAX_FILE:
+        raise ProtocolError('too_large', 'file exceeds the size limit')
+    with open(target, 'r', encoding='utf-8') as handle:
+        return {'content': handle.read()}
+
+
+def op_write(request):
+    root = check_root(request.get('root'))
+    target = resolve(root, request.get('path'))
+    if os.path.basename(target) not in SAFE_NAME:
+        raise ProtocolError('name_not_allowed',
+                            f'{os.path.basename(target)} is not a keystore file')
+    content = request.get('content')
+    if not isinstance(content, str):
+        raise ProtocolError('bad_content', 'content must be a string')
+    if len(content.encode('utf-8')) > MAX_FILE:
+        raise ProtocolError('too_large', 'content exceeds the size limit')
+    os.makedirs(os.path.dirname(target), exist_ok=True)
+    # Same staged write the in-browser backend performs: write beside the target,
+    # flush to the device, keep the previous generation, then rename into place.
+    # rename() within a directory is atomic on POSIX, so a reader sees either the
+    # old file or the new one, never a partial write.
+    directory = os.path.dirname(target)
+    handle, staged = tempfile.mkstemp(dir=directory, prefix='.mvelo-', suffix='.tmp')
+    try:
+        with os.fdopen(handle, 'w', encoding='utf-8') as staged_file:
+            staged_file.write(content)
+            staged_file.flush()
+            os.fsync(staged_file.fileno())
+        if os.path.exists(target):
+            backup = target + '.bak'
+            if os.path.exists(backup):
+                os.unlink(backup)
+            os.replace(target, backup)
+        os.replace(staged, target)
+        staged = None
+    finally:
+        if staged and os.path.exists(staged):
+            os.unlink(staged)
+    return {'ok': True}
+
+
+def op_remove(request):
+    root = check_root(request.get('root'))
+    target = resolve(root, request.get('path'))
+    if os.path.basename(target) not in SAFE_NAME:
+        raise ProtocolError('name_not_allowed', 'not a keystore file')
+    if os.path.exists(target):
+        os.unlink(target)
+    return {'ok': True}
+
+
+def op_list(request):
+    root = check_root(request.get('root'))
+    path = request.get('path')
+    target = root if not path else resolve(root, path)
+    if not os.path.isdir(target):
+        return {'names': []}
+    return {'names': sorted(os.listdir(target))}
+
+
+OPERATIONS = {
+    'hello': op_hello,
+    'listDevices': op_list_devices,
+    'probe': op_probe,
+    'read': op_read,
+    'write': op_write,
+    'remove': op_remove,
+    'list': op_list,
+}
+
+
+def handle(request):
+    """Dispatch one request to a response, never raising."""
+    request_id = request.get('id') if isinstance(request, dict) else None
+    try:
+        if not isinstance(request, dict):
+            raise ProtocolError('bad_request', 'request must be an object')
+        operation = OPERATIONS.get(request.get('op'))
+        if not operation:
+            raise ProtocolError('unknown_op', f"unknown operation {request.get('op')!r}")
+        return {'id': request_id, 'result': operation(request)}
+    except ProtocolError as error:
+        return {'id': request_id, 'error': error.code, 'message': str(error)}
+    except OSError as error:
+        # Device pulled mid-operation lands here; report it as unavailable rather
+        # than as a protocol fault, so the extension can treat it as absence.
+        return {'id': request_id, 'error': 'io_error', 'message': error.strerror or str(error)}
+    except Exception as error:  # noqa: BLE001 - a host that dies stops answering
+        return {'id': request_id, 'error': 'internal', 'message': str(error)}
+
+
+def main():
+    while True:
+        try:
+            request = read_message()
+        except ProtocolError as error:
+            write_message({'error': error.code, 'message': str(error)})
+            continue
+        except (ValueError, struct.error) as error:
+            write_message({'error': 'bad_message', 'message': str(error)})
+            continue
+        if request is None:
+            return 0
+        write_message(handle(request))
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/native-host/mailvelope_usb_keystore.py
+++ b/native-host/mailvelope_usb_keystore.py
@@ -30,6 +30,18 @@ arbitrary paths.
   * Only the file names this feature uses are writable; see SAFE_NAME.
   * Reads and writes are size-capped, so a hostile request cannot exhaust memory.
 
+SIZE AND CHUNKING
+-----------------
+A browser caps a single message from a native host at 1 MB, in both Firefox and
+Chrome. That cap belongs to the browser, not to this host: an oversized response is
+dropped before the extension ever sees it, so it can only be stayed under, never
+raised. A whole public keyring is one file here -- `gpg --export --armor` of a
+sizeable keyring is comfortably several megabytes -- so both directions are chunked:
+`read` takes a byte offset and returns one chunk, and `write` takes a byte offset and
+a `final` flag, staging chunks in one part file and renaming it into place on the
+last one. The atomicity guarantee is unchanged: the target is replaced by a rename
+after the whole content has been staged and flushed.
+
 None of this defends against a user who is already running malicious code as
 themselves. It defends against the realistic case: a bug or a compromise in the
 extension turning into arbitrary file access.
@@ -39,15 +51,31 @@ import json
 import os
 import struct
 import sys
-import tempfile
 
 VERSION = 1
 
-# Native messaging caps a single message at 1 MB in each direction. Stay well under
-# it: a keyring of any sane size is far smaller, and the cap is a useful bound on
-# what a single request can cost.
-MAX_MESSAGE = 768 * 1024
-MAX_FILE = 512 * 1024
+# Bytes of file content carried by one message, in either direction.
+#
+# The binding constraint is the browser's 1 MB cap on a message from the host, so
+# this leaves room for JSON escaping: armored key text carries a newline every 64
+# characters and each becomes a two-byte \n, which is about 1.5% of expansion.
+# Writes use the same size even though the inbound cap is far more generous (4 GB in
+# Firefox, 1 MB in Chrome), so that one code path serves both browsers.
+CHUNK_BYTES = 384 * 1024
+
+# Hard ceiling on a response, checked after encoding. A response over the browser's
+# cap is discarded by the browser, so replacing it with an error is the only way the
+# extension learns anything at all.
+MAX_RESPONSE = 768 * 1024
+
+# Inbound cap. Only a bound on what one request can cost in memory now that writes
+# are chunked -- a chunk plus its JSON overhead is under half a megabyte.
+MAX_MESSAGE = 4 * 1024 * 1024
+
+# Ceiling on a single keystore file. This has to allow for a keyring rather than a
+# key: importing a public keyring exported with `gpg --export --armor` puts all of it
+# in one public.asc.
+MAX_FILE = 16 * 1024 * 1024
 
 # Roots must live directly under one of these. Removable media only: this is what
 # stops the browser asking for $HOME or /etc.
@@ -72,25 +100,56 @@ class ProtocolError(Exception):
         self.code = code
 
 
+def read_exactly(count):
+    """Read exactly count bytes, or None if the stream ends first."""
+    parts, remaining = [], count
+    while remaining:
+        part = sys.stdin.buffer.read(remaining)
+        if not part:
+            return None
+        parts.append(part)
+        remaining -= len(part)
+    return b''.join(parts)
+
+
+def discard(count):
+    """Consume and drop count bytes of a message that will not be served."""
+    while count:
+        part = sys.stdin.buffer.read(min(count, 64 * 1024))
+        if not part:
+            return
+        count -= len(part)
+
+
 def read_message():
     """Read one native message, or None at end of stream."""
-    header = sys.stdin.buffer.read(4)
-    if len(header) < 4:
+    header = read_exactly(4)
+    if header is None:
         return None
     length = struct.unpack('=I', header)[0]
     if length > MAX_MESSAGE:
+        # Consume the body even though the message is refused. Leaving it in the pipe
+        # made the next read take message bytes for a length header, so a single
+        # oversized message desynchronised the host for the rest of the session and
+        # every later request failed for an unrelated-looking reason.
+        discard(length)
         raise ProtocolError('too_large', f'message of {length} bytes exceeds the limit')
-    payload = sys.stdin.buffer.read(length)
+    payload = read_exactly(length)
+    if payload is None:
+        raise ProtocolError('bad_message', f'stream ended inside a {length} byte message')
     return json.loads(payload.decode('utf-8'))
 
 
 def write_message(message):
     """Write one native message."""
-    encoded = json.dumps(message).encode('utf-8')
-    if len(encoded) > MAX_MESSAGE:
+    # Compact separators: the browser's 1 MB cap counts every byte, and whitespace
+    # between thousands of JSON tokens is not free.
+    encoded = json.dumps(message, separators=(',', ':')).encode('utf-8')
+    if len(encoded) > MAX_RESPONSE:
         encoded = json.dumps({
+            'id': message.get('id') if isinstance(message, dict) else None,
             'error': 'too_large',
-            'message': 'response exceeds the native messaging limit'
+            'message': f'response of {len(encoded)} bytes exceeds the native messaging limit'
         }).encode('utf-8')
     sys.stdout.buffer.write(struct.pack('=I', len(encoded)))
     sys.stdout.buffer.write(encoded)
@@ -141,11 +200,55 @@ def resolve(root, path):
     return target
 
 
+def as_offset(value):
+    """Validate a byte offset from a request. Absent means the start of the file."""
+    if value is None:
+        return 0
+    # bool is an int subclass, and True would silently mean offset 1.
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        raise ProtocolError('bad_offset', 'offset must be a non-negative integer')
+    return value
+
+
+def decode_prefix(data):
+    """Decode the longest whole-character UTF-8 prefix of data.
+
+    A chunk boundary lands on an arbitrary byte, so the last character in the chunk
+    may be cut in half. Trimming up to three trailing bytes finds the character
+    boundary; the client is told how many bytes were actually decoded and asks for
+    the rest from there, so nothing is lost. A file that is not valid UTF-8 at all
+    still fails, as it must -- these files are text.
+
+    Returns the text, and how many bytes of data it came from.
+    """
+    for trim in range(min(4, len(data) + 1)):
+        candidate = data[:len(data) - trim] if trim else data
+        try:
+            return candidate.decode('utf-8'), len(candidate)
+        except UnicodeDecodeError:
+            continue
+    raise ProtocolError('bad_encoding', 'file is not valid UTF-8 text')
+
+
+def part_path(target):
+    """Staging file for a chunked write of target.
+
+    Derived from the target rather than random (as a single-message write once was),
+    because each native message is served by a fresh process: the name is the only
+    thing the next chunk has to find the staged content by. Two concurrent writes to
+    one path would collide, which the offset check turns into an error rather than a
+    corrupt file -- and the extension serialises its writes anyway.
+    """
+    return os.path.join(os.path.dirname(target), f'.mvelo-{os.path.basename(target)}.part')
+
+
 def op_hello(_request):
     return {
         'version': VERSION,
         'platform': sys.platform,
-        'allowedRootPrefixes': list(ALLOWED_ROOT_PREFIXES)
+        'allowedRootPrefixes': list(ALLOWED_ROOT_PREFIXES),
+        'chunkBytes': CHUNK_BYTES,
+        'maxFileBytes': MAX_FILE
     }
 
 
@@ -188,17 +291,55 @@ def op_probe(request):
 
 
 def op_read(request):
+    """One chunk of a file, starting at a byte offset.
+
+    Chunked because the browser drops any response over 1 MB before the extension
+    sees it. A caller reads from offset 0 and follows nextOffset until eof.
+    """
     root = check_root(request.get('root'))
     target = resolve(root, request.get('path'))
     if not os.path.isfile(target):
         raise ProtocolError('not_found', 'no such file')
-    if os.path.getsize(target) > MAX_FILE:
-        raise ProtocolError('too_large', 'file exceeds the size limit')
-    with open(target, 'r', encoding='utf-8') as handle:
-        return {'content': handle.read()}
+    size = os.path.getsize(target)
+    if size > MAX_FILE:
+        raise ProtocolError('too_large',
+                            f'file of {size} bytes exceeds the {MAX_FILE} byte limit')
+    offset = as_offset(request.get('offset'))
+    if offset > size:
+        raise ProtocolError('bad_offset', f'offset {offset} is past the end of a {size} byte file')
+    limit = CHUNK_BYTES
+    requested = request.get('maxBytes')
+    if isinstance(requested, int) and not isinstance(requested, bool) and 0 < requested < limit:
+        limit = requested
+    with open(target, 'rb') as handle:
+        handle.seek(offset)
+        data = handle.read(limit)
+    content, consumed = decode_prefix(data)
+    if data and not consumed:
+        # Cannot happen with a chunk of any real size, but a client that trusted
+        # nextOffset would spin forever if it ever did.
+        raise ProtocolError('bad_encoding', 'no whole character fits in the chunk')
+    return {
+        'content': content,
+        'offset': offset,
+        'bytesRead': consumed,
+        'nextOffset': offset + consumed,
+        'size': size,
+        'eof': offset + consumed >= size
+    }
 
 
 def op_write(request):
+    """Write one chunk of a file, and on the final chunk publish it.
+
+    Chunks are appended to a staging file beside the target and only renamed into
+    place once the last one has arrived and been flushed to the device -- the same
+    staged write as before, spread over as many messages as the content needs.
+    rename() within a directory is atomic on POSIX, so a reader sees either the old
+    file or the complete new one, never a partial write.
+
+    A write with neither offset nor final is one whole file, exactly as before.
+    """
     root = check_root(request.get('root'))
     target = resolve(root, request.get('path'))
     if os.path.basename(target) not in SAFE_NAME:
@@ -207,20 +348,38 @@ def op_write(request):
     content = request.get('content')
     if not isinstance(content, str):
         raise ProtocolError('bad_content', 'content must be a string')
-    if len(content.encode('utf-8')) > MAX_FILE:
-        raise ProtocolError('too_large', 'content exceeds the size limit')
+    offset = as_offset(request.get('offset'))
+    final = request.get('final', True) is not False
+    data = content.encode('utf-8')
+    if offset + len(data) > MAX_FILE:
+        raise ProtocolError('too_large',
+                            f'content of {offset + len(data)} bytes exceeds the '
+                            f'{MAX_FILE} byte limit')
     os.makedirs(os.path.dirname(target), exist_ok=True)
-    # Same staged write the in-browser backend performs: write beside the target,
-    # flush to the device, keep the previous generation, then rename into place.
-    # rename() within a directory is atomic on POSIX, so a reader sees either the
-    # old file or the new one, never a partial write.
-    directory = os.path.dirname(target)
-    handle, staged = tempfile.mkstemp(dir=directory, prefix='.mvelo-', suffix='.tmp')
+    staged = part_path(target)
+    if offset:
+        if not os.path.isfile(staged):
+            raise ProtocolError('bad_offset',
+                                'no staged write to continue; start again at offset 0')
+        staged_size = os.path.getsize(staged)
+        if staged_size != offset:
+            raise ProtocolError('bad_offset',
+                                f'staged write holds {staged_size} bytes, '
+                                f'chunk starts at {offset}')
     try:
-        with os.fdopen(handle, 'w', encoding='utf-8') as staged_file:
-            staged_file.write(content)
+        # offset 0 truncates, which also clears anything left behind by a write that
+        # was abandoned midway -- a device pulled between chunks leaves the part file
+        # on it, and the target it would have replaced untouched.
+        with open(staged, 'ab' if offset else 'wb') as staged_file:
+            staged_file.write(data)
             staged_file.flush()
-            os.fsync(staged_file.fileno())
+            if final:
+                # fsync flushes the file, not merely what this descriptor wrote, so
+                # one at the end covers every chunk -- and each chunk paying for its
+                # own would be felt on flash media.
+                os.fsync(staged_file.fileno())
+        if not final:
+            return {'ok': True, 'staged': offset + len(data)}
         if os.path.exists(target):
             backup = target + '.bak'
             if os.path.exists(backup):
@@ -229,7 +388,9 @@ def op_write(request):
         os.replace(staged, target)
         staged = None
     finally:
-        if staged and os.path.exists(staged):
+        # Only the failed final chunk cleans up: an incomplete write keeps its
+        # staging file, because the next chunk is what continues it.
+        if staged and final and os.path.exists(staged):
             os.unlink(staged)
     return {'ok': True}
 
@@ -241,6 +402,11 @@ def op_remove(request):
         raise ProtocolError('name_not_allowed', 'not a keystore file')
     if os.path.exists(target):
         os.unlink(target)
+    # A write abandoned midway leaves its staging file on the device. Deleting the
+    # file it was going to become is as good a moment as any to drop it.
+    staged = part_path(target)
+    if os.path.exists(staged):
+        os.unlink(staged)
     return {'ok': True}
 
 

--- a/native-host/mailvelope_usb_keystore.py
+++ b/native-host/mailvelope_usb_keystore.py
@@ -311,6 +311,17 @@ def op_read(request):
     requested = request.get('maxBytes')
     if isinstance(requested, int) and not isinstance(requested, bool) and 0 < requested < limit:
         limit = requested
+    # A request carrying neither field is asking for the whole file, from a client
+    # that will not follow nextOffset. Handing it the first chunk would answer with a
+    # prefix that looks like a complete file: a keyring read that way loses every key
+    # past the cut, silently, and the caller has no way to tell. This is not
+    # hypothetical -- an extension build from before chunked reads did exactly that,
+    # and a 412-key keyring came back as 132. Refuse instead.
+    if 'offset' not in request and 'maxBytes' not in request and size > limit:
+        raise ProtocolError(
+            'needs_chunked_read',
+            f'file of {size} bytes must be read in chunks; this request asked for all of it'
+        )
     with open(target, 'rb') as handle:
         handle.seek(offset)
         data = handle.read(limit)

--- a/native-host/test_host.py
+++ b/native-host/test_host.py
@@ -107,15 +107,26 @@ class PathHandling(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.root = None
+        cls.skipped = 'no writable removable device mounted'
         response = one({'op': 'listDevices'})
         devices = response.get('result', {}).get('devices', [])
-        writable = [d for d in devices if d.get('writable')]
-        if writable:
-            cls.root = writable[0]['path']
+        for device in devices:
+            if not device.get('writable'):
+                continue
+            # Never a device that holds a real keystore. These tests write and delete
+            # files on whatever they are pointed at, and a stick carrying someone's
+            # only copy of their keys is not a test fixture. Use the scratch tmpfs
+            # device from the install notes instead.
+            if os.path.isdir(os.path.join(device['path'], 'mailvelope-keystore')):
+                cls.skipped = (f"{device['path']} holds a keystore; "
+                               'mount a scratch device for these tests')
+                continue
+            cls.root = device['path']
+            break
 
     def setUp(self):
         if not self.root:
-            self.skipTest('no writable removable device mounted')
+            self.skipTest(self.skipped)
 
     def test_rejects_traversal(self):
         for path in ('../../../../etc/passwd',
@@ -319,6 +330,23 @@ class Chunking(unittest.TestCase):
         self.assertEqual(chunk['bytesRead'], 2, 'should stop before the split character')
         self.assertFalse(chunk['eof'])
         self.assertEqual(self.read_all(max_bytes=3), content)
+
+    # The failure this actually caused: an extension build from before chunked reads
+    # asked for the whole file, got the first chunk, and showed a 412-key keyring as
+    # 132 keys -- with nothing anywhere reporting a problem.
+    def test_refuses_to_answer_a_whole_file_request_with_a_prefix(self):
+        self.write('x' * (host.CHUNK_BYTES + 1))
+        with self.assertRaises(host.ProtocolError) as caught:
+            host.op_read({'root': self.root, 'path': self.path})
+        self.assertEqual(caught.exception.code, 'needs_chunked_read')
+
+    # ...but a file that fits in one chunk has no prefix to hide, so the simple form
+    # of the request keeps working.
+    def test_serves_a_small_file_without_a_chunked_request(self):
+        self.write('small enough')
+        chunk = host.op_read({'root': self.root, 'path': self.path})
+        self.assertEqual(chunk['content'], 'small enough')
+        self.assertTrue(chunk['eof'])
 
     def test_reports_offsets_and_the_end_of_the_file(self):
         self.write('0123456789')

--- a/native-host/test_host.py
+++ b/native-host/test_host.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+# Copyright (C) 2026 Noam Rathaus
+# Licensed under the GNU Affero General Public License version 3
+"""Tests for the USB keystore native messaging host.
+
+This host runs with the user's full filesystem authority and is driven by the
+browser, so the tests that matter most are the ones that try to escape the keystore
+root. They are not hypothetical: the mount-point requirement exists because an
+earlier version accepted /run/media/<user>, which is local tmpfs rather than the
+device -- keys written there would have been on this machine while appearing to be
+on the stick.
+
+Run directly: python3 native-host/test_host.py
+No dependencies, so it works wherever the host itself does.
+"""
+
+import json
+import os
+import struct
+import subprocess
+import sys
+import tempfile
+import unittest
+
+HOST = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                    'mailvelope_usb_keystore.py')
+
+
+def call(*requests):
+    """Send requests through the host exactly as a browser would."""
+    payload = b''
+    for request in requests:
+        encoded = json.dumps(request).encode('utf-8')
+        payload += struct.pack('=I', len(encoded)) + encoded
+    process = subprocess.run([sys.executable, HOST], input=payload,
+                             capture_output=True, check=False)
+    responses, out = [], process.stdout
+    while len(out) >= 4:
+        length = struct.unpack('=I', out[:4])[0]
+        responses.append(json.loads(out[4:4 + length]))
+        out = out[4 + length:]
+    return responses
+
+
+def one(request):
+    responses = call(request)
+    return responses[0] if responses else {'error': 'no_response'}
+
+
+class Confinement(unittest.TestCase):
+    """The host must refuse anything outside a mounted removable device."""
+
+    def assertRefused(self, request, code=None):
+        response = one(request)
+        self.assertIn('error', response, f'should have been refused: {request}')
+        if code:
+            self.assertEqual(response['error'], code)
+        return response
+
+    def test_rejects_system_directories(self):
+        for root in ('/etc', '/', '/usr', '/home', os.path.expanduser('~')):
+            self.assertRefused({'op': 'list', 'root': root}, 'root_not_allowed')
+
+    def test_rejects_the_prefix_itself(self):
+        self.assertRefused({'op': 'list', 'root': '/run/media'}, 'root_not_allowed')
+
+    # An earlier version allowed this. It is under an allowed prefix but is not a
+    # mount point: it is local tmpfs holding the user's mount points.
+    def test_rejects_a_directory_under_a_prefix_that_is_not_a_mount(self):
+        root = f'/run/media/{os.environ.get("USER", "nobody")}'
+        if not os.path.isdir(root):
+            self.skipTest('no per-user media directory on this machine')
+        self.assertRefused({'op': 'list', 'root': root}, 'root_not_mounted')
+
+    def test_rejects_a_temporary_directory(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertRefused({'op': 'list', 'root': tmp}, 'root_not_allowed')
+
+    def test_rejects_nonsense_roots(self):
+        for root in (None, '', 42, [], {}):
+            self.assertRefused({'op': 'list', 'root': root})
+
+
+class PathHandling(unittest.TestCase):
+    """Path checks are exercised against a real mounted device when one exists."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.root = None
+        response = one({'op': 'listDevices'})
+        devices = response.get('result', {}).get('devices', [])
+        writable = [d for d in devices if d.get('writable')]
+        if writable:
+            cls.root = writable[0]['path']
+
+    def setUp(self):
+        if not self.root:
+            self.skipTest('no writable removable device mounted')
+
+    def test_rejects_traversal(self):
+        for path in ('../../../../etc/passwd',
+                     'mailvelope-keystore/../../../../etc/hosts',
+                     '..',
+                     'a/../../..'):
+            response = one({'op': 'read', 'root': self.root, 'path': path})
+            self.assertIn('error', response, f'traversal not blocked: {path}')
+
+    def test_rejects_absolute_paths(self):
+        response = one({'op': 'read', 'root': self.root, 'path': '/etc/passwd'})
+        self.assertEqual(response['error'], 'bad_path')
+
+    # Without this, the write path could be used to drop a file of the caller's
+    # choosing anywhere inside the device -- a shell script, a desktop entry.
+    def test_only_writes_known_keystore_files(self):
+        for name in ('evil.sh', 'autorun.inf', '.bashrc', 'index.html'):
+            response = one({'op': 'write', 'root': self.root,
+                            'path': f'mailvelope-keystore/{name}', 'content': 'x'})
+            self.assertEqual(response['error'], 'name_not_allowed', name)
+
+    def test_write_read_remove_round_trip(self):
+        path = 'mailvelope-keystore/meta.json'
+        content = json.dumps({'test': True})
+        self.assertIn('result', one({'op': 'write', 'root': self.root,
+                                     'path': path, 'content': content}))
+        read = one({'op': 'read', 'root': self.root, 'path': path})
+        self.assertEqual(read['result']['content'], content)
+        self.assertIn('result', one({'op': 'remove', 'root': self.root, 'path': path}))
+        self.assertEqual(one({'op': 'read', 'root': self.root,
+                              'path': path})['error'], 'not_found')
+
+    # The staged write keeps the previous generation, so an interrupted save leaves
+    # something recoverable rather than a truncated file.
+    def test_overwrite_keeps_a_backup(self):
+        path = 'mailvelope-keystore/meta.json'
+        try:
+            one({'op': 'write', 'root': self.root, 'path': path, 'content': 'first'})
+            one({'op': 'write', 'root': self.root, 'path': path, 'content': 'second'})
+            self.assertEqual(one({'op': 'read', 'root': self.root,
+                                  'path': path})['result']['content'], 'second')
+            backup = one({'op': 'read', 'root': self.root, 'path': path + '.bak'})
+            self.assertEqual(backup['result']['content'], 'first')
+        finally:
+            for p in (path, path + '.bak'):
+                target = os.path.join(self.root, p)
+                if os.path.exists(target):
+                    os.unlink(target)
+
+    def test_leaves_no_staging_files_behind(self):
+        path = 'mailvelope-keystore/meta.json'
+        try:
+            one({'op': 'write', 'root': self.root, 'path': path, 'content': 'x'})
+            names = one({'op': 'list', 'root': self.root,
+                         'path': 'mailvelope-keystore'})['result']['names']
+            self.assertEqual([n for n in names if n.endswith('.tmp')], [])
+        finally:
+            target = os.path.join(self.root, path)
+            if os.path.exists(target):
+                os.unlink(target)
+
+
+class Protocol(unittest.TestCase):
+    def test_hello_reports_a_version(self):
+        result = one({'op': 'hello'})['result']
+        self.assertIsInstance(result['version'], int)
+        self.assertIn('allowedRootPrefixes', result)
+
+    def test_unknown_operation(self):
+        self.assertEqual(one({'op': 'exec'})['error'], 'unknown_op')
+
+    def test_malformed_request(self):
+        self.assertIn('error', one({'nope': 1}))
+
+    def test_correlates_responses_by_id(self):
+        responses = call({'id': 'a', 'op': 'hello'}, {'id': 'b', 'op': 'hello'})
+        self.assertEqual([r['id'] for r in responses], ['a', 'b'])
+
+    # A host that dies stops answering, so one bad request must not end the session.
+    def test_survives_a_bad_request_mid_stream(self):
+        responses = call({'id': 1, 'op': 'hello'},
+                         {'id': 2, 'op': 'read', 'root': '/etc', 'path': 'passwd'},
+                         {'id': 3, 'op': 'hello'})
+        self.assertEqual(len(responses), 3)
+        self.assertIn('result', responses[2])
+
+    def test_list_devices_reports_only_mount_points(self):
+        for device in one({'op': 'listDevices'})['result']['devices']:
+            self.assertTrue(os.path.ismount(device['path']), device['path'])
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/native-host/test_host.py
+++ b/native-host/test_host.py
@@ -14,8 +14,10 @@ Run directly: python3 native-host/test_host.py
 No dependencies, so it works wherever the host itself does.
 """
 
+import importlib.util
 import json
 import os
+import shutil
 import struct
 import subprocess
 import sys
@@ -26,12 +28,19 @@ HOST = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                     'mailvelope_usb_keystore.py')
 
 
-def call(*requests):
-    """Send requests through the host exactly as a browser would."""
-    payload = b''
-    for request in requests:
-        encoded = json.dumps(request).encode('utf-8')
-        payload += struct.pack('=I', len(encoded)) + encoded
+def load_host():
+    """Import the host as a module, for tests that call its functions directly."""
+    spec = importlib.util.spec_from_file_location('mvelo_usb_keystore_host', HOST)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+host = load_host()
+
+
+def call_raw(payload):
+    """Send raw bytes down the host's stdin and decode whatever comes back."""
     process = subprocess.run([sys.executable, HOST], input=payload,
                              capture_output=True, check=False)
     responses, out = [], process.stdout
@@ -40,6 +49,17 @@ def call(*requests):
         responses.append(json.loads(out[4:4 + length]))
         out = out[4 + length:]
     return responses
+
+
+def framed(request):
+    """One request in the length-prefixed form the browser sends."""
+    encoded = json.dumps(request).encode('utf-8')
+    return struct.pack('=I', len(encoded)) + encoded
+
+
+def call(*requests):
+    """Send requests through the host exactly as a browser would."""
+    return call_raw(b''.join(framed(request) for request in requests))
 
 
 def one(request):
@@ -145,17 +165,217 @@ class PathHandling(unittest.TestCase):
                 if os.path.exists(target):
                     os.unlink(target)
 
+    # The whole point of chunking, over the real wire and a real filesystem: the
+    # in-process tests cannot exercise the length-prefixed framing, and a FAT32 stick
+    # is where the rename and fsync actually have to hold.
+    def test_a_keyring_sized_file_survives_the_wire(self):
+        path = 'mailvelope-keystore/meta.json'
+        content = ('-----BEGIN PGP PUBLIC KEY BLOCK-----\n' +
+                   'mQINBF\n' * 300 +
+                   '-----END PGP PUBLIC KEY BLOCK-----\n') * 700
+        data = content.encode('utf-8')
+        self.assertGreater(len(data), 1024 * 1024)
+        try:
+            requests, offset = [], 0
+            while offset < len(data):
+                end = min(offset + host.CHUNK_BYTES, len(data))
+                requests.append({'op': 'write', 'root': self.root, 'path': path,
+                                 'content': data[offset:end].decode('utf-8'),
+                                 'offset': offset, 'final': end >= len(data)})
+                offset = end
+            self.assertGreater(len(requests), 1, 'content must need more than one message')
+            for response in call(*requests):
+                self.assertIn('result', response)
+
+            parts, offset = [], 0
+            while True:
+                chunk = one({'op': 'read', 'root': self.root, 'path': path,
+                             'offset': offset})['result']
+                parts.append(chunk['content'])
+                if chunk['eof']:
+                    break
+                offset = chunk['nextOffset']
+            self.assertEqual(''.join(parts), content)
+        finally:
+            one({'op': 'remove', 'root': self.root, 'path': path})
+            backup = os.path.join(self.root, path + '.bak')
+            if os.path.exists(backup):
+                os.unlink(backup)
+
     def test_leaves_no_staging_files_behind(self):
         path = 'mailvelope-keystore/meta.json'
         try:
             one({'op': 'write', 'root': self.root, 'path': path, 'content': 'x'})
             names = one({'op': 'list', 'root': self.root,
                          'path': 'mailvelope-keystore'})['result']['names']
-            self.assertEqual([n for n in names if n.endswith('.tmp')], [])
+            self.assertEqual([n for n in names if n.startswith('.mvelo-')], [])
         finally:
             target = os.path.join(self.root, path)
             if os.path.exists(target):
                 os.unlink(target)
+
+
+class Chunking(unittest.TestCase):
+    """The chunk bookkeeping, exercised in-process against a temporary directory.
+
+    A browser drops a message from the host that exceeds 1 MB before the extension
+    sees it, so a keyring of any size has to move in pieces. What can go wrong is
+    bookkeeping: a chunk landing at the wrong offset, a half-written file published as
+    if it were whole, or a character cut in half at a chunk boundary.
+
+    The content operations refuse a root that is not a mounted removable device, and a
+    test cannot mount one -- so these call them with the root check replaced by
+    realpath. That check is what Confinement covers, in a real subprocess.
+    """
+
+    def setUp(self):
+        self.root = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.root)
+        self.original_check_root = host.check_root
+        host.check_root = os.path.realpath
+        self.addCleanup(self.restore_check_root)
+        self.path = 'mailvelope-keystore/public.asc'
+        self.target = os.path.join(self.root, self.path)
+
+    def restore_check_root(self):
+        host.check_root = self.original_check_root
+
+    def write(self, content, offset=0, final=True):
+        return host.op_write({'root': self.root, 'path': self.path,
+                              'content': content, 'offset': offset, 'final': final})
+
+    def read_all(self, max_bytes=None):
+        """Read the way the extension does: from 0, following nextOffset."""
+        parts, offset = [], 0
+        while True:
+            request = {'root': self.root, 'path': self.path, 'offset': offset}
+            if max_bytes:
+                request['maxBytes'] = max_bytes
+            chunk = host.op_read(request)
+            parts.append(chunk['content'])
+            if chunk['eof']:
+                return ''.join(parts)
+            self.assertGreater(chunk['nextOffset'], offset, 'read made no progress')
+            offset = chunk['nextOffset']
+
+    def test_a_keyring_larger_than_one_message_round_trips(self):
+        block = '-----BEGIN PGP PUBLIC KEY BLOCK-----\n' + 'mQINBF\n' * 300 + \
+                '-----END PGP PUBLIC KEY BLOCK-----\n'
+        keyring = block * 700
+        data = keyring.encode('utf-8')
+        self.assertGreater(len(data), 1024 * 1024, 'test content must exceed the 1 MB cap')
+        offset = 0
+        while offset < len(data):
+            end = min(offset + host.CHUNK_BYTES, len(data))
+            self.write(data[offset:end].decode('utf-8'), offset=offset, final=end >= len(data))
+            offset = end
+        self.assertEqual(self.read_all(), keyring)
+
+    def test_only_the_final_chunk_publishes_the_file(self):
+        self.write('first half ', final=False)
+        self.assertFalse(os.path.exists(self.target), 'published before the last chunk')
+        self.assertTrue(os.path.exists(host.part_path(self.target)), 'nothing staged')
+        self.write('second half', offset=len('first half '), final=True)
+        with open(self.target, encoding='utf-8') as handle:
+            self.assertEqual(handle.read(), 'first half second half')
+
+    def test_a_finished_write_leaves_no_staging_file(self):
+        self.write('x' * 10, final=False)
+        self.write('y' * 10, offset=10, final=True)
+        self.assertEqual([n for n in os.listdir(os.path.dirname(self.target))
+                          if n.startswith('.mvelo-')], [])
+
+    # Out-of-order chunks would corrupt the file silently, so they are refused rather
+    # than written where they claim to belong.
+    def test_refuses_a_chunk_at_the_wrong_offset(self):
+        self.write('abc', final=False)
+        with self.assertRaises(host.ProtocolError) as caught:
+            self.write('def', offset=99, final=True)
+        self.assertEqual(caught.exception.code, 'bad_offset')
+
+    def test_refuses_a_continuation_with_nothing_staged(self):
+        with self.assertRaises(host.ProtocolError) as caught:
+            self.write('def', offset=3, final=True)
+        self.assertEqual(caught.exception.code, 'bad_offset')
+
+    def test_an_unchunked_write_still_works(self):
+        host.op_write({'root': self.root, 'path': self.path, 'content': 'plain'})
+        self.assertEqual(self.read_all(), 'plain')
+
+    def test_overwriting_a_chunked_write_keeps_a_backup(self):
+        self.write('first')
+        self.write('second')
+        with open(self.target + '.bak', encoding='utf-8') as handle:
+            self.assertEqual(handle.read(), 'first')
+
+    # A chunk boundary falls on an arbitrary byte, and a user ID with a non-ASCII name
+    # will eventually straddle one. Half a character cannot be sent as JSON text, so
+    # the host stops short of it and reports how far it actually got.
+    def test_a_read_boundary_inside_a_character_loses_nothing(self):
+        content = 'a' + 'e\u0301' * 20  # each combining mark is two bytes
+        self.write(content)
+        # Three bytes reach into the middle of the two-byte mark, so only two come back.
+        chunk = host.op_read({'root': self.root, 'path': self.path, 'maxBytes': 3})
+        self.assertEqual(chunk['bytesRead'], 2, 'should stop before the split character')
+        self.assertFalse(chunk['eof'])
+        self.assertEqual(self.read_all(max_bytes=3), content)
+
+    def test_reports_offsets_and_the_end_of_the_file(self):
+        self.write('0123456789')
+        chunk = host.op_read({'root': self.root, 'path': self.path, 'offset': 4, 'maxBytes': 3})
+        self.assertEqual(chunk, {'content': '456', 'offset': 4, 'bytesRead': 3,
+                                 'nextOffset': 7, 'size': 10, 'eof': False})
+        end = host.op_read({'root': self.root, 'path': self.path, 'offset': 10})
+        self.assertEqual(end['content'], '')
+        self.assertTrue(end['eof'])
+
+    def test_refuses_an_offset_past_the_end(self):
+        self.write('short')
+        for bad in (99, -1, 'x', True):
+            with self.assertRaises(host.ProtocolError, msg=repr(bad)):
+                host.op_read({'root': self.root, 'path': self.path, 'offset': bad})
+
+    def test_refuses_a_file_that_is_not_text(self):
+        os.makedirs(os.path.dirname(self.target), exist_ok=True)
+        with open(self.target, 'wb') as handle:
+            handle.write(b'\xff\xfe not utf-8')
+        with self.assertRaises(host.ProtocolError) as caught:
+            host.op_read({'root': self.root, 'path': self.path})
+        self.assertEqual(caught.exception.code, 'bad_encoding')
+
+    def test_removing_a_file_drops_its_staging_file(self):
+        self.write('abandoned', final=False)
+        host.op_remove({'root': self.root, 'path': self.path})
+        self.assertEqual(os.listdir(os.path.dirname(self.target)), [])
+
+    def test_refuses_content_beyond_the_file_limit(self):
+        with self.assertRaises(host.ProtocolError) as caught:
+            self.write('x', offset=host.MAX_FILE, final=True)
+        self.assertEqual(caught.exception.code, 'too_large')
+
+    # A response over the browser's cap is dropped before the extension sees it, so
+    # an error in its place is the only way the failure is ever reported.
+    def test_replaces_an_oversized_response_with_an_error(self):
+        captured = []
+
+        class Sink:
+            @staticmethod
+            def write(data):
+                captured.append(data)
+
+            @staticmethod
+            def flush():
+                pass
+
+        original = sys.stdout
+        sys.stdout = type('Out', (), {'buffer': Sink})
+        try:
+            host.write_message({'id': 7, 'result': {'content': 'x' * (host.MAX_RESPONSE + 1)}})
+        finally:
+            sys.stdout = original
+        body = json.loads(b''.join(captured)[4:])
+        self.assertEqual(body['error'], 'too_large')
+        self.assertEqual(body['id'], 7)
 
 
 class Protocol(unittest.TestCase):
@@ -173,6 +393,27 @@ class Protocol(unittest.TestCase):
     def test_correlates_responses_by_id(self):
         responses = call({'id': 'a', 'op': 'hello'}, {'id': 'b', 'op': 'hello'})
         self.assertEqual([r['id'] for r in responses], ['a', 'b'])
+
+    def test_hello_reports_the_chunk_size(self):
+        result = one({'op': 'hello'})['result']
+        self.assertIsInstance(result['chunkBytes'], int)
+        self.assertLess(result['chunkBytes'], 1024 * 1024)
+        self.assertGreater(result['maxFileBytes'], result['chunkBytes'])
+
+    # Importing a public keyring sent one oversized message, and the body was left in
+    # the pipe: the next read took message bytes for a length header, so one refused
+    # message broke every request after it.
+    def test_an_oversized_message_does_not_desynchronise_the_stream(self):
+        oversized = host.MAX_MESSAGE + 1
+        payload = struct.pack('=I', oversized) + b'{' + b'x' * (oversized - 1)
+        responses = call_raw(payload + framed({'id': 'after', 'op': 'hello'}))
+        self.assertEqual(responses[0]['error'], 'too_large')
+        self.assertEqual(responses[1]['id'], 'after')
+        self.assertIn('result', responses[1])
+
+    def test_reports_a_message_that_ends_early(self):
+        responses = call_raw(struct.pack('=I', 4096) + b'{"op":"hello"}')
+        self.assertEqual(responses[0]['error'], 'bad_message')
 
     # A host that dies stops answering, so one bad request must not end the session.
     def test_survives_a_bad_request_mid_stream(self):

--- a/src/app/app.js
+++ b/src/app/app.js
@@ -31,6 +31,7 @@ import Decrypt from './decrypt/Decrypt';
 import Settings from './settings/Settings';
 import AnalyticsConsent from './settings/AnalyticsConsent';
 import Onboarding from './onboarding/Onboarding';
+import UsbStatusBanner from '../components/usb/UsbStatusBanner';
 
 import './app.scss';
 
@@ -120,6 +121,7 @@ class App extends React.Component {
         />
 
         <main className={`container-lg ${(this.state.prefs && !this.state.prefs.security.personalized && this.props.location.pathname !== '/settings/security-background') ? 'featured' : ''}`} role="main">
+          <UsbStatusBanner />
           <AppOptions.Provider value={{gnupg: this.state.gnupg}}>
             <Route path="/dashboard" component={Dashboard} />
             <Route path="/keyring" render={() => <Keyring prefs={this.state.prefs} />} />

--- a/src/app/app.js
+++ b/src/app/app.js
@@ -32,6 +32,7 @@ import Settings from './settings/Settings';
 import AnalyticsConsent from './settings/AnalyticsConsent';
 import Onboarding from './onboarding/Onboarding';
 import UsbStatusBanner from '../components/usb/UsbStatusBanner';
+import UsbErrorToast from '../components/usb/UsbErrorToast';
 
 import './app.scss';
 
@@ -122,6 +123,7 @@ class App extends React.Component {
 
         <main className={`container-lg ${(this.state.prefs && !this.state.prefs.security.personalized && this.props.location.pathname !== '/settings/security-background') ? 'featured' : ''}`} role="main">
           <UsbStatusBanner />
+          <UsbErrorToast />
           <AppOptions.Provider value={{gnupg: this.state.gnupg}}>
             <Route path="/dashboard" component={Dashboard} />
             <Route path="/keyring" render={() => <Keyring prefs={this.state.prefs} />} />

--- a/src/app/keyring/GenerateKey.js
+++ b/src/app/keyring/GenerateKey.js
@@ -41,6 +41,29 @@ export default class GenerateKey extends React.Component {
 
   componentDidMount() {
     this.setState(this.getInitialState(this.context));
+    this.applyUsbDefaults();
+  }
+
+  /**
+   * Default the key server upload off when keys live on a USB device.
+   *
+   * Uploading publishes the association between this identity and the key. That is
+   * a deliberate act of publication, which sits oddly with having taken the keys
+   * off the machine in the first place, so it should be opted into rather than
+   * out of. Still a default, not a prohibition: the checkbox remains available.
+   */
+  async applyUsbDefaults() {
+    let status;
+    try {
+      status = await port.send('usb-get-status');
+    } catch (e) {
+      return;
+    }
+    if (!status?.enabled) {
+      return;
+    }
+    // Leave it alone if the user has already touched the form.
+    this.setState(state => (state.modified ? null : {mveloKeyServerUpload: false}));
   }
 
   getInitialState({gnupg = false, demail = false} = {}) {

--- a/src/app/keyring/Key.js
+++ b/src/app/keyring/Key.js
@@ -268,11 +268,11 @@ export default class Key extends React.Component {
         <div className="card-title d-flex align-items-center justify-content-between flex-wrap">
           <h2 className="d-inline-flex align-items-center">{this.state.keyDetails.name} <KeyStatus className="small ml-2" status={this.state.keyDetails.status} /></h2>
           <div className="btn-bar">
-            {(!this.context.gnupg || this.state.keyDetails.type === 'public') && <button type="button" onClick={() => this.setState({showDeleteModal: true})} className="btn btn-secondary" title={l10n.map.key_remove_btn_title}>{l10n.map.key_remove_btn}</button>}
+            {(!this.context.gnupg || this.state.keyDetails.type === 'public') && <button type="button" onClick={() => this.setState({showDeleteModal: true})} className="btn btn-secondary" disabled={this.props.canModify === false} title={this.props.cannotModifyReason || l10n.map.key_remove_btn_title}>{l10n.map.key_remove_btn}</button>}
             <button type="button" onClick={() => this.setState({showExportModal: true})} className="btn btn-secondary" title={l10n.map.key_export_btn_title}>{l10n.map.key_export_btn}</button>
             {(!this.context.gnupg && this.state.keyDetails.type !== 'public') &&
               <>
-                <button type="button" onClick={() => this.setState({showRevokeModal: true})} className="btn btn-secondary" disabled={!this.state.keyDetails.validity} title={l10n.map.key_revoke_btn_title}>{l10n.map.key_revoke_btn}</button>
+                <button type="button" onClick={() => this.setState({showRevokeModal: true})} className="btn btn-secondary" disabled={!this.state.keyDetails.validity || this.props.canModify === false} title={this.props.cannotModifyReason || l10n.map.key_revoke_btn_title}>{l10n.map.key_revoke_btn}</button>
                 <DefaultKeyButton onClick={this.handleDefaultClick} isDefault={this.state.isDefault} disabled={!this.state.keyDetails.validDefaultKey} />
               </>
             }
@@ -323,6 +323,10 @@ export default class Key extends React.Component {
 Key.contextType = KeyringOptions;
 
 Key.propTypes = {
+  // Whether the keystore can accept changes. Destructive controls are disabled
+  // rather than offered and then refused; see canModifyKeys.
+  canModify: PropTypes.bool,
+  cannotModifyReason: PropTypes.string,
   keyData: PropTypes.object,
   getKeyDetails: PropTypes.func,
   defaultKeyFpr: PropTypes.string,

--- a/src/app/keyring/KeyGrid.js
+++ b/src/app/keyring/KeyGrid.js
@@ -14,6 +14,7 @@ import Modal from '../../components/util/Modal';
 import Alert from '../../components/util/Alert';
 import SimpleDialog from '../../components/util/SimpleDialog';
 import KeyringSelect from './components/KeyringSelect';
+import UsbStatusBadge from '../../components/usb/UsbStatusBadge';
 import {Redirect, Link} from 'react-router-dom';
 import './KeyGrid.scss';
 
@@ -168,16 +169,30 @@ export default class KeyGrid extends React.Component {
       <div className="card-body">
         <div className="card-title d-flex flex-wrap align-items-center">
           <h1 className="flex-shrink-0 mr-auto">{l10n.map.keyring_header}</h1>
+          {/* Where the keys actually live belongs on the page that lists them. The
+              badge was previously only on the import and generate headings, which
+              are the least useful places for it. */}
+          <div className="flex-shrink-0 mr-3">
+            <UsbStatusBadge />
+          </div>
           <div className="flex-shrink-0">
             <KeyringSelect keyringId={this.context.keyringId} keyringAttr={this.props.keyringAttr} onChange={this.props.onChangeKeyring} onDelete={(keyringId, keyringName) => this.setState({showDeleteKeyringModal: true, activeKeyring: {id: keyringId, name: keyringName}})} prefs={this.props.prefs} />
           </div>
         </div>
         <div className="form-group btn-toolbar justify-content-between" role="toolbar" aria-label="Toolbar with button groups">
           <div className="btn-bar">
-            <Link className="btn btn-secondary" to="/keyring/generate" replace tabIndex="0" title={l10n.map.keygrid_generate_title}>
+            <Link className={`btn btn-secondary ${this.props.canModify === false ? 'disabled' : ''}`}
+              to="/keyring/generate" replace tabIndex={this.props.canModify === false ? '-1' : '0'}
+              aria-disabled={this.props.canModify === false}
+              onClick={event => this.props.canModify === false && event.preventDefault()}
+              title={this.props.cannotModifyReason || l10n.map.keygrid_generate_title}>
               <span className="icon icon-add" aria-hidden="true"></span> {l10n.map.key_gen_generate}
             </Link>
-            <Link className="btn btn-secondary" to="/keyring/import" replace tabIndex="0" title={l10n.map.keygrid_import_title}>
+            <Link className={`btn btn-secondary ${this.props.canModify === false ? 'disabled' : ''}`}
+              to="/keyring/import" replace tabIndex={this.props.canModify === false ? '-1' : '0'}
+              aria-disabled={this.props.canModify === false}
+              onClick={event => this.props.canModify === false && event.preventDefault()}
+              title={this.props.cannotModifyReason || l10n.map.keygrid_import_title}>
               <span className="icon icon-download" aria-hidden="true"></span> {l10n.map.form_import}
             </Link>
             <Link className={`btn btn-secondary ${this.context.demail ? 'd-none' : ''}`} to="/keyring/import/search" replace tabIndex="0" title={l10n.map.keygrid_import_search_title}>
@@ -278,6 +293,11 @@ KeyGrid.propTypes = {
   onDeleteKeyring: PropTypes.func.isRequired,
   onChangeDefaultKey: PropTypes.func.isRequired,
   onDeleteKey: PropTypes.func,
+  // Whether the keystore can accept changes; see canModifyKeys. Generate and Import
+  // are Links, so they are disabled by class and a prevented click rather than the
+  // disabled attribute, which anchors do not have.
+  canModify: PropTypes.bool,
+  cannotModifyReason: PropTypes.string,
   onRefreshKeyring: PropTypes.func,
   spinner: PropTypes.bool,
   location: PropTypes.object,

--- a/src/app/keyring/Keyring.js
+++ b/src/app/keyring/Keyring.js
@@ -138,10 +138,20 @@ class Keyring extends React.Component {
     ]);
     const sortedKeys = keys.sort((a, b) => a.name.localeCompare(b.name));
     const hasPrivateKey = sortedKeys.some(key => key.type === 'private');
+    const wasEmpty = !this.state.keys.length;
     /* eslint-enable react/no-access-state-in-setstate */
     this.setState({
       keyringId, defaultKeyFpr, demail, gnupg, keyringAttr, hasPrivateKey, hasUsablePrivateKey, keys: sortedKeys, setupSkipped: Boolean(setupSkipped), keysLoading: false
     });
+    // The redirect to the setup screen only happens on the exact /keyring path, so
+    // once there the URL is sticky: keys arriving later leave the user looking at
+    // "set up a key" with a perfectly good key loaded behind it. That is precisely
+    // what happens when a USB device is reconnected. Leave the screen when keys
+    // turn up, and only then -- a 0 to N transition cannot be confused with someone
+    // deliberately opening setup while they already have keys.
+    if (wasEmpty && sortedKeys.length && this.props.location?.pathname === '/keyring/setup') {
+      this.props.history.push('/keyring/display');
+    }
   }
 
   async handleSkipSetup() {

--- a/src/app/keyring/Keyring.js
+++ b/src/app/keyring/Keyring.js
@@ -21,6 +21,7 @@ import KeyringSelect from './components/KeyringSelect';
 import KeyringBreadcrumb from './components/KeyringBreadcrumb';
 import Notifications from '../../components/util/Notifications';
 import UsbStatusBadge from '../../components/usb/UsbStatusBadge';
+import {subscribeStatus} from '../../components/usb/usbStatus';
 
 l10n.register([
   'keyring_generate_key',
@@ -80,6 +81,25 @@ class Keyring extends React.Component {
   async componentDidMount() {
     await this.initActiveKeyring();
     await this.loadKeyring();
+    // The background reloads the keystore when the device returns, so refresh the
+    // list rather than leaving the page showing the empty keyring it read while
+    // the device was away.
+    // Reload on any change of device state, in both directions. Leaving READY
+    // matters as much as returning to it: the background purges its keyrings when
+    // the device goes away, so a page that does not refresh keeps listing keys it
+    // can no longer use.
+    this.unsubscribeUsb = subscribeStatus(port, status => {
+      const next = status?.state;
+      const changed = this.usbState !== undefined && this.usbState !== next;
+      this.usbState = next;
+      if (changed) {
+        this.loadKeyring();
+      }
+    });
+  }
+
+  componentWillUnmount() {
+    this.unsubscribeUsb?.();
   }
 
   setStateAsync(state) {

--- a/src/app/keyring/Keyring.js
+++ b/src/app/keyring/Keyring.js
@@ -21,7 +21,7 @@ import KeyringSelect from './components/KeyringSelect';
 import KeyringBreadcrumb from './components/KeyringBreadcrumb';
 import Notifications from '../../components/util/Notifications';
 import UsbStatusBadge from '../../components/usb/UsbStatusBadge';
-import {subscribeStatus} from '../../components/usb/usbStatus';
+import {subscribeStatus, isUnavailable} from '../../components/usb/usbStatus';
 
 l10n.register([
   'keyring_generate_key',
@@ -66,6 +66,7 @@ class Keyring extends React.Component {
       keys: [], // active keyring: keys
       keysLoading: true, // active keyring: waiting for loading of keys
       setupSkipped: false,
+      usbStatus: null,
       notifications: []
     };
     this.handleChangeKeyring = this.handleChangeKeyring.bind(this);
@@ -92,6 +93,8 @@ class Keyring extends React.Component {
       const next = status?.state;
       const changed = this.usbState !== undefined && this.usbState !== next;
       this.usbState = next;
+      // Kept in state so render can tell "no key pair" from "cannot read the keys".
+      this.setState({usbStatus: status});
       if (changed) {
         this.loadKeyring();
       }
@@ -162,7 +165,12 @@ class Keyring extends React.Component {
   }
 
   async handleRefreshKeyring() {
-    if (this.state.gnupg) {
+    // Re-read the store, not just the in-memory copy, whenever the keys live
+    // somewhere Mailvelope does not control. That was already true of GnuPG; it is
+    // equally true of a USB device, whose contents can change while detached or be
+    // edited from another machine. Without this, Refresh silently did less than it
+    // appears to for a USB keystore.
+    if (this.state.gnupg || this.state.usbStatus?.enabled) {
       this.setState({keysLoading: true});
       await port.send('reload-keystore', {keyringId: this.state.keyringId});
     }
@@ -213,7 +221,7 @@ class Keyring extends React.Component {
                       <KeyringSetup
                         generatePath="/keyring/generate"
                         importPath="/keyring/import"
-                        showNoKeypairAlert={!this.state.hasPrivateKey && !this.state.hasUsablePrivateKey}
+                        showNoKeypairAlert={!this.state.hasPrivateKey && !this.state.hasUsablePrivateKey && !isUnavailable(this.state.usbStatus)}
                         showGnupgFooter
                       />
                     </div>

--- a/src/app/keyring/Keyring.js
+++ b/src/app/keyring/Keyring.js
@@ -20,8 +20,7 @@ import Spinner from '../../components/util/Spinner';
 import KeyringSelect from './components/KeyringSelect';
 import KeyringBreadcrumb from './components/KeyringBreadcrumb';
 import Notifications from '../../components/util/Notifications';
-import UsbStatusBadge from '../../components/usb/UsbStatusBadge';
-import {subscribeStatus, isUnavailable} from '../../components/usb/usbStatus';
+import {subscribeStatus, isUnavailable, canModifyKeys, whyCannotModify} from '../../components/usb/usbStatus';
 
 l10n.register([
   'keyring_generate_key',
@@ -36,7 +35,6 @@ function PageTitle({children}) {
   return (
     <div className="card-title d-flex flex-wrap align-items-center">
       <h1 className="flex-shrink-0 mr-auto">{children}</h1>
-      <UsbStatusBadge />
     </div>
   );
 }
@@ -175,7 +173,20 @@ class Keyring extends React.Component {
   }
 
   async handleDeleteKey(fingerprint, type) {
-    await port.send('removeKey', {fingerprint, type, keyringId: this.state.keyringId});
+    try {
+      await port.send('removeKey', {fingerprint, type, keyringId: this.state.keyringId});
+    } catch (e) {
+      // A swallowed failure here is worse than a visible one: the keyring mutates
+      // memory before persisting, so a refused write made the key vanish from the
+      // list while it remained on the device. Someone deleting a compromised key
+      // would believe it gone.
+      this.handleNotification({
+        header: l10n.map.keyring_header,
+        message: e.message,
+        type: 'error',
+        hideDelay: 10000
+      });
+    }
     this.loadKeyring();
   }
 
@@ -207,9 +218,9 @@ class Keyring extends React.Component {
               ) : (
                 <>
                   <Route exact path="/keyring" render={() => this.state.keys.length || this.state.setupSkipped || this.state.hasUsablePrivateKey ? <Redirect to="/keyring/display" /> : <Redirect to="/keyring/setup" />} />
-                  <Route exact path="/keyring/key/:keyFpr" render={props => <Key {...props} keyData={this.state.keys.find(key => key.fingerprint === props.match.params.keyFpr)} defaultKeyFpr={this.state.defaultKeyFpr} onChangeDefaultKey={this.handleChangeDefaultKey} onDeleteKey={this.handleDeleteKey} onKeyringChange={this.loadKeyring} />} />
+                  <Route exact path="/keyring/key/:keyFpr" render={props => <Key {...props} keyData={this.state.keys.find(key => key.fingerprint === props.match.params.keyFpr)} defaultKeyFpr={this.state.defaultKeyFpr} onChangeDefaultKey={this.handleChangeDefaultKey} onDeleteKey={this.handleDeleteKey} onKeyringChange={this.loadKeyring} canModify={canModifyKeys(this.state.usbStatus)} cannotModifyReason={whyCannotModify(this.state.usbStatus)} />} />
                   <Route exact path="/keyring/key/:keyFpr/user/:userIdx" render={props => <User {...props} keyData={this.state.keys.find(key => key.fingerprint === props.match.params.keyFpr)} onKeyringChange={this.loadKeyring} />} />
-                  <Route path="/keyring/display/:keyId?" render={props => (<KeyGrid keys={this.state.keys} {...props} keyringAttr={this.state.keyringAttr} onChangeKeyring={this.handleChangeKeyring} onDeleteKeyring={this.handleDeleteKeyring} prefs={this.props.prefs} defaultKeyFpr={this.state.defaultKeyFpr} onChangeDefaultKey={this.handleChangeDefaultKey} onDeleteKey={this.handleDeleteKey} onRefreshKeyring={this.handleRefreshKeyring} spinner={this.state.keysLoading} />)} />
+                  <Route path="/keyring/display/:keyId?" render={props => (<KeyGrid keys={this.state.keys} {...props} keyringAttr={this.state.keyringAttr} onChangeKeyring={this.handleChangeKeyring} onDeleteKeyring={this.handleDeleteKeyring} prefs={this.props.prefs} defaultKeyFpr={this.state.defaultKeyFpr} onChangeDefaultKey={this.handleChangeDefaultKey} onDeleteKey={this.handleDeleteKey} onRefreshKeyring={this.handleRefreshKeyring} spinner={this.state.keysLoading} canModify={canModifyKeys(this.state.usbStatus)} cannotModifyReason={whyCannotModify(this.state.usbStatus)} />)} />
                   <Route path="/keyring/import" render={({location}) => (
                     <div className="card-body">
                       <KeyringBreadcrumb />

--- a/src/app/keyring/Keyring.js
+++ b/src/app/keyring/Keyring.js
@@ -95,7 +95,12 @@ class Keyring extends React.Component {
       this.usbState = next;
       // Kept in state so render can tell "no key pair" from "cannot read the keys".
       this.setState({usbStatus: status});
-      if (changed) {
+      // Reload on a change, and also whenever a reachable device coincides with an
+      // empty list: that combination means this page read the keyring before the
+      // background finished loading it from the device, and without a second look
+      // it would keep offering to generate a key that already exists.
+      const staleEmpty = status?.enabled && next === 'READY' && !this.state.keys.length;
+      if (changed || staleEmpty) {
         this.loadKeyring();
       }
     });

--- a/src/app/keyring/Keyring.js
+++ b/src/app/keyring/Keyring.js
@@ -20,6 +20,7 @@ import Spinner from '../../components/util/Spinner';
 import KeyringSelect from './components/KeyringSelect';
 import KeyringBreadcrumb from './components/KeyringBreadcrumb';
 import Notifications from '../../components/util/Notifications';
+import UsbStatusBadge from '../../components/usb/UsbStatusBadge';
 
 l10n.register([
   'keyring_generate_key',
@@ -34,6 +35,7 @@ function PageTitle({children}) {
   return (
     <div className="card-title d-flex flex-wrap align-items-center">
       <h1 className="flex-shrink-0 mr-auto">{children}</h1>
+      <UsbStatusBadge />
     </div>
   );
 }

--- a/src/app/keyring/KeyringSetup.js
+++ b/src/app/keyring/KeyringSetup.js
@@ -8,6 +8,7 @@ import PropTypes from 'prop-types';
 import {Link} from 'react-router-dom';
 import * as l10n from '../../lib/l10n';
 import GnupgFooter from './GnupgFooter';
+import UsbSetupCard from '../../components/usb/UsbSetupCard';
 
 import './KeyringSetup.scss';
 
@@ -60,6 +61,7 @@ export default function KeyringSetup({generatePath, importPath, showNoKeypairAle
             </div>
           </div>
         </div>
+        <UsbSetupCard />
       </div>
       {showGnupgFooter && (
         <GnupgFooter heading={l10n.map.gnupg_connection} body={l10n.map.keyring_available_settings} />

--- a/src/app/keyring/KeyringSetup.js
+++ b/src/app/keyring/KeyringSetup.js
@@ -9,6 +9,7 @@ import {Link} from 'react-router-dom';
 import * as l10n from '../../lib/l10n';
 import GnupgFooter from './GnupgFooter';
 import UsbSetupCard from '../../components/usb/UsbSetupCard';
+import UsbKeyActionGate from '../../components/usb/UsbKeyActionGate';
 
 import './KeyringSetup.scss';
 
@@ -33,34 +34,36 @@ export default function KeyringSetup({generatePath, importPath, showNoKeypairAle
         </div>
       )}
       <div className="row row-cols-1 row-cols-md-2">
-        <div className="col mb-3">
-          <div className="card h-100 border keyring-setup-card">
-            <div className="card-img-top py-5 text-center">
-              <img src="../img/key.svg" width="64" height="64" alt="" />
-            </div>
-            <div className="card-body d-flex flex-column">
-              <h5 className="card-title">{l10n.map.keyring_setup_generate_key}</h5>
-              <p className="card-text flex-grow-1">{l10n.map.keyring_setup_generate_key_explanation}</p>
-              <Link to={generatePath} className="btn btn-primary btn-lg w-100 mt-auto">
-                {l10n.map.keyring_setup_generate_key}
-              </Link>
-            </div>
-          </div>
-        </div>
-        <div className="col mb-3">
-          <div className="card h-100 border keyring-setup-card">
-            <div className="card-img-top py-5 text-center">
-              <img src="../img/attachment.svg" width="64" height="64" alt="" />
-            </div>
-            <div className="card-body d-flex flex-column">
-              <h5 className="card-title">{l10n.map.keyring_setup_import_key}</h5>
-              <p className="card-text flex-grow-1">{l10n.map.keyring_setup_import_key_explanation}</p>
-              <Link to={importPath} className="btn btn-primary btn-lg w-100 mt-auto">
-                {l10n.map.keyring_setup_import_key}
-              </Link>
+        <UsbKeyActionGate>
+          <div className="col mb-3">
+            <div className="card h-100 border keyring-setup-card">
+              <div className="card-img-top py-5 text-center">
+                <img src="../img/key.svg" width="64" height="64" alt="" />
+              </div>
+              <div className="card-body d-flex flex-column">
+                <h5 className="card-title">{l10n.map.keyring_setup_generate_key}</h5>
+                <p className="card-text flex-grow-1">{l10n.map.keyring_setup_generate_key_explanation}</p>
+                <Link to={generatePath} className="btn btn-primary btn-lg w-100 mt-auto">
+                  {l10n.map.keyring_setup_generate_key}
+                </Link>
+              </div>
             </div>
           </div>
-        </div>
+          <div className="col mb-3">
+            <div className="card h-100 border keyring-setup-card">
+              <div className="card-img-top py-5 text-center">
+                <img src="../img/attachment.svg" width="64" height="64" alt="" />
+              </div>
+              <div className="card-body d-flex flex-column">
+                <h5 className="card-title">{l10n.map.keyring_setup_import_key}</h5>
+                <p className="card-text flex-grow-1">{l10n.map.keyring_setup_import_key_explanation}</p>
+                <Link to={importPath} className="btn btn-primary btn-lg w-100 mt-auto">
+                  {l10n.map.keyring_setup_import_key}
+                </Link>
+              </div>
+            </div>
+          </div>
+        </UsbKeyActionGate>
         <UsbSetupCard />
       </div>
       {showGnupgFooter && (

--- a/src/app/settings/Security.js
+++ b/src/app/settings/Security.js
@@ -8,6 +8,7 @@ import PropTypes from 'prop-types';
 import {port} from '../app';
 import {str2bool} from '../../lib/util';
 import * as l10n from '../../lib/l10n';
+import {strings as usbStrings} from '../../modules/usb/strings';
 
 l10n.register([
   'form_cancel',
@@ -35,6 +36,8 @@ export default class Security extends React.Component {
       password_timeout: 30,
       hide_armored_header: false,
       modified: false,
+      // Keys on a USB device override this setting; see usbCacheDisabled in render.
+      usbConfigured: false,
       errors: {}
     };
     this.handleChange = this.handleChange.bind(this);
@@ -54,6 +57,16 @@ export default class Security extends React.Component {
       password_timeout: security.password_timeout,
       hide_armored_header: security.hide_armored_header
     });
+    // Reported separately from the preference, which is deliberately left as the user
+    // set it: disabling the USB keystore should restore their own choice rather than
+    // silently having overwritten it.
+    try {
+      const {enabled} = await port.send('usb-get-status');
+      this.setState({usbConfigured: Boolean(enabled)});
+    } catch (e) {
+      // The setting is merely ineffective if this fails, so it must not break the page.
+      console.log('could not read USB keystore status', e);
+    }
   }
 
   handleChange(event) {
@@ -105,17 +118,20 @@ export default class Security extends React.Component {
         <form className="form">
           <div className="form-group mb-4">
             <h3>{l10n.map.security_cache_header}</h3>
+            {this.state.usbConfigured && (
+              <p className="text-muted small">{usbStrings.cache_disabled}</p>
+            )}
             <div className="form-inline">
               <div className="custom-control custom-radio custom-control-inline mr-2">
-                <input type="radio" name="password_cache" id="pwdCacheRadios1" value="true" checked={this.state.password_cache} onChange={this.handleChange} className="custom-control-input" />
+                <input type="radio" name="password_cache" id="pwdCacheRadios1" value="true" checked={this.state.password_cache && !this.state.usbConfigured} onChange={this.handleChange} disabled={this.state.usbConfigured} className="custom-control-input" />
                 <label className="custom-control-label" htmlFor="pwdCacheRadios1">{l10n.map.security_cache_on}</label>
               </div>
-              <input type="text" maxLength="3" id="pwdCacheTime" name="password_timeout" value={this.state.password_timeout} style={{width: '50px'}} onChange={this.handleChange} className={`form-control mr-2 text-right ${this.state.errors.password_timeout ? 'is-invalid' : ''}`} />
+              <input type="text" maxLength="3" id="pwdCacheTime" name="password_timeout" value={this.state.password_timeout} style={{width: '50px'}} onChange={this.handleChange} disabled={this.state.usbConfigured} className={`form-control mr-2 text-right ${this.state.errors.password_timeout ? 'is-invalid' : ''}`} />
               <label className="my-1 mr-2" htmlFor="pwdCacheTime">{l10n.map.security_cache_time}</label>
               {this.state.errors.password_timeout && <div className="invalid-feedback mb-2">{l10n.map.security_cache_help}</div>}
             </div>
             <div className="custom-control custom-radio custom-control-inline mr-2">
-              <input type="radio" name="password_cache" id="pwdCacheRadios2" value="false" checked={!this.state.password_cache} onChange={this.handleChange} className="custom-control-input" />
+              <input type="radio" name="password_cache" id="pwdCacheRadios2" value="false" checked={!this.state.password_cache || this.state.usbConfigured} onChange={this.handleChange} disabled={this.state.usbConfigured} className="custom-control-input" />
               <label className="custom-control-label" htmlFor="pwdCacheRadios2">{l10n.map.security_cache_off}</label>
             </div>
           </div>

--- a/src/app/settings/Settings.js
+++ b/src/app/settings/Settings.js
@@ -9,6 +9,7 @@ import PropTypes from 'prop-types';
 import {NavPill} from '../util/util';
 import * as l10n from '../../lib/l10n';
 import Notifications from '../../components/util/Notifications';
+import {strings as usbStrings} from '../../modules/usb/strings';
 
 import General from './General';
 import Security from './Security';
@@ -18,6 +19,7 @@ import SecurityLog from './SecurityLog';
 import KeyServer from './keyserver';
 import Provider from './Provider';
 import Analytics from './Analytics';
+import KeyStorageSettings from '../../components/usb/KeyStorageSettings';
 
 l10n.register([
   'settings_analytics',
@@ -62,6 +64,7 @@ export default class Settings extends React.Component {
                       <NavPill to="/settings/security-log">{l10n.map.settings_security_log}</NavPill>
                       <NavPill to="/settings/key-server">{l10n.map.settings_keyserver}</NavPill>
                       <NavPill to="/settings/analytics">{l10n.map.settings_analytics}</NavPill>
+                      <NavPill to="/settings/key-storage">{usbStrings.settings_tab}</NavPill>
                     </div>
                   </div>
                 </div>
@@ -74,6 +77,7 @@ export default class Settings extends React.Component {
                   <Route path="/settings/security-log" component={SecurityLog} />
                   <Route path="/settings/key-server" render={() => <KeyServer prefs={this.props.prefs} onChangePrefs={this.props.onChangePrefs} />} />
                   <Route path="/settings/analytics" component={Analytics} />
+                  <Route path="/settings/key-storage" render={() => <KeyStorageSettings onSetNotification={this.handleSetNotification} />} />
                 </div>
               </div>
             </div>

--- a/src/background.js
+++ b/src/background.js
@@ -21,6 +21,7 @@ import {init as initKeyring} from './modules/keyring';
 import {initController} from './controller/main.controller';
 import {initScriptInjection, initAuthRequestApi} from './lib/inject';
 import {initAnalytics} from './lib/analytics';
+import {installUsbKeystore} from './modules/usb/install';
 
 async function main() {
   initBrowserRuntime();
@@ -28,6 +29,7 @@ async function main() {
   initAuthRequestApi();
   initScriptInjection();
   initAnalytics();
+  await installUsbKeystore();
   await initModel();
   await initKeyring();
 }

--- a/src/components/action-menu/components/ActionMenuBase.js
+++ b/src/components/action-menu/components/ActionMenuBase.js
@@ -5,6 +5,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import UsbActionMenuRow from '../../usb/UsbActionMenuRow';
 import * as l10n from '../../../lib/l10n';
 
 l10n.register([
@@ -24,6 +25,7 @@ l10n.register([
 export default function ActionMenuBase(props) {
   return (
     <>
+      {props.port && <UsbActionMenuRow port={props.port} />}
       <div className="action-menu-content list-group list-group-flush" role="menu" aria-label={l10n.map.action_menu_primary_menu_aria_label}>
         <a className="action-menu-item list-group-item list-group-item-action" id="dashboard" role="menuitem" onClick={props.onMenuItemClickHandler}>
           <div className="action-menu-item-title d-flex align-items-center"><img src="../../img/Mailvelope/dashboard.svg" role="presentation" /> <strong>{l10n.map.action_menu_dashboard_label}</strong></div>
@@ -51,6 +53,7 @@ export default function ActionMenuBase(props) {
 }
 
 ActionMenuBase.propTypes = {
-  onMenuItemClickHandler: PropTypes.func
+  onMenuItemClickHandler: PropTypes.func,
+  port: PropTypes.object
 };
 

--- a/src/components/action-menu/components/ActionMenuWrapper.js
+++ b/src/components/action-menu/components/ActionMenuWrapper.js
@@ -52,7 +52,7 @@ class ActionMenuWrapper extends Component {
     if (!this.state.isSetupDone) {
       actionMenuContent = <ActionMenuSetup onMenuItemClickHandler={e => this.onMenuItemClick(e)} />;
     } else {
-      actionMenuContent = <ActionMenuBase onMenuItemClickHandler={e => this.onMenuItemClick(e)} />;
+      actionMenuContent = <ActionMenuBase onMenuItemClickHandler={e => this.onMenuItemClick(e)} port={this.port} />;
     }
 
     return (

--- a/src/components/enter-password/PasswordDialog.js
+++ b/src/components/enter-password/PasswordDialog.js
@@ -7,6 +7,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import * as l10n from '../../lib/l10n';
 import EventHandler from '../../lib/EventHandler';
+import {strings as usbStrings} from '../../modules/usb/strings';
 import SecurityBG from '../util/SecurityBG';
 import Spinner from '../util/Spinner';
 import Alert from '../util/Alert';
@@ -40,6 +41,9 @@ export default class PasswordDialog extends React.Component {
       userId: '',
       reason: '',
       cache: false,
+      // Set by the controller when keys live on a USB device: the cache refuses to
+      // run then, so the box must not offer something that will not happen.
+      cacheDisabled: false,
       password: '',
       waiting: true,
       showError: false,
@@ -106,12 +110,13 @@ export default class PasswordDialog extends React.Component {
     }, 1200);
   }
 
-  setInitData({keyId, userId, reason, cache}) {
+  setInitData({keyId, userId, reason, cache, cacheDisabled}) {
     this.setState({
       keyId,
       userId,
       reason: reason !== '' ? l10n.map[reason.toLowerCase()] : '',
       cache,
+      cacheDisabled: Boolean(cacheDisabled),
       waiting: false
     });
   }
@@ -176,9 +181,12 @@ export default class PasswordDialog extends React.Component {
                     </div>
                     <div>
                       <div className="custom-control custom-checkbox">
-                        <input type="checkbox" checked={this.state.cache} onChange={e => this.onChangeCache(e.target.checked)} className="custom-control-input" id="remember" />
+                        <input type="checkbox" checked={this.state.cache} disabled={this.state.cacheDisabled} onChange={e => this.onChangeCache(e.target.checked)} className="custom-control-input" id="remember" />
                         <label className="custom-control-label" htmlFor="remember">{l10n.map.pwd_dialog_cache_pwd}</label>
                       </div>
+                      {this.state.cacheDisabled && (
+                        <p className="text-muted small mb-0">{usbStrings.cache_unavailable}</p>
+                      )}
                     </div>
                   </div>
                   <div className="modal-footer justify-content-center border-0 p-4 flex-shrink-0">

--- a/src/components/usb/KeyStorageSettings.js
+++ b/src/components/usb/KeyStorageSettings.js
@@ -216,12 +216,32 @@ export default class KeyStorageSettings extends React.Component {
             <span className={`badge badge-${statusVariant(status)} mr-2`}>{status?.state ?? '…'}</span>
             {describeState(status?.state)}
           </p>
+          {configured && (
+            <dl className="row small mb-3">
+              <dt className="col-sm-4">{strings.status_folder}</dt>
+              <dd className="col-sm-8 mb-1">
+                <code>{status.label || strings.status_folder_unknown}</code>
+                {status.label && <span className="d-block text-muted">{strings.status_path_note}</span>}
+              </dd>
+              {status.keystoreId && (
+                <>
+                  <dt className="col-sm-4">{strings.status_keystore_id}</dt>
+                  <dd className="col-sm-8 mb-0"><code>{status.keystoreId}</code></dd>
+                </>
+              )}
+            </dl>
+          )}
           {configured && status.detail && <p className="text-muted small mb-3">{status.detail}</p>}
           <div className="d-flex flex-wrap">
-            {!configured && (
-              <button type="button" className="btn btn-primary mr-2 mb-2"
+            {/* Offered whenever the device is not usable, not only before setup:
+                a removable device turns up at a different mount point all the time,
+                and requiring "Stop using the USB keystore" first makes re-pointing
+                look like a destructive act. */}
+            {(!configured || status.state !== USB_STATE.READY) && (
+              <button type="button"
+                className={`btn mr-2 mb-2 ${configured ? 'btn-secondary' : 'btn-primary'}`}
                 onClick={() => this.handleChooseDirectory()} disabled={busy || !isPickerAvailable()}>
-                {strings.choose_directory}
+                {configured ? strings.choose_other_directory : strings.choose_directory}
               </button>
             )}
             {configured && (
@@ -246,7 +266,9 @@ export default class KeyStorageSettings extends React.Component {
             )}
           </div>
           <p className="text-muted small mb-0">
-            {configured ? strings.disable_hint : strings.choose_directory_hint}
+            {!configured && strings.choose_directory_hint}
+            {configured && status.state !== USB_STATE.READY && strings.choose_other_directory_hint}
+            {configured && status.state === USB_STATE.READY && strings.disable_hint}
           </p>
           {diagnostics?.keyrings?.length > 0 && (
             <ul className="list-unstyled small text-muted mt-3 mb-0">

--- a/src/components/usb/KeyStorageSettings.js
+++ b/src/components/usb/KeyStorageSettings.js
@@ -205,6 +205,19 @@ export default class KeyStorageSettings extends React.Component {
     );
   }
 
+  /**
+   * How recently the device was checked, in words.
+   * @return {String}
+   */
+  describeFreshness() {
+    const checkedAt = this.state.status?.checkedAt;
+    if (!checkedAt) {
+      return '';
+    }
+    const seconds = Math.max(0, Math.round((Date.now() - checkedAt) / 1000));
+    return seconds < 2 ? strings.status_checked_now : strings.status_checked_ago.replace('$1', String(seconds));
+  }
+
   renderDevicePanel() {
     const {status, diagnostics, busy} = this.state;
     const configured = Boolean(status?.enabled);
@@ -212,9 +225,18 @@ export default class KeyStorageSettings extends React.Component {
       <div className="card mb-4">
         <div className="card-body">
           <h3 className="h6">{strings.status_heading}</h3>
-          <p className="mb-3">
+          <p className="mb-1">
             <span className={`badge badge-${statusVariant(status)} mr-2`}>{status?.state ?? '…'}</span>
             {describeState(status?.state)}
+          </p>
+          {/* Freshness rather than a countdown: while this page is visible the
+              device is rechecked every second, so a countdown would just flicker.
+              What is worth showing is that the status is live and how recently it
+              was confirmed -- and if this stops advancing, checking has stopped. */}
+          <p className="text-muted small mb-3">
+            {this.describeFreshness()}
+            {' · '}
+            {document.visibilityState === 'visible' ? strings.status_checking_live : strings.status_checking_background}
           </p>
           {configured && (
             <dl className="row small mb-3">

--- a/src/components/usb/KeyStorageSettings.js
+++ b/src/components/usb/KeyStorageSettings.js
@@ -47,7 +47,14 @@ export default class KeyStorageSettings extends React.Component {
   componentDidMount() {
     this.unsubscribe = subscribeStatus(port, status => {
       this.setState({status});
-      this.refreshDetails(status);
+      // Only on a change of state, not on every tick. This page polls the device
+      // once a second, and the details it loads now include a count of the keys on
+      // the device -- which means reading the key files. Doing that every second
+      // would keep a removable device busy for no news.
+      if (status?.state !== this.detailsFor) {
+        this.detailsFor = status?.state;
+        this.refreshDetails(status);
+      }
     });
   }
 
@@ -61,6 +68,7 @@ export default class KeyStorageSettings extends React.Component {
    * @param {Object} status
    */
   async refreshDetails(status) {
+    this.detailsFor = status?.state;
     try {
       this.setState({local: await port.send('usb-inspect-local')});
     } catch (e) {
@@ -252,6 +260,43 @@ export default class KeyStorageSettings extends React.Component {
     return seconds < 2 ? strings.status_checked_now : strings.status_checked_ago.replace('$1', String(seconds));
   }
 
+  /**
+   * What the device holds, and what the extension actually loaded from it.
+   *
+   * Two numbers rather than one: they are normally the same, and when they are not,
+   * the difference is the whole story. A keyring that arrived in part looks like a
+   * smaller keyring everywhere else in the UI.
+   * @return {React.Node}
+   */
+  renderKeyCounts() {
+    const keyrings = this.state.diagnostics?.keyrings;
+    if (!keyrings) {
+      return <span className="text-muted">{strings.status_keys_unknown}</span>;
+    }
+    const sum = (which, type) => keyrings.reduce((total, keyring) => total + (keyring[which]?.[type] ?? 0), 0);
+    const onDevice = {publicKeys: sum('onDevice', 'publicKeys'), privateKeys: sum('onDevice', 'privateKeys')};
+    // A keyring the extension has not loaded at all reports null rather than zero, and
+    // counting it as zero would raise a false alarm about an incomplete read.
+    const counted = keyrings.filter(keyring => keyring.loaded);
+    const loadedTotal = counted.reduce((total, keyring) => total + keyring.loaded.publicKeys + keyring.loaded.privateKeys, 0);
+    const deviceTotal = onDevice.publicKeys + onDevice.privateKeys;
+    const incomplete = counted.length === keyrings.length && loadedTotal < deviceTotal;
+    return (
+      <>
+        {strings.status_keys_counts
+        .replace('$1', String(onDevice.publicKeys))
+        .replace('$2', String(onDevice.privateKeys))}
+        {incomplete && (
+          <span className="d-block text-danger">
+            {strings.status_keys_incomplete
+            .replace('$1', String(loadedTotal))
+            .replace('$2', String(deviceTotal))}
+          </span>
+        )}
+      </>
+    );
+  }
+
   renderDevicePanel() {
     const {status, diagnostics, busy} = this.state;
     const configured = Boolean(status?.enabled);
@@ -282,7 +327,13 @@ export default class KeyStorageSettings extends React.Component {
               {status.keystoreId && (
                 <>
                   <dt className="col-sm-4">{strings.status_keystore_id}</dt>
-                  <dd className="col-sm-8 mb-0"><code>{status.keystoreId}</code></dd>
+                  <dd className="col-sm-8 mb-1"><code>{status.keystoreId}</code></dd>
+                </>
+              )}
+              {status.state === USB_STATE.READY && (
+                <>
+                  <dt className="col-sm-4">{strings.status_keys}</dt>
+                  <dd className="col-sm-8 mb-0">{this.renderKeyCounts()}</dd>
                 </>
               )}
             </dl>
@@ -332,7 +383,15 @@ export default class KeyStorageSettings extends React.Component {
           {diagnostics?.keyrings?.length > 0 && (
             <ul className="list-unstyled small text-muted mt-3 mb-0">
               {diagnostics.keyrings.map(keyring => (
-                <li key={keyring.dir}><code>{keyring.dir}</code>: {keyring.files.join(', ')}</li>
+                <li key={keyring.dir}>
+                  <code>{keyring.dir}</code>: {keyring.files.join(', ')}
+                  {keyring.onDevice && (
+                    <span className="d-block text-muted">
+                      {`device ${keyring.onDevice.publicKeys} public / ${keyring.onDevice.privateKeys} pairs`}
+                      {keyring.loaded && ` · loaded ${keyring.loaded.publicKeys} public / ${keyring.loaded.privateKeys} pairs`}
+                    </span>
+                  )}
+                </li>
               ))}
             </ul>
           )}

--- a/src/components/usb/KeyStorageSettings.js
+++ b/src/components/usb/KeyStorageSettings.js
@@ -14,8 +14,11 @@ import PropTypes from 'prop-types';
 import {port} from '../../app/app';
 import {USB_STATE} from '../../modules/usb/constants';
 import {strings, describeState} from '../../modules/usb/strings';
-import {pickDirectory, isPickerAvailable} from '../../modules/usb/provision';
+import {pickDirectory, isPickerAvailable, regrantPermission} from '../../modules/usb/provision';
 import {STORAGE, storageOf, statusVariant, subscribeStatus, updateStatus} from './usbStatus';
+
+/** Provisioning refusals the user is allowed to overrule. */
+const OVERRIDABLE = ['USB_KEYSTORE_DIFFERENT_DEVICE', 'USB_KEYSTORE_NOT_CONFIGURED_DEVICE'];
 
 export default class KeyStorageSettings extends React.Component {
   constructor(props) {
@@ -27,13 +30,16 @@ export default class KeyStorageSettings extends React.Component {
       pendingUsb: false,  // 'USB' selected in the UI but no device chosen yet
       busy: false,
       error: null,
-      notice: null
+      notice: null,
+      adoptable: null  // label to retry with when a refusal can be overridden
     };
     this.handleSelectStorage = this.handleSelectStorage.bind(this);
     this.handleChooseDirectory = this.handleChooseDirectory.bind(this);
     this.handleMigrate = this.handleMigrate.bind(this);
     this.handleDisable = this.handleDisable.bind(this);
     this.handleProbe = this.handleProbe.bind(this);
+    this.handleReconnect = this.handleReconnect.bind(this);
+    this.handleAdopt = this.handleAdopt.bind(this);
   }
 
   componentDidMount() {
@@ -73,7 +79,7 @@ export default class KeyStorageSettings extends React.Component {
    * @param {String} [notice] - success message
    */
   async run(fn, notice) {
-    this.setState({busy: true, error: null, notice: null});
+    this.setState({busy: true, error: null, notice: null, adoptable: null});
     try {
       const status = await fn();
       if (status) {
@@ -102,15 +108,50 @@ export default class KeyStorageSettings extends React.Component {
     this.setState({pendingUsb: true, error: null, notice: null});
   }
 
-  handleChooseDirectory() {
+  /**
+   * @param {Boolean} [adoptArg] - true only when the user has explicitly agreed to
+   *   switch to a different keystore. Coerced strictly: React hands a click event
+   *   to an unwrapped handler, and a truthy event must not read as consent.
+   */
+  handleChooseDirectory(adoptArg) {
+    const adopt = adoptArg === true;
     return this.run(async () => {
       const {name} = await pickDirectory();
-      return port.send('usb-provision', {label: name});
+      try {
+        return await port.send('usb-provision', {label: name, adopt});
+      } catch (e) {
+        // Two refusals are the user's to overrule: a folder holding a different
+        // keystore, or none at all. Offer the override rather than dead-ending.
+        if (OVERRIDABLE.includes(e.code)) {
+          this.setState({adoptable: name});
+        }
+        throw e;
+      }
     });
+  }
+
+  handleAdopt() {
+    const label = this.state.adoptable;
+    return this.run(() => port.send('usb-provision', {label, adopt: true}));
   }
 
   handleProbe() {
     return this.run(() => port.send('usb-probe'));
+  }
+
+  /**
+   * Restore access to the directory already configured, falling back to a full
+   * pick only if there is nothing stored or the user declines.
+   */
+  handleReconnect() {
+    return this.run(async () => {
+      const {granted} = await regrantPermission();
+      if (!granted) {
+        const {name} = await pickDirectory();
+        return port.send('usb-provision', {label: name});
+      }
+      return port.send('usb-probe');
+    });
   }
 
   handleMigrate() {
@@ -179,7 +220,7 @@ export default class KeyStorageSettings extends React.Component {
           <div className="d-flex flex-wrap">
             {!configured && (
               <button type="button" className="btn btn-primary mr-2 mb-2"
-                onClick={this.handleChooseDirectory} disabled={busy || !isPickerAvailable()}>
+                onClick={() => this.handleChooseDirectory()} disabled={busy || !isPickerAvailable()}>
                 {strings.choose_directory}
               </button>
             )}
@@ -189,7 +230,7 @@ export default class KeyStorageSettings extends React.Component {
                     picking the directory again from this page. */}
                 {status.state === USB_STATE.PERMISSION_REQUIRED && (
                   <button type="button" className="btn btn-primary mr-2 mb-2"
-                    onClick={this.handleChooseDirectory} disabled={busy}>
+                    onClick={this.handleReconnect} disabled={busy}>
                     {strings.reconnect}
                   </button>
                 )}
@@ -253,12 +294,25 @@ export default class KeyStorageSettings extends React.Component {
   }
 
   render() {
-    const {status, pendingUsb, error, notice} = this.state;
+    const {status, pendingUsb, error, notice, adoptable} = this.state;
     const showDevice = pendingUsb || Boolean(status?.enabled);
     return (
       <div id="key-storage">
         <h2 className="mb-4">{strings.settings_tab}</h2>
-        {error && <div className="alert alert-danger">{error}</div>}
+        {error && (
+          <div className="alert alert-danger">
+            <p className={adoptable ? 'mb-2' : 'mb-0'}>{error}</p>
+            {adoptable && (
+              <>
+                <p className="mb-2 small">{strings.adopt_hint}</p>
+                <button type="button" className="btn btn-sm btn-danger"
+                  onClick={this.handleAdopt} disabled={this.state.busy}>
+                  {strings.adopt_anyway}
+                </button>
+              </>
+            )}
+          </div>
+        )}
         {notice && <div className="alert alert-success">{notice}</div>}
         {this.renderStorageChoice()}
         {showDevice && this.renderDevicePanel()}

--- a/src/components/usb/KeyStorageSettings.js
+++ b/src/components/usb/KeyStorageSettings.js
@@ -1,0 +1,283 @@
+/**
+ * Copyright (C) 2026 Noam Rathaus
+ * Licensed under the GNU Affero General Public License version 3
+ *
+ * Settings page for where key material is stored: this computer, or a USB device.
+ *
+ * Framed as a storage location rather than a feature toggle so the current location
+ * is always legible. The directory picker has to run here, in the page: it needs a
+ * document and a user gesture, which the service worker has neither of.
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import {port} from '../../app/app';
+import {USB_STATE} from '../../modules/usb/constants';
+import {strings, describeState} from '../../modules/usb/strings';
+import {pickDirectory, isPickerAvailable} from '../../modules/usb/provision';
+import {STORAGE, storageOf, statusVariant, subscribeStatus, updateStatus} from './usbStatus';
+
+export default class KeyStorageSettings extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      status: null,
+      local: null,        // key material still in the browser profile
+      diagnostics: null,
+      pendingUsb: false,  // 'USB' selected in the UI but no device chosen yet
+      busy: false,
+      error: null,
+      notice: null
+    };
+    this.handleSelectStorage = this.handleSelectStorage.bind(this);
+    this.handleChooseDirectory = this.handleChooseDirectory.bind(this);
+    this.handleMigrate = this.handleMigrate.bind(this);
+    this.handleDisable = this.handleDisable.bind(this);
+    this.handleProbe = this.handleProbe.bind(this);
+  }
+
+  componentDidMount() {
+    this.unsubscribe = subscribeStatus(port, status => {
+      this.setState({status});
+      this.refreshDetails(status);
+    });
+  }
+
+  componentWillUnmount() {
+    this.unsubscribe?.();
+  }
+
+  /**
+   * Reload the informational panels. Takes the status explicitly rather than reading
+   * it back out of state, which may not have been applied yet.
+   * @param {Object} status
+   */
+  async refreshDetails(status) {
+    try {
+      this.setState({local: await port.send('usb-inspect-local')});
+    } catch (e) {
+      // Informational only; a failure here must not break the page.
+    }
+    if (status?.state !== USB_STATE.READY) {
+      this.setState({diagnostics: null});
+      return;
+    }
+    try {
+      this.setState({diagnostics: await port.send('usb-diagnostics')});
+    } catch (e) {}
+  }
+
+  /**
+   * Run an action with a busy flag, surfacing failures rather than swallowing them.
+   * @param {Function} fn - resolves to a status object, or undefined
+   * @param {String} [notice] - success message
+   */
+  async run(fn, notice) {
+    this.setState({busy: true, error: null, notice: null});
+    try {
+      const status = await fn();
+      if (status) {
+        // Share it with the other subscribed components, not just this page.
+        updateStatus(status);
+        this.setState({status});
+      }
+      if (notice) {
+        this.setState({notice});
+      }
+      await this.refreshDetails(status ?? this.state.status);
+    } catch (e) {
+      this.setState({error: e.message});
+    } finally {
+      this.setState({busy: false});
+    }
+  }
+
+  handleSelectStorage({target}) {
+    if (target.value === STORAGE.LOCAL) {
+      this.handleDisable();
+      return;
+    }
+    // Selecting 'USB device' only reveals the setup panel. Nothing moves until a
+    // directory is actually chosen, so a mis-click cannot relocate key material.
+    this.setState({pendingUsb: true, error: null, notice: null});
+  }
+
+  handleChooseDirectory() {
+    return this.run(async () => {
+      const {name} = await pickDirectory();
+      return port.send('usb-provision', {label: name});
+    });
+  }
+
+  handleProbe() {
+    return this.run(() => port.send('usb-probe'));
+  }
+
+  handleMigrate() {
+    return this.run(async () => {
+      const {moved, failed} = await port.send('usb-migrate');
+      if (failed.length) {
+        throw new Error(strings.migrate_failed.replace('$1', failed.map(item => item.key).join(', ')));
+      }
+      this.setState({notice: strings.migrate_done.replace('$1', String(moved.length))});
+      return port.send('usb-get-status');
+    });
+  }
+
+  handleDisable() {
+    return this.run(() => port.send('usb-disable'));
+  }
+
+  renderStorageChoice() {
+    const {status, busy, pendingUsb} = this.state;
+    const selected = pendingUsb ? STORAGE.USB : storageOf(status);
+    const pickerAvailable = isPickerAvailable();
+    return (
+      <fieldset className="form-group">
+        <legend className="h6">{strings.storage_heading}</legend>
+        <div className="custom-control custom-radio mb-3">
+          <input
+            type="radio" id="storage-local" name="storage" value={STORAGE.LOCAL}
+            className="custom-control-input" checked={selected === STORAGE.LOCAL}
+            onChange={this.handleSelectStorage} disabled={busy}
+          />
+          <label className="custom-control-label" htmlFor="storage-local">
+            <strong>{strings.storage_local_label}</strong>
+            <span className="d-block text-muted">{strings.storage_local_description}</span>
+          </label>
+        </div>
+        <div className="custom-control custom-radio">
+          <input
+            type="radio" id="storage-usb" name="storage" value={STORAGE.USB}
+            className="custom-control-input" checked={selected === STORAGE.USB}
+            onChange={this.handleSelectStorage} disabled={busy || !pickerAvailable}
+          />
+          <label className="custom-control-label" htmlFor="storage-usb">
+            <strong>{strings.storage_usb_label}</strong>
+            <span className="d-block text-muted">{strings.storage_usb_description}</span>
+          </label>
+        </div>
+        {!pickerAvailable && (
+          <div className="alert alert-secondary mt-3 mb-0">{strings.status_unsupported}</div>
+        )}
+      </fieldset>
+    );
+  }
+
+  renderDevicePanel() {
+    const {status, diagnostics, busy} = this.state;
+    const configured = Boolean(status?.enabled);
+    return (
+      <div className="card mb-4">
+        <div className="card-body">
+          <h3 className="h6">{strings.status_heading}</h3>
+          <p className="mb-3">
+            <span className={`badge badge-${statusVariant(status)} mr-2`}>{status?.state ?? '…'}</span>
+            {describeState(status?.state)}
+          </p>
+          {configured && status.detail && <p className="text-muted small mb-3">{status.detail}</p>}
+          <div className="d-flex flex-wrap">
+            {!configured && (
+              <button type="button" className="btn btn-primary mr-2 mb-2"
+                onClick={this.handleChooseDirectory} disabled={busy || !isPickerAvailable()}>
+                {strings.choose_directory}
+              </button>
+            )}
+            {configured && (
+              <>
+                {/* Re-granting permission needs a user gesture, so reconnecting means
+                    picking the directory again from this page. */}
+                {status.state === USB_STATE.PERMISSION_REQUIRED && (
+                  <button type="button" className="btn btn-primary mr-2 mb-2"
+                    onClick={this.handleChooseDirectory} disabled={busy}>
+                    {strings.reconnect}
+                  </button>
+                )}
+                <button type="button" className="btn btn-secondary mr-2 mb-2"
+                  onClick={this.handleProbe} disabled={busy}>
+                  {strings.check_again}
+                </button>
+                <button type="button" className="btn btn-outline-danger mb-2"
+                  onClick={this.handleDisable} disabled={busy}>
+                  {strings.disable}
+                </button>
+              </>
+            )}
+          </div>
+          <p className="text-muted small mb-0">
+            {configured ? strings.disable_hint : strings.choose_directory_hint}
+          </p>
+          {diagnostics?.keyrings?.length > 0 && (
+            <ul className="list-unstyled small text-muted mt-3 mb-0">
+              {diagnostics.keyrings.map(keyring => (
+                <li key={keyring.dir}><code>{keyring.dir}</code>: {keyring.files.join(', ')}</li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  renderMigration() {
+    const {local, status, busy} = this.state;
+    if (!status?.enabled || !local) {
+      return null;
+    }
+    const total = local.privateKeys + local.publicKeys + local.autocrypt;
+    return (
+      <div className="card mb-4">
+        <div className="card-body">
+          <h3 className="h6">{strings.migrate_heading}</h3>
+          {total === 0 ? (
+            <p className="mb-0 text-muted">{strings.migrate_none}</p>
+          ) : (
+            <>
+              <p>{strings.migrate_text}</p>
+              <ul className="small text-muted">
+                <li>{strings.migrate_private.replace('$1', String(local.privateKeys))}</li>
+                <li>{strings.migrate_public.replace('$1', String(local.publicKeys))}</li>
+                <li>{strings.migrate_autocrypt.replace('$1', String(local.autocrypt))}</li>
+              </ul>
+              <div className="alert alert-warning small">{strings.migrate_residue_warning}</div>
+              <button type="button" className="btn btn-primary"
+                onClick={this.handleMigrate}
+                disabled={busy || status.state !== USB_STATE.READY}>
+                {strings.migrate_button}
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  render() {
+    const {status, pendingUsb, error, notice} = this.state;
+    const showDevice = pendingUsb || Boolean(status?.enabled);
+    return (
+      <div id="key-storage">
+        <h2 className="mb-4">{strings.settings_tab}</h2>
+        {error && <div className="alert alert-danger">{error}</div>}
+        {notice && <div className="alert alert-success">{notice}</div>}
+        {this.renderStorageChoice()}
+        {showDevice && this.renderDevicePanel()}
+        {this.renderMigration()}
+        {showDevice && (
+          <div className="card">
+            <div className="card-body small text-muted">
+              <p className="mb-2">{strings.passphrase_required}</p>
+              <p className="mb-2">{strings.encrypted_volume_hint}</p>
+              <p className="mb-2">{strings.formatting_hint}</p>
+              <p className="mb-0">{strings.storage_switch_back_warning}</p>
+            </div>
+          </div>
+        )}
+      </div>
+    );
+  }
+}
+
+KeyStorageSettings.propTypes = {
+  onSetNotification: PropTypes.func
+};

--- a/src/components/usb/KeyStorageSettings.js
+++ b/src/components/usb/KeyStorageSettings.js
@@ -15,6 +15,7 @@ import {port} from '../../app/app';
 import {USB_STATE} from '../../modules/usb/constants';
 import {strings, describeState} from '../../modules/usb/strings';
 import {pickDirectory, isPickerAvailable, regrantPermission} from '../../modules/usb/provision';
+import UsbDevicePicker from './UsbDevicePicker';
 import {STORAGE, storageOf, statusVariant, subscribeStatus, updateStatus} from './usbStatus';
 
 /** Provisioning refusals the user is allowed to overrule. */
@@ -40,6 +41,7 @@ export default class KeyStorageSettings extends React.Component {
     this.handleProbe = this.handleProbe.bind(this);
     this.handleReconnect = this.handleReconnect.bind(this);
     this.handleAdopt = this.handleAdopt.bind(this);
+    this.handleSelectDevice = this.handleSelectDevice.bind(this);
   }
 
   componentDidMount() {
@@ -140,6 +142,26 @@ export default class KeyStorageSettings extends React.Component {
   }
 
   /**
+   * Adopt a device chosen from the helper's list, then provision it. Two steps
+   * because the path has to be recorded before the device can be inspected: the
+   * native backend has no stored handle to recover its location from.
+   * @param {String} devicePath
+   */
+  handleSelectDevice(devicePath) {
+    return this.run(async () => {
+      await port.send('usb-select-device', {devicePath});
+      try {
+        return await port.send('usb-provision', {label: devicePath.split('/').pop()});
+      } catch (e) {
+        if (OVERRIDABLE.includes(e.code)) {
+          this.setState({adoptable: devicePath.split('/').pop()});
+        }
+        throw e;
+      }
+    });
+  }
+
+  /**
    * Restore access to the directory already configured, falling back to a full
    * pick only if there is nothing stored or the user declines.
    */
@@ -169,10 +191,22 @@ export default class KeyStorageSettings extends React.Component {
     return this.run(() => port.send('usb-disable'));
   }
 
+  /**
+   * Whether this browser can configure a device at all.
+   *
+   * Two routes: a directory picker (Chromium), or the native helper enumerating
+   * devices (Firefox). Gating on the picker alone wrongly refused the whole feature
+   * on Firefox once the helper existed.
+   * @return {Boolean}
+   */
+  canConfigure() {
+    return isPickerAvailable() || Boolean(this.state.status?.native);
+  }
+
   renderStorageChoice() {
     const {status, busy, pendingUsb} = this.state;
     const selected = pendingUsb ? STORAGE.USB : storageOf(status);
-    const pickerAvailable = isPickerAvailable();
+    const configurable = this.canConfigure();
     return (
       <fieldset className="form-group">
         <legend className="h6">{strings.storage_heading}</legend>
@@ -191,14 +225,14 @@ export default class KeyStorageSettings extends React.Component {
           <input
             type="radio" id="storage-usb" name="storage" value={STORAGE.USB}
             className="custom-control-input" checked={selected === STORAGE.USB}
-            onChange={this.handleSelectStorage} disabled={busy || !pickerAvailable}
+            onChange={this.handleSelectStorage} disabled={busy || !configurable}
           />
           <label className="custom-control-label" htmlFor="storage-usb">
             <strong>{strings.storage_usb_label}</strong>
             <span className="d-block text-muted">{strings.storage_usb_description}</span>
           </label>
         </div>
-        {!pickerAvailable && (
+        {!configurable && (
           <div className="alert alert-secondary mt-3 mb-0">{strings.status_unsupported}</div>
         )}
       </fieldset>
@@ -258,11 +292,14 @@ export default class KeyStorageSettings extends React.Component {
             {/* Offered whenever the device is not usable, not only before setup:
                 a removable device turns up at a different mount point all the time,
                 and requiring "Stop using the USB keystore" first makes re-pointing
-                look like a destructive act. */}
-            {(!configured || status.state !== USB_STATE.READY) && (
+                look like a destructive act.
+
+                Only on the picker path -- the native path lists devices instead,
+                below, since Firefox has no directory picker. */}
+            {isPickerAvailable() && (!configured || status.state !== USB_STATE.READY) && (
               <button type="button"
                 className={`btn mr-2 mb-2 ${configured ? 'btn-secondary' : 'btn-primary'}`}
-                onClick={() => this.handleChooseDirectory()} disabled={busy || !isPickerAvailable()}>
+                onClick={() => this.handleChooseDirectory()} disabled={busy}>
                 {configured ? strings.choose_other_directory : strings.choose_directory}
               </button>
             )}
@@ -360,6 +397,9 @@ export default class KeyStorageSettings extends React.Component {
         {notice && <div className="alert alert-success">{notice}</div>}
         {this.renderStorageChoice()}
         {showDevice && this.renderDevicePanel()}
+        {showDevice && status?.native && status.state !== USB_STATE.READY && (
+          <UsbDevicePicker onSelect={this.handleSelectDevice} />
+        )}
         {this.renderMigration()}
         {showDevice && (
           <div className="card">

--- a/src/components/usb/UsbActionMenuRow.js
+++ b/src/components/usb/UsbActionMenuRow.js
@@ -1,0 +1,40 @@
+/**
+ * Copyright (C) 2026 Noam Rathaus
+ * Licensed under the GNU Affero General Public License version 3
+ *
+ * Warning row in the toolbar menu when the USB keystore is not connected. Fetches
+ * its own status so the surrounding menu needs no state of its own.
+ */
+
+import React, {useEffect, useState} from 'react';
+import PropTypes from 'prop-types';
+import {strings, describeState} from '../../modules/usb/strings';
+import {isUnavailable} from './usbStatus';
+
+export default function UsbActionMenuRow({port}) {
+  const [status, setStatus] = useState(null);
+  useEffect(() => {
+    let active = true;
+    port.send('usb-get-status')
+    .then(next => active && setStatus(next))
+    .catch(() => {});
+    return () => {
+      active = false;
+    };
+  }, [port]);
+  if (!isUnavailable(status)) {
+    return null;
+  }
+  return (
+    <div className="action-menu-item list-group-item list-group-item-warning" role="menuitem">
+      <div className="action-menu-item-title d-flex align-items-center">
+        <strong>{strings.action_menu_unavailable}</strong>
+      </div>
+      <p className="mb-0">{describeState(status.state)}</p>
+    </div>
+  );
+}
+
+UsbActionMenuRow.propTypes = {
+  port: PropTypes.object.isRequired
+};

--- a/src/components/usb/UsbDevicePicker.js
+++ b/src/components/usb/UsbDevicePicker.js
@@ -1,0 +1,165 @@
+/**
+ * Copyright (C) 2026 Noam Rathaus
+ * Licensed under the GNU Affero General Public License version 3
+ *
+ * Device chooser for the native-host path.
+ *
+ * Firefox has no directory picker, so a folder cannot be chosen the way it is on
+ * Chromium. Instead the helper enumerates mounted removable media and the user picks
+ * from that list. This is arguably the better interface: it only ever offers actual
+ * devices, and it can show the real path, which the File System Access API
+ * deliberately withholds.
+ *
+ * Two prerequisites can be missing, and they need different remedies, so they are
+ * reported separately rather than as one "unavailable":
+ *   - the nativeMessaging permission, which is optional and must be requested
+ *   - the helper program itself, which is installed outside the browser
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import {port} from '../../app/app';
+import {strings} from '../../modules/usb/strings';
+
+export default class UsbDevicePicker extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      devices: null,      // null = not yet asked
+      permission: null,   // null = not yet checked
+      hostMissing: false,
+      busy: false,
+      error: null
+    };
+    this.handleRefresh = this.handleRefresh.bind(this);
+    this.handleGrant = this.handleGrant.bind(this);
+  }
+
+  componentDidMount() {
+    this.checkPermission();
+  }
+
+  /**
+   * The nativeMessaging permission is optional, so it may simply not be granted
+   * yet. Without it every helper call fails, which would otherwise look like a
+   * missing helper.
+   */
+  checkPermission() {
+    if (!chrome.permissions?.contains) {
+      this.setState({permission: true}, this.handleRefresh);
+      return;
+    }
+    chrome.permissions.contains({permissions: ['nativeMessaging']}, granted => {
+      this.setState({permission: granted}, () => {
+        if (granted) {
+          this.handleRefresh();
+        }
+      });
+    });
+  }
+
+  handleGrant() {
+    // Must be called from a user gesture, which is why this is a button rather than
+    // something done automatically on mount.
+    chrome.permissions.request({permissions: ['nativeMessaging']}, granted => {
+      this.setState({permission: granted}, () => {
+        if (granted) {
+          this.handleRefresh();
+        }
+      });
+    });
+  }
+
+  async handleRefresh() {
+    this.setState({busy: true, error: null, hostMissing: false});
+    try {
+      const devices = await port.send('usb-list-devices');
+      this.setState({devices});
+    } catch (e) {
+      // A helper that is not installed cannot be distinguished from one that failed
+      // to start, and the remedy is the same, so both land here.
+      if (e.code === 'USB_HOST_PERMISSION') {
+        this.setState({permission: false, error: null});
+        return;
+      }
+      this.setState({hostMissing: e.code === 'USB_HOST_UNAVAILABLE', error: e.message});
+    } finally {
+      this.setState({busy: false});
+    }
+  }
+
+  handleSelect(devicePath) {
+    return this.props.onSelect(devicePath);
+  }
+
+  render() {
+    const {devices, permission, hostMissing, busy, error} = this.state;
+
+    if (permission === false) {
+      return (
+        <div className="alert alert-warning">
+          <strong className="d-block">{strings.helper_permission_heading}</strong>
+          <p className="mb-2">{strings.helper_permission}</p>
+          <button type="button" className="btn btn-sm btn-primary" onClick={this.handleGrant}>
+            {strings.helper_permission_grant}
+          </button>
+        </div>
+      );
+    }
+
+    if (hostMissing) {
+      return (
+        <div className="alert alert-warning">
+          <strong className="d-block">{strings.helper_needed_heading}</strong>
+          <p className="mb-2">{strings.helper_needed}</p>
+          <button type="button" className="btn btn-sm btn-secondary"
+            onClick={this.handleRefresh} disabled={busy}>
+            {strings.devices_refresh}
+          </button>
+        </div>
+      );
+    }
+
+    return (
+      <div className="card mb-4">
+        <div className="card-body">
+          <h3 className="h6">{strings.devices_heading}</h3>
+          {error && <div className="alert alert-danger small">{error}</div>}
+          {devices?.length === 0 && (
+            <p className="text-muted mb-3">{strings.devices_none}</p>
+          )}
+          {devices?.length > 0 && (
+            <ul className="list-group list-group-flush mb-3">
+              {devices.map(device => (
+                <li key={device.path}
+                  className="list-group-item d-flex align-items-center px-0">
+                  <div className="mr-auto">
+                    <strong>{device.label}</strong>
+                    {!device.writable && (
+                      <span className="badge badge-secondary ml-2">{strings.devices_read_only}</span>
+                    )}
+                    <code className="d-block small text-muted">{device.path}</code>
+                  </div>
+                  <button type="button" className="btn btn-sm btn-primary"
+                    onClick={() => this.handleSelect(device.path)}
+                    disabled={busy || !device.writable}>
+                    {strings.devices_use}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+          <button type="button" className="btn btn-sm btn-secondary"
+            onClick={this.handleRefresh} disabled={busy}>
+            {strings.devices_refresh}
+          </button>
+          <p className="text-muted small mb-0 mt-2">{strings.devices_hint}</p>
+        </div>
+      </div>
+    );
+  }
+}
+
+UsbDevicePicker.propTypes = {
+  onSelect: PropTypes.func.isRequired
+};

--- a/src/components/usb/UsbErrorToast.js
+++ b/src/components/usb/UsbErrorToast.js
@@ -1,0 +1,83 @@
+/**
+ * Copyright (C) 2026 Noam Rathaus
+ * Licensed under the GNU Affero General Public License version 3
+ *
+ * Surfaces USB keystore failures that no component reports.
+ *
+ * The keyring UI has one shape for key operations: swallow a cancelled password
+ * dialog, rethrow everything else. In an async event handler a rethrow becomes an
+ * unhandled promise rejection, so the failure is simply lost -- Key.handleRevoke,
+ * User.addUser/removeUser/revokeUser, Keyring.handleDeleteKey and several others all
+ * do this. That was nearly harmless while keys lived in local storage and writes
+ * effectively never failed.
+ *
+ * A removable keystore makes those failures routine: the device can be unplugged
+ * mid-operation, or be write-protected. Worse, the keyring mutates its in-memory
+ * copy before persisting, so a refused write leaves a key looking deleted while it
+ * is still on the device. Someone deleting a compromised key would believe it gone.
+ *
+ * Catching unhandled rejections centrally, rather than patching each call site,
+ * keeps the change small and covers paths not enumerated here -- including any added
+ * later.
+ */
+
+import React from 'react';
+import {strings} from '../../modules/usb/strings';
+import {USB_KEYSTORE_UNAVAILABLE, USB_READ_ONLY} from '../../modules/usb/constants';
+
+/** Error codes this component takes responsibility for reporting. */
+const REPORTED = [USB_KEYSTORE_UNAVAILABLE, USB_READ_ONLY, 'USB_HOST_UNAVAILABLE',
+  'USB_HOST_PERMISSION', 'USB_KEYSTORE_LEAK_BLOCKED'];
+
+export default class UsbErrorToast extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {message: null};
+    this.handleRejection = this.handleRejection.bind(this);
+    this.dismiss = this.dismiss.bind(this);
+  }
+
+  componentDidMount() {
+    window.addEventListener('unhandledrejection', this.handleRejection);
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('unhandledrejection', this.handleRejection);
+    clearTimeout(this.timer);
+  }
+
+  handleRejection(event) {
+    const reason = event?.reason;
+    if (!reason || !REPORTED.includes(reason.code)) {
+      return;
+    }
+    // Reported, so stop it also reaching the console as an uncaught error.
+    event.preventDefault();
+    this.setState({message: reason.message || strings.status_error});
+    clearTimeout(this.timer);
+    // Long enough to read and act on; these explain why something did not happen.
+    this.timer = setTimeout(() => this.setState({message: null}), 12000);
+  }
+
+  dismiss() {
+    clearTimeout(this.timer);
+    this.setState({message: null});
+  }
+
+  render() {
+    if (!this.state.message) {
+      return null;
+    }
+    return (
+      <div className="alert alert-danger d-flex align-items-start" role="alert">
+        <div className="mr-auto">
+          <strong className="d-block">{strings.operation_failed}</strong>
+          {this.state.message}
+        </div>
+        <button type="button" className="close ml-3" aria-label="Close" onClick={this.dismiss}>
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+    );
+  }
+}

--- a/src/components/usb/UsbKeyActionGate.js
+++ b/src/components/usb/UsbKeyActionGate.js
@@ -1,0 +1,48 @@
+/**
+ * Copyright (C) 2026 Noam Rathaus
+ * Licensed under the GNU Affero General Public License version 3
+ *
+ * Blocks the key-creating actions while keys are meant to live on a USB device
+ * that is not currently reachable.
+ *
+ * The gate deliberately triggers only when a keystore is configured but unusable.
+ * When none is configured at all, generating locally is ordinary upstream
+ * behaviour and must not be obstructed — there is no way to tell a user who has
+ * simply not set up a device from one who intends to and has not got round to it.
+ *
+ * The background already refuses the write, so this exists to explain the refusal
+ * before the user fills in a form, not to enforce it.
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import {Link} from 'react-router-dom';
+import {port} from '../../app/app';
+import {strings, describeState} from '../../modules/usb/strings';
+import {isUnavailable, useUsbStatus} from './usbStatus';
+
+export default function UsbKeyActionGate({status: statusProp, children}) {
+  // The hook must run unconditionally; the prop only overrides its result.
+  const fetched = useUsbStatus(port);
+  const status = statusProp ?? fetched;
+  if (!isUnavailable(status)) {
+    return <>{children}</>;
+  }
+  return (
+    <div className="col-12 mb-3">
+      <div className="alert alert-warning mb-0">
+        <strong>{strings.generate_first_heading}</strong>
+        <p className="mb-2">{strings.generate_first_text}</p>
+        <p className="mb-2">{describeState(status.state)}</p>
+        <Link to="/settings/key-storage" className="btn btn-sm btn-primary">
+          {strings.banner_reconnect}
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+UsbKeyActionGate.propTypes = {
+  status: PropTypes.object,
+  children: PropTypes.node
+};

--- a/src/components/usb/UsbKeyActionGate.js
+++ b/src/components/usb/UsbKeyActionGate.js
@@ -31,8 +31,8 @@ export default function UsbKeyActionGate({status: statusProp, children}) {
   return (
     <div className="col-12 mb-3">
       <div className="alert alert-warning mb-0">
-        <strong>{strings.generate_first_heading}</strong>
-        <p className="mb-2">{strings.generate_first_text}</p>
+        <strong>{strings.generate_blocked_heading}</strong>
+        <p className="mb-2">{strings.generate_blocked_text}</p>
         <p className="mb-2">{describeState(status.state)}</p>
         <Link to="/settings/key-storage" className="btn btn-sm btn-primary">
           {strings.banner_reconnect}

--- a/src/components/usb/UsbSetupCard.js
+++ b/src/components/usb/UsbSetupCard.js
@@ -15,7 +15,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {Link} from 'react-router-dom';
 import {port} from '../../app/app';
-import {strings} from '../../modules/usb/strings';
+import {strings, describeState} from '../../modules/usb/strings';
 import {isUnavailable, useUsbStatus} from './usbStatus';
 
 export default function UsbSetupCard({status: statusProp}) {
@@ -36,7 +36,10 @@ export default function UsbSetupCard({status: statusProp}) {
           <h5 className="card-title">{strings.setup_card_title}</h5>
           <p className="card-text flex-grow-1">{strings.setup_card_text}</p>
           {isUnavailable(status) && (
-            <p className="text-warning small">{strings.status_absent}</p>
+            // Per-state, not a single "not available": telling someone to connect a
+            // device they have already connected -- the wrong-device and
+            // write-protected cases -- points away from the only real remedy.
+            <p className="text-warning small">{describeState(status.state)}</p>
           )}
           <Link to="/settings/key-storage" className="btn btn-secondary btn-lg w-100 mt-auto">
             {strings.setup_card_button}

--- a/src/components/usb/UsbSetupCard.js
+++ b/src/components/usb/UsbSetupCard.js
@@ -1,0 +1,52 @@
+/**
+ * Copyright (C) 2026 Noam Rathaus
+ * Licensed under the GNU Affero General Public License version 3
+ *
+ * Card offering a USB keystore on the keyring setup screen, so the option is
+ * present at the moment a user would otherwise create keys on this computer.
+ *
+ * Ordering matters: setting up the device before generating a key is what keeps key
+ * material off the local disk entirely, because deleting it later does not erase it
+ * (see doc/usb-keystore-plan.md §3.1). Hence the card, and the note that appears
+ * once a device is selected but not yet reachable.
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import {Link} from 'react-router-dom';
+import {port} from '../../app/app';
+import {strings} from '../../modules/usb/strings';
+import {isUnavailable, useUsbStatus} from './usbStatus';
+
+export default function UsbSetupCard({status: statusProp}) {
+  // The hook must run unconditionally; the prop only overrides its result.
+  const fetched = useUsbStatus(port);
+  const status = statusProp ?? fetched;
+  // Once keys are on a reachable device there is nothing to offer here.
+  if (status?.enabled && !isUnavailable(status)) {
+    return null;
+  }
+  return (
+    <div className="col mb-3">
+      <div className="card h-100 border keyring-setup-card">
+        <div className="card-img-top py-5 text-center">
+          <img src="../img/key.svg" width="64" height="64" alt="" />
+        </div>
+        <div className="card-body d-flex flex-column">
+          <h5 className="card-title">{strings.setup_card_title}</h5>
+          <p className="card-text flex-grow-1">{strings.setup_card_text}</p>
+          {isUnavailable(status) && (
+            <p className="text-warning small">{strings.status_absent}</p>
+          )}
+          <Link to="/settings/key-storage" className="btn btn-secondary btn-lg w-100 mt-auto">
+            {strings.setup_card_button}
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+UsbSetupCard.propTypes = {
+  status: PropTypes.object
+};

--- a/src/components/usb/UsbStatusBadge.js
+++ b/src/components/usb/UsbStatusBadge.js
@@ -1,0 +1,44 @@
+/**
+ * Copyright (C) 2026 Noam Rathaus
+ * Licensed under the GNU Affero General Public License version 3
+ *
+ * Compact indicator of where keys are stored and, for a USB keystore, whether the
+ * device is currently reachable. Shown on the keyring page so the storage location
+ * is always visible rather than buried in settings.
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import {USB_STATE} from '../../modules/usb/constants';
+import {strings} from '../../modules/usb/strings';
+import {port} from '../../app/app';
+import {statusVariant, useUsbStatus} from './usbStatus';
+
+export default function UsbStatusBadge({status: statusProp}) {
+  // The hook must run unconditionally; the prop only overrides its result.
+  const fetched = useUsbStatus(port);
+  const status = statusProp ?? fetched;
+  if (!status) {
+    return null;
+  }
+  if (!status.enabled) {
+    return (
+      <span className="badge badge-secondary" title={strings.storage_local_description}>
+        {strings.storage_indicator_local}
+      </span>
+    );
+  }
+  const ready = status.state === USB_STATE.READY;
+  return (
+    <span
+      className={`badge badge-${statusVariant(status)}`}
+      title={ready ? strings.status_ready : strings.status_absent}
+    >
+      {ready ? strings.storage_indicator_usb : strings.storage_indicator_usb_disconnected}
+    </span>
+  );
+}
+
+UsbStatusBadge.propTypes = {
+  status: PropTypes.object
+};

--- a/src/components/usb/UsbStatusBadge.js
+++ b/src/components/usb/UsbStatusBadge.js
@@ -10,7 +10,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {USB_STATE} from '../../modules/usb/constants';
-import {strings} from '../../modules/usb/strings';
+import {strings, describeState} from '../../modules/usb/strings';
 import {port} from '../../app/app';
 import {statusVariant, useUsbStatus} from './usbStatus';
 
@@ -28,15 +28,36 @@ export default function UsbStatusBadge({status: statusProp}) {
       </span>
     );
   }
-  const ready = status.state === USB_STATE.READY;
   return (
     <span
       className={`badge badge-${statusVariant(status)}`}
-      title={ready ? strings.status_ready : strings.status_absent}
+      // Derived from the shared state description rather than a local guess, so the
+      // tooltip cannot drift from what the settings page says.
+      title={describeState(status.state)}
     >
-      {ready ? strings.storage_indicator_usb : strings.storage_indicator_usb_disconnected}
+      {indicatorLabel(status.state)}
     </span>
   );
+}
+
+/**
+ * The short label for a state.
+ *
+ * Previously binary -- anything other than READY read as "disconnected", which is
+ * plainly false for a device that is connected but write-protected, and that was the
+ * only signal the keyring page carried.
+ * @param {String} state
+ * @return {String}
+ */
+function indicatorLabel(state) {
+  switch (state) {
+    case USB_STATE.READY:
+      return strings.storage_indicator_usb;
+    case USB_STATE.READ_ONLY:
+      return strings.storage_indicator_usb_read_only;
+    default:
+      return strings.storage_indicator_usb_disconnected;
+  }
 }
 
 UsbStatusBadge.propTypes = {

--- a/src/components/usb/UsbStatusBanner.js
+++ b/src/components/usb/UsbStatusBanner.js
@@ -1,0 +1,48 @@
+/**
+ * Copyright (C) 2026 Noam Rathaus
+ * Licensed under the GNU Affero General Public License version 3
+ *
+ * Banner shown whenever keys live on a USB device that is not currently usable.
+ *
+ * This is the visible half of the requirement that an unavailable device is
+ * clearly noted: the badge on the toolbar covers the case where no Mailvelope page
+ * is open, this covers the case where one is.
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import {Link} from 'react-router-dom';
+import {port} from '../../app/app';
+import {strings, describeState} from '../../modules/usb/strings';
+import {isUnavailable, useUsbStatus} from './usbStatus';
+
+export default function UsbStatusBanner({status: statusProp, onReconnect}) {
+  // The hook must run unconditionally; the prop only overrides its result.
+  const fetched = useUsbStatus(port);
+  const status = statusProp ?? fetched;
+  if (!isUnavailable(status)) {
+    return null;
+  }
+  return (
+    <div className="alert alert-warning d-flex flex-wrap align-items-center" role="alert">
+      <div className="mr-auto">
+        <strong>{strings.banner_unavailable_heading}</strong>
+        <div>{describeState(status.state)}</div>
+      </div>
+      {onReconnect ? (
+        <button type="button" className="btn btn-sm btn-primary" onClick={onReconnect}>
+          {strings.banner_reconnect}
+        </button>
+      ) : (
+        <Link to="/settings/key-storage" className="btn btn-sm btn-primary">
+          {strings.banner_reconnect}
+        </Link>
+      )}
+    </div>
+  );
+}
+
+UsbStatusBanner.propTypes = {
+  status: PropTypes.object,
+  onReconnect: PropTypes.func
+};

--- a/src/components/usb/usbStatus.js
+++ b/src/components/usb/usbStatus.js
@@ -11,7 +11,7 @@
  */
 
 import {useEffect, useState} from 'react';
-import {USB_STATE} from '../../modules/usb/constants';
+import {USB_STATE, FOCUS_PROBE_INTERVAL_MS} from '../../modules/usb/constants';
 
 /** Storage locations offered in the UI. */
 export const STORAGE = {LOCAL: 'local', USB: 'usb'};
@@ -33,6 +33,43 @@ function wire(port) {
   }
   wiredPort = port;
   port.on('usb-status-changed', publish);
+  if (typeof document !== 'undefined') {
+    // Check the moment the page is looked at again, rather than waiting for the
+    // next tick of any timer.
+    document.addEventListener('visibilitychange', () => {
+      updatePolling(port);
+      if (document.visibilityState === 'visible') {
+        port.send('usb-get-status').then(publish).catch(() => {});
+      }
+    });
+    window.addEventListener('focus', () => {
+      port.send('usb-get-status').then(publish).catch(() => {});
+    });
+  }
+}
+
+let pollTimer = null;
+
+/**
+ * Poll the device while this page is visible.
+ *
+ * The background alarm cannot run faster than every 30 seconds, which is a long
+ * time to stare at a page that is telling you the wrong thing. Someone looking at
+ * Mailvelope is exactly when latency is felt, so poll quickly then and stop as soon
+ * as the page is hidden or nobody is subscribed.
+ * @param {EventHandler} port
+ */
+function updatePolling(port) {
+  const shouldPoll = subscribers.size > 0 &&
+    (typeof document === 'undefined' || document.visibilityState === 'visible');
+  if (shouldPoll && !pollTimer) {
+    pollTimer = setInterval(() => {
+      port.send('usb-get-status').then(publish).catch(() => {});
+    }, FOCUS_PROBE_INTERVAL_MS);
+  } else if (!shouldPoll && pollTimer) {
+    clearInterval(pollTimer);
+    pollTimer = null;
+  }
 }
 
 /**
@@ -47,10 +84,14 @@ export function subscribeStatus(port, onStatus) {
   subscribers.add(onStatus);
   if (lastStatus) {
     onStatus(lastStatus);
-  } else {
-    port.send('usb-get-status').then(publish).catch(() => {});
   }
-  return () => subscribers.delete(onStatus);
+  // Always ask, even with a cached value: the cache may predate a device change.
+  port.send('usb-get-status').then(publish).catch(() => {});
+  updatePolling(port);
+  return () => {
+    subscribers.delete(onStatus);
+    updatePolling(port);
+  };
 }
 
 /** Push a status obtained out of band (e.g. as an action's return value). */

--- a/src/components/usb/usbStatus.js
+++ b/src/components/usb/usbStatus.js
@@ -12,6 +12,7 @@
 
 import {useEffect, useState} from 'react';
 import {USB_STATE, FOCUS_PROBE_INTERVAL_MS} from '../../modules/usb/constants';
+import {describeState} from '../../modules/usb/strings';
 
 /** Storage locations offered in the UI. */
 export const STORAGE = {LOCAL: 'local', USB: 'usb'};
@@ -135,7 +136,40 @@ export function storageOf(status) {
  * @return {Boolean}
  */
 export function isUnavailable(status) {
-  return Boolean(status?.enabled) && status.state !== USB_STATE.READY;
+  if (!status?.enabled) {
+    return false;
+  }
+  // READ_ONLY is deliberately not "unavailable": the keys are readable and usable,
+  // so treating it as absence would hide them and claim the keystore was missing.
+  return status.state !== USB_STATE.READY && status.state !== USB_STATE.READ_ONLY;
+}
+
+/**
+ * Whether the keystore can accept changes right now.
+ *
+ * Destructive controls should be disabled rather than offered and then refused:
+ * clicking Delete and watching a key disappear -- because the keyring mutates
+ * memory before persisting -- then having it reappear is worse than not being able
+ * to click at all. Especially for a key being deleted because it is compromised.
+ *
+ * True when no keystore is configured, so ordinary local operation is untouched.
+ * @param {Object} status
+ * @return {Boolean}
+ */
+export function canModifyKeys(status) {
+  if (!status?.enabled) {
+    return true;
+  }
+  return status.state === USB_STATE.READY;
+}
+
+/**
+ * Why changes are not possible, for a title attribute on a disabled control.
+ * @param {Object} status
+ * @return {String|undefined}
+ */
+export function whyCannotModify(status) {
+  return canModifyKeys(status) ? undefined : describeState(status?.state);
 }
 
 /**
@@ -152,6 +186,7 @@ export function statusVariant(status) {
       return 'success';
     case USB_STATE.ABSENT:
     case USB_STATE.PERMISSION_REQUIRED:
+    case USB_STATE.READ_ONLY:
       return 'warning';
     default:
       return 'danger';

--- a/src/components/usb/usbStatus.js
+++ b/src/components/usb/usbStatus.js
@@ -1,0 +1,118 @@
+/**
+ * Copyright (C) 2026 Noam Rathaus
+ * Licensed under the GNU Affero General Public License version 3
+ *
+ * Shared client-side helpers for the USB keystore UI.
+ *
+ * Note on subscriptions: EventHandler.on() keeps one handler per event in a Map, so
+ * a second registration for the same event silently replaces the first. Several
+ * components on a page need the status, so they must not each call port.on() —
+ * only the last would stay live. This module registers once and fans out.
+ */
+
+import {useEffect, useState} from 'react';
+import {USB_STATE} from '../../modules/usb/constants';
+
+/** Storage locations offered in the UI. */
+export const STORAGE = {LOCAL: 'local', USB: 'usb'};
+
+const subscribers = new Set();
+let wiredPort = null;
+let lastStatus = null;
+
+function publish(status) {
+  lastStatus = status;
+  for (const subscriber of subscribers) {
+    subscriber(status);
+  }
+}
+
+function wire(port) {
+  if (wiredPort === port) {
+    return;
+  }
+  wiredPort = port;
+  port.on('usb-status-changed', publish);
+}
+
+/**
+ * Subscribe to USB keystore status. The first subscriber triggers one fetch; later
+ * ones get the cached value immediately and share the background pushes.
+ * @param {EventHandler} port
+ * @param {Function} onStatus
+ * @return {Function} unsubscribe
+ */
+export function subscribeStatus(port, onStatus) {
+  wire(port);
+  subscribers.add(onStatus);
+  if (lastStatus) {
+    onStatus(lastStatus);
+  } else {
+    port.send('usb-get-status').then(publish).catch(() => {});
+  }
+  return () => subscribers.delete(onStatus);
+}
+
+/** Push a status obtained out of band (e.g. as an action's return value). */
+export function updateStatus(status) {
+  if (status) {
+    publish(status);
+  }
+}
+
+/**
+ * React hook giving the current USB keystore status, kept up to date by background
+ * pushes. Lets each UI site be wired in with a single component tag rather than
+ * threading status through props.
+ * @param {EventHandler} port
+ * @return {Object|null}
+ */
+export function useUsbStatus(port) {
+  const [status, setStatus] = useState(lastStatus);
+  useEffect(() => {
+    if (!port) {
+      return;
+    }
+    return subscribeStatus(port, setStatus);
+  }, [port]);
+  return status;
+}
+
+/**
+ * Which storage location a status describes.
+ * @param {Object} status - from the 'usb-get-status' event
+ * @return {String} one of STORAGE
+ */
+export function storageOf(status) {
+  return status?.enabled ? STORAGE.USB : STORAGE.LOCAL;
+}
+
+/**
+ * Whether the USB keystore is configured but currently unusable — the condition
+ * that has to be visible to the user everywhere, not just in settings.
+ * @param {Object} status
+ * @return {Boolean}
+ */
+export function isUnavailable(status) {
+  return Boolean(status?.enabled) && status.state !== USB_STATE.READY;
+}
+
+/**
+ * Bootstrap contextual class for a status, for badges and alerts.
+ * @param {Object} status
+ * @return {String}
+ */
+export function statusVariant(status) {
+  if (!status?.enabled) {
+    return 'secondary';
+  }
+  switch (status.state) {
+    case USB_STATE.READY:
+      return 'success';
+    case USB_STATE.ABSENT:
+    case USB_STATE.PERMISSION_REQUIRED:
+      return 'warning';
+    default:
+      return 'danger';
+  }
+}

--- a/src/controller/app.controller.js
+++ b/src/controller/app.controller.js
@@ -144,8 +144,7 @@ export default class AppController extends SubController {
 
   async reloadKeystore({keyringId}) {
     const keyring = await keyringById(keyringId);
-    keyring.keystore.clear();
-    await keyring.keystore.load();
+    await keyring.keystore.reload();
   }
 
   async getKeyServerSync({fingerprint, keyringId}) {

--- a/src/controller/app.controller.js
+++ b/src/controller/app.controller.js
@@ -23,6 +23,7 @@ import {gpgme} from '../lib/browser.runtime';
 import * as mveloKeyServer from '../modules/mveloKeyServer';
 import * as autocrypt from '../modules/autocryptWrapper';
 import {denyCampaign, isCampaignCurrentlyGranted, grantCampaign, recordOnboardingStep, ADD_KEY, BEGIN, ONBOARDING_CAMPAIGN} from '../lib/analytics';
+import {registerUsbHandlers} from '../modules/usb/handlers';
 
 export default class AppController extends SubController {
   constructor(port) {
@@ -81,6 +82,7 @@ export default class AppController extends SubController {
     this.on('grant-consent', ({campaignId}) => this.grantCampaignConsent(campaignId));
     this.on('deny-consent', ({campaignId}) => denyCampaign(campaignId));
     this.on('get-consent', ({campaignId}) => isCampaignCurrentlyGranted(campaignId));
+    registerUsbHandlers(this);
   }
 
   async updatePreferences(options) {

--- a/src/controller/app.controller.js
+++ b/src/controller/app.controller.js
@@ -24,6 +24,7 @@ import * as mveloKeyServer from '../modules/mveloKeyServer';
 import * as autocrypt from '../modules/autocryptWrapper';
 import {denyCampaign, isCampaignCurrentlyGranted, grantCampaign, recordOnboardingStep, ADD_KEY, BEGIN, ONBOARDING_CAMPAIGN} from '../lib/analytics';
 import {registerUsbHandlers} from '../modules/usb/handlers';
+import {assertPassphrase} from '../modules/usb/guard';
 
 export default class AppController extends SubController {
   constructor(port) {
@@ -242,6 +243,7 @@ export default class AppController extends SubController {
   }
 
   async generateKey({parameters, keyringId}) {
+    assertPassphrase(parameters.passphrase);
     const keyring = await keyringById(keyringId);
     const newKey = await keyring.generateKey(parameters);
     const keyId = newKey.privateKey.getKeyID().toHex().toUpperCase();

--- a/src/controller/menu.controller.js
+++ b/src/controller/menu.controller.js
@@ -8,6 +8,7 @@ import {getUUID} from '../lib/util';
 import {SubController, reloadFrames, setAppDataSlot} from './sub.controller';
 import * as prefs from '../modules/prefs';
 import {hasAnyPrivateKey} from '../modules/keyring';
+import {isEnabled as usbEnabled, isUsable as usbUsable, hadKeys as usbHadKeys} from '../modules/usb/state';
 import {shouldSeeConsentDialog} from '../lib/analytics';
 
 export default class MenuController extends SubController {
@@ -59,6 +60,16 @@ export default class MenuController extends SubController {
   }
 
   async getIsSetupDone() {
+    // A configured keystore that is merely disconnected means the keys cannot be
+    // read, not that setup never happened. Reporting "not set up" here shows the
+    // onboarding menu, which invites someone whose key is safe on a detached device
+    // to generate a replacement -- the worst possible suggestion for a keystore
+    // that is deliberately the only copy.
+    if (usbEnabled() && !usbUsable()) {
+      // Only claim setup is done if the device is known to have held a key. A
+      // keystore configured but never used should still offer onboarding.
+      return {isSetupDone: await usbHadKeys()};
+    }
     return {isSetupDone: await hasAnyPrivateKey()};
   }
 

--- a/src/controller/privateKey.controller.js
+++ b/src/controller/privateKey.controller.js
@@ -13,7 +13,7 @@ import * as pwdCache from '../modules/pwdCache';
 import * as sync from './sync.controller';
 import {getById as getKeyringById} from '../modules/keyring';
 import {createPrivateKeyBackup, restorePrivateKeyBackup} from '../modules/pgpModel';
-import {assertRemoteKeyStorageAllowed} from '../modules/usb/guard';
+import {assertRemoteKeyStorageAllowed, assertPassphrase} from '../modules/usb/guard';
 
 export default class PrivateKeyController extends SubController {
   constructor(port) {
@@ -115,6 +115,7 @@ export default class PrivateKeyController extends SubController {
     }
     this.ports.keyGenDialog.emit('show-waiting');
     try {
+      assertPassphrase(password);
       const keyring = await getKeyringById(this.state.keyringId);
       const {publicKey, privateKey} = await keyring.generateKey({
         keyAlgo: 'rsa',

--- a/src/controller/privateKey.controller.js
+++ b/src/controller/privateKey.controller.js
@@ -13,6 +13,7 @@ import * as pwdCache from '../modules/pwdCache';
 import * as sync from './sync.controller';
 import {getById as getKeyringById} from '../modules/keyring';
 import {createPrivateKeyBackup, restorePrivateKeyBackup} from '../modules/pgpModel';
+import {assertRemoteKeyStorageAllowed} from '../modules/usb/guard';
 
 export default class PrivateKeyController extends SubController {
   constructor(port) {
@@ -147,6 +148,7 @@ export default class PrivateKeyController extends SubController {
   }
 
   async createPrivateKeyBackup() {
+    assertRemoteKeyStorageAllowed('private key backup');
     const keyring = await getKeyringById(this.state.keyringId);
     const defaultKey = await keyring.getDefaultKey();
     if (!defaultKey) {

--- a/src/controller/pwd.controller.js
+++ b/src/controller/pwd.controller.js
@@ -11,6 +11,7 @@ import {SubController} from './sub.controller';
 import * as uiLog from '../modules/uiLog';
 import {getUserInfo} from '../modules/key';
 import * as pwdCache from '../modules/pwdCache';
+import {isConfigured as usbKeystoreConfigured} from '../modules/usb/state';
 
 export default class PwdController extends SubController {
   constructor() {
@@ -33,10 +34,15 @@ export default class PwdController extends SubController {
   async onPwdDialogInit() {
     // pass over keyId and userId to dialog
     const {userId} = await getUserInfo(this.options.key, {allowInvalid: true});
+    // pwdCache.set() refuses to cache while keys live on a USB device, so the stored
+    // preference is not what will happen. Send the effective answer and say why it is
+    // fixed: a checked box that caches nothing is worse than no box at all.
+    const cacheDisabled = await usbKeystoreConfigured();
     this.ports.pwdDialog.emit('set-init-data', {
       userId,
       keyId: this.options.key.getKeyID().toHex().toUpperCase(),
-      cache: prefs.prefs.security.password_cache,
+      cache: cacheDisabled ? false : prefs.prefs.security.password_cache,
+      cacheDisabled,
       reason: this.options.reason
     });
   }
@@ -44,7 +50,11 @@ export default class PwdController extends SubController {
   async onOk(msg) {
     try {
       this.options.password = msg.password;
-      if (msg.cache != prefs.prefs.security.password_cache) {
+      // The dialog reports the box off whenever a USB keystore is configured, so
+      // taking that as the user's choice would silently overwrite their preference
+      // with a value they were never offered. Leave it as they set it, so disabling
+      // the keystore restores it.
+      if (msg.cache != prefs.prefs.security.password_cache && !await usbKeystoreConfigured()) {
         // update pwd cache status
         await prefs.update({security: {password_cache: msg.cache}});
       }

--- a/src/controller/sync.controller.js
+++ b/src/controller/sync.controller.js
@@ -10,6 +10,7 @@ import {getById as getKeyringById} from '../modules/keyring';
 import {isCached} from '../modules/pwdCache';
 import {readMessage, decryptSyncMessage, encryptSyncMessage} from '../modules/pgpModel';
 import {equalKey} from '../modules/key';
+import {isRemoteKeyStorageAllowed} from '../modules/usb/guard';
 
 export class SyncController extends SubController {
   constructor(port) {
@@ -42,6 +43,9 @@ export class SyncController extends SubController {
    * @param {String} [options.password] - password for options.key
    */
   async triggerSync(options) {
+    if (!isRemoteKeyStorageAllowed()) {
+      return;
+    }
     options = options || {};
     if (this.syncRunning) {
       this.repeatSync = options;

--- a/src/modules/keyStore.js
+++ b/src/modules/keyStore.js
@@ -14,6 +14,30 @@ export class KeyStoreBase {
     this.privateKeys = new KeyArray([]);
   }
 
+  /**
+   * Reload every key from the backing store, publishing the result in one step.
+   *
+   * clear() followed by load() leaves the keyring visibly empty, then visibly
+   * half-full, for as long as the load takes: microseconds for a keyring of two keys,
+   * seconds for one of four hundred read off a removable device. Anything that reads
+   * in that window gets a partial keyring -- a key list missing most of its rows, or
+   * a decryption that cannot find a key which is in fact present -- and nothing tells
+   * it to look again, because a short list is not obviously a wrong one.
+   *
+   * Loading into a detached store and swapping the result in makes a concurrent
+   * reader see either the old generation whole or the new one whole.
+   */
+  async reload() {
+    const fresh = new this.constructor(this.id);
+    await fresh.load();
+    for (const [property, value] of Object.entries(fresh)) {
+      // Whatever load() populated: the two key arrays, plus defaultKeyFpr for GnuPG.
+      if (property !== 'id') {
+        this[property] = value;
+      }
+    }
+  }
+
   getKeysForId(keyId, deep) {
     let result = [];
     result = result.concat(this.publicKeys.getForId(keyId, deep) || []);

--- a/src/modules/keyring.js
+++ b/src/modules/keyring.js
@@ -15,7 +15,7 @@ import {gpgme, initNativeMessaging} from '../lib/browser.runtime';
 import {prefs} from './prefs';
 import {isValidEncryptionKey, getLastModifiedDate, toPublic} from './key';
 import {getKeyBinding, isKeyBound} from './keyBinding';
-import {isEnabled as usbKeystoreEnabled} from './usb/state';
+import {isEnabled as usbKeystoreEnabled, isUsable as usbKeystoreUsable} from './usb/state';
 
 /**
  * Map with all keyrings and their attributes. Data is persisted in local storage.
@@ -237,6 +237,15 @@ async function preVerifyKeys(keyringId) {
  */
 async function sanitizeKeyring(keyringId) {
   if (keyringAttr.get(keyringId, 'sanitized')) {
+    return;
+  }
+  // Sanitising writes the keyring back, and a write fails when the USB device
+  // holding it is absent. init() treats any failure here as a broken keyring and
+  // deletes it from the attribute map, so an unplugged device would deregister the
+  // keyring -- permanently for client-API keyrings, whose keys would then be
+  // stranded on the device. Defer instead; the flag stays unset and sanitising
+  // happens on a later start with the device attached.
+  if (usbKeystoreEnabled() && !usbKeystoreUsable()) {
     return;
   }
   const keyring = keyringMap.get(keyringId);

--- a/src/modules/keyring.js
+++ b/src/modules/keyring.js
@@ -15,6 +15,7 @@ import {gpgme, initNativeMessaging} from '../lib/browser.runtime';
 import {prefs} from './prefs';
 import {isValidEncryptionKey, getLastModifiedDate, toPublic} from './key';
 import {getKeyBinding, isKeyBound} from './keyBinding';
+import {isEnabled as usbKeystoreEnabled} from './usb/state';
 
 /**
  * Map with all keyrings and their attributes. Data is persisted in local storage.
@@ -266,7 +267,12 @@ export async function getById(keyringId) {
  */
 export async function getAll() {
   await keyringInitialized;
-  return Array.from(keyringMap.values());
+  const keyrings = Array.from(keyringMap.values());
+  if (usbKeystoreEnabled()) {
+    // See getPreferredKeyringQueue: GnuPG's store is on the local machine.
+    return keyrings.filter(keyring => keyring.id !== GNUPG_KEYRING_ID);
+  }
+  return keyrings;
 }
 
 /**
@@ -305,6 +311,11 @@ export async function getAllKeyringIds() {
 export async function getAllKeyringAttr() {
   await keyringInitialized;
   const attrObj = keyringAttr.toObject();
+  if (usbKeystoreEnabled()) {
+    // Hide it from the keyring selector too, not just from key selection.
+    delete attrObj[GNUPG_KEYRING_ID];
+    return attrObj;
+  }
   if (keyringAttr.has(GNUPG_KEYRING_ID)) {
     const gpgKeyring = keyringMap.get(GNUPG_KEYRING_ID);
     if (gpgKeyring) {
@@ -479,7 +490,9 @@ export async function getKeyByAddress(keyringId, emails, {validForEncrypt = true
  */
 function getPreferredKeyringQueue(keyringId) {
   const keyrings = [];
-  const hasGpgKeyring = keyringMap.has(GNUPG_KEYRING_ID);
+  // GnuPG keeps secret keys in the OS home directory, which is exactly what a USB
+  // keystore exists to avoid, so it is excluded while that backend is active.
+  const hasGpgKeyring = keyringMap.has(GNUPG_KEYRING_ID) && !usbKeystoreEnabled();
   // use gnupg keyring if available and preferred
   if (hasGpgKeyring && prefs.general.prefer_gnupg) {
     keyrings.push(keyringMap.get(GNUPG_KEYRING_ID));

--- a/src/modules/pgpModel.js
+++ b/src/modules/pgpModel.js
@@ -21,6 +21,7 @@ import * as keyringSync from './keyringSync';
 import * as trustKey from './trustKey';
 import {updateKeyBinding, init as initKeyBinding} from './keyBinding';
 import {KEYSERVER_ADDRESS, COMMUNICATION, recordOnboardingStep} from '../lib/analytics';
+import {assertKeystoreForCrypto} from './usb/guard';
 
 let modelInitDone;
 export const modelInitialized = new Promise(resolve => modelInitDone = resolve);
@@ -62,6 +63,7 @@ export function initOpenPGP() {
  *   decode the body parts via the MIME parser's charset handling.
  */
 export async function decryptMessage({message, armored, keyringId, unlockKey, senderAddress, selfSigned, uiLogSource, lookupKey}) {
+  await assertKeystoreForCrypto();
   message ??= await readMessage({armoredMessage: armored});
   const encryptionKeyIds = message.getEncryptionKeyIDs();
   const keyring = await getKeyringWithPrivKey(encryptionKeyIds, keyringId);
@@ -182,6 +184,7 @@ export async function readMessage({armoredMessage, binaryMessage}) {
  * @return {Promise<String>} - armored PGP message
  */
 export async function encryptMessage({data, keyringId, unlockKey, encryptionKeyFprs, signingKeyFpr, uiLogSource, filename, noCache, allKeyrings}) {
+  await assertKeystoreForCrypto();
   const keyring = await getKeyringWithPrivKey(signingKeyFpr, keyringId, noCache);
   if (!keyring) {
     throw new MvError('No private key found', 'NO_PRIVATE_KEY_FOUND');
@@ -325,6 +328,7 @@ async function acquireSigningKeys({senderAddress, keyring, lookupKey, keyId}) {
  * @return {Promise<String>}
  */
 export async function signMessage({data, keyringId, unlockKey, signingKeyFpr}) {
+  await assertKeystoreForCrypto();
   const keyring = await getKeyringWithPrivKey(signingKeyFpr, keyringId);
   if (!keyring) {
     throw new MvError('No private key found', 'NO_PRIVATE_KEY_FOUND');
@@ -483,6 +487,7 @@ function convertChangeLog(key, changeLog, syncData) {
  * @return {String} - encrypted file as armored block or JS binary string
  */
 export async function encryptFile({plainFile, keyringId, unlockKey, encryptionKeyFprs, signingKeyFpr, uiLogSource, armor, noCache, allKeyrings}) {
+  await assertKeystoreForCrypto();
   const keyring = await getKeyringWithPrivKey(signingKeyFpr, keyringId, noCache);
   if (!keyring) {
     throw new MvError('No private key found', 'NO_PRIVATE_KEY_FOUND');
@@ -508,6 +513,7 @@ export async function encryptFile({plainFile, keyringId, unlockKey, encryptionKe
  * @return {Object<data, signatures, filename>} - data as JS binary string
  */
 export async function decryptFile({encryptedFile, unlockKey, uiLogSource}) {
+  await assertKeystoreForCrypto();
   let armoredMessage;
   let binaryMessage;
   try {

--- a/src/modules/pwdCache.js
+++ b/src/modules/pwdCache.js
@@ -116,6 +116,12 @@ export function initSession() {
   cache = new PwdMap();
 }
 
+/* Purge every cached passphrase and unlocked key. Used by the USB keystore when the
+   device is removed, so no decrypted key material outlives it. */
+export function clear() {
+  cache?.clear();
+}
+
 function clearIntervals() {
   // clear interval functions
   cache.forEach(entry => clearInterval(entry.tlTimer));

--- a/src/modules/pwdCache.js
+++ b/src/modules/pwdCache.js
@@ -4,6 +4,7 @@
  */
 
 import {MvError} from '../lib/util';
+import {isConfigured as usbKeystoreConfigured} from './usb/state';
 import {enums, decryptKey} from 'openpgp';
 import * as prefs from './prefs';
 
@@ -200,6 +201,19 @@ export {deleteEntry as delete};
  * @param {Number} [reserverdOperations] - number of decrypt operations initially used
  */
 export async function set({key, password, reservedOperations = 0}) {
+  // Never cache while keys live on a USB device. Caching an entry makes
+  // chrome.alarms hold an alarm named PWD_ALARM_<fingerprint>, and Chrome persists
+  // alarm names to disk with persistAcrossSessions -- so the fingerprint of a key
+  // that is supposed to exist only on the device is written to the local profile,
+  // where LevelDB's append-only log keeps it readable long after the alarm is
+  // cleared. The passphrase itself never reaches disk, but a fingerprint still
+  // records which key this machine used.
+  //
+  // Gated here rather than at the `active` check in unlock(), because
+  // privateKey.controller calls this directly and would bypass that.
+  if (await usbKeystoreConfigured()) {
+    return;
+  }
   // primary key fingerprint is main key of cache
   const primaryKeyFpr = key.getFingerprint();
   let entry;

--- a/src/modules/usb/FsaBackend.js
+++ b/src/modules/usb/FsaBackend.js
@@ -9,6 +9,7 @@
  * backend works in the MV3 service worker, which cannot open a picker itself.
  */
 
+import {isChrome} from '../../lib/browser';
 import * as handleStore from './handleStore';
 import {UsbBackend, NotFoundError, DeviceUnavailableError} from './backend';
 
@@ -32,10 +33,15 @@ export default class FsaBackend extends UsbBackend {
   }
 
   static isSupported() {
-    // FileSystemDirectoryHandle exists in both window and worker scopes; the
-    // picker itself is only reachable from a document, which is why provisioning
-    // happens in the app page.
-    return typeof FileSystemDirectoryHandle !== 'undefined';
+    // Two conditions, and the browser check is the load-bearing one.
+    //
+    // Firefox implements FileSystemDirectoryHandle for the origin-private file
+    // system, so testing for that alone reports support there -- even though
+    // Firefox has no showDirectoryPicker and cannot reach a USB device at all.
+    // The picker cannot be tested for directly, because it does not exist in the
+    // background context in any browser; that is why provisioning happens in the
+    // app page. So the browser itself is the only usable signal here.
+    return isChrome && typeof FileSystemDirectoryHandle !== 'undefined';
   }
 
   /**

--- a/src/modules/usb/FsaBackend.js
+++ b/src/modules/usb/FsaBackend.js
@@ -1,0 +1,243 @@
+/**
+ * Copyright (C) 2026 Noam Rathaus
+ * Licensed under the GNU Affero General Public License version 3
+ *
+ * File System Access API backend. Chromium only; Firefox has no
+ * showDirectoryPicker() and needs NativeBackend instead.
+ *
+ * The directory handle comes from IndexedDB (see handleStore.js) so that this
+ * backend works in the MV3 service worker, which cannot open a picker itself.
+ */
+
+import * as handleStore from './handleStore';
+import {UsbBackend, NotFoundError, DeviceUnavailableError} from './backend';
+
+/** Errors the platform raises when the device has gone away. */
+const ABSENT_ERRORS = ['NotFoundError', 'NotReadableError', 'InvalidStateError', 'AbortError'];
+
+function isAbsentError(e) {
+  return ABSENT_ERRORS.includes(e?.name);
+}
+
+function splitPath(path) {
+  const segments = path.split('/').filter(segment => segment.length);
+  const name = segments.pop();
+  return {dirs: segments, name};
+}
+
+export default class FsaBackend extends UsbBackend {
+  constructor() {
+    super();
+    this.root = null;
+  }
+
+  static isSupported() {
+    // FileSystemDirectoryHandle exists in both window and worker scopes; the
+    // picker itself is only reachable from a document, which is why provisioning
+    // happens in the app page.
+    return typeof FileSystemDirectoryHandle !== 'undefined';
+  }
+
+  /**
+   * Load the stored directory handle. Cached, since IndexedDB access is not free
+   * and the handle does not change while configured.
+   * @return {Promise<FileSystemDirectoryHandle>}
+   */
+  async getRoot() {
+    if (!this.root) {
+      this.root = await handleStore.get();
+    }
+    if (!this.root) {
+      throw new DeviceUnavailableError('No USB keystore directory configured');
+    }
+    return this.root;
+  }
+
+  /** Drop the cached handle, e.g. after the configuration changed. */
+  clearCache() {
+    this.root = null;
+  }
+
+  async probe() {
+    let root;
+    try {
+      root = await this.getRoot();
+    } catch (e) {
+      return {available: false, permission: 'prompt', configured: false};
+    }
+    let permission;
+    try {
+      permission = await root.queryPermission({mode: 'readwrite'});
+    } catch (e) {
+      // Some builds reject queryPermission once the underlying entry is gone.
+      return {available: false, permission: 'prompt', configured: true};
+    }
+    if (permission !== 'granted') {
+      return {available: false, permission, configured: true};
+    }
+    // A granted permission says nothing about whether the device is plugged in;
+    // only touching the filesystem does. Callers probe the marker file next.
+    return {available: true, permission, configured: true};
+  }
+
+  /**
+   * Resolve a directory handle for a list of path segments.
+   * @param {Array<String>} dirs
+   * @param {Boolean} create
+   * @return {Promise<FileSystemDirectoryHandle>}
+   */
+  async resolveDir(dirs, create = false) {
+    let dir = await this.getRoot();
+    for (const segment of dirs) {
+      try {
+        dir = await dir.getDirectoryHandle(segment, {create});
+      } catch (e) {
+        if (e?.name === 'NotFoundError' && !create) {
+          throw new NotFoundError(dirs.join('/'));
+        }
+        if (isAbsentError(e)) {
+          throw new DeviceUnavailableError();
+        }
+        throw e;
+      }
+    }
+    return dir;
+  }
+
+  async readFile(path) {
+    const {dirs, name} = splitPath(path);
+    const dir = await this.resolveDir(dirs);
+    try {
+      const fileHandle = await dir.getFileHandle(name);
+      const file = await fileHandle.getFile();
+      return await file.text();
+    } catch (e) {
+      if (e?.name === 'NotFoundError') {
+        throw new NotFoundError(path);
+      }
+      if (isAbsentError(e)) {
+        throw new DeviceUnavailableError();
+      }
+      throw e;
+    }
+  }
+
+  /**
+   * Atomic-as-possible write: stage to a .tmp file, verify it round-trips, keep the
+   * previous generation as .bak, then move the staged file into place. A device
+   * pulled at any point leaves either the old file or a recoverable .bak, never a
+   * truncated primary.
+   */
+  async writeFile(path, content) {
+    const {dirs, name} = splitPath(path);
+    const dir = await this.resolveDir(dirs, true);
+    const tmpName = `${name}.tmp`;
+    try {
+      await this.writeRaw(dir, tmpName, content);
+      // Verify the staged copy before it replaces anything.
+      const staged = await (await dir.getFileHandle(tmpName)).getFile();
+      if (await staged.text() !== content) {
+        throw new Error(`Verification of staged write failed: ${path}`);
+      }
+      const previous = await this.tryGetFileHandle(dir, name);
+      const tmpHandle = await dir.getFileHandle(tmpName);
+      if (typeof tmpHandle.move === 'function') {
+        if (previous) {
+          await this.removeEntry(dir, `${name}.bak`);
+          await previous.move(dir, `${name}.bak`);
+        }
+        await tmpHandle.move(dir, name);
+      } else {
+        // No move() available: fall back to a direct write. Less safe, but the
+        // staged copy has already been verified and is left in place as .bak.
+        if (previous) {
+          await this.removeEntry(dir, `${name}.bak`);
+          await previous.move?.(dir, `${name}.bak`);
+        }
+        await this.writeRaw(dir, name, content);
+        await this.removeEntry(dir, tmpName);
+      }
+    } catch (e) {
+      if (isAbsentError(e)) {
+        throw new DeviceUnavailableError();
+      }
+      throw e;
+    }
+  }
+
+  async writeRaw(dir, name, content) {
+    const fileHandle = await dir.getFileHandle(name, {create: true});
+    const writable = await fileHandle.createWritable();
+    try {
+      await writable.write(content);
+    } finally {
+      await writable.close();
+    }
+  }
+
+  async tryGetFileHandle(dir, name) {
+    try {
+      return await dir.getFileHandle(name);
+    } catch (e) {
+      if (e?.name === 'NotFoundError') {
+        return null;
+      }
+      throw e;
+    }
+  }
+
+  async removeEntry(dir, name) {
+    try {
+      await dir.removeEntry(name, {recursive: true});
+    } catch (e) {
+      if (e?.name !== 'NotFoundError') {
+        throw e;
+      }
+    }
+  }
+
+  async removeFile(path) {
+    const {dirs, name} = splitPath(path);
+    let dir;
+    try {
+      dir = await this.resolveDir(dirs);
+    } catch (e) {
+      if (e instanceof NotFoundError) {
+        return;
+      }
+      throw e;
+    }
+    try {
+      await this.removeEntry(dir, name);
+    } catch (e) {
+      if (isAbsentError(e)) {
+        throw new DeviceUnavailableError();
+      }
+      throw e;
+    }
+  }
+
+  async listDir(path) {
+    let dir;
+    try {
+      dir = await this.resolveDir(splitPath(`${path}/x`).dirs);
+    } catch (e) {
+      if (e instanceof NotFoundError) {
+        return [];
+      }
+      throw e;
+    }
+    const names = [];
+    try {
+      for await (const name of dir.keys()) {
+        names.push(name);
+      }
+    } catch (e) {
+      if (isAbsentError(e)) {
+        throw new DeviceUnavailableError();
+      }
+      throw e;
+    }
+    return names;
+  }
+}

--- a/src/modules/usb/NativeBackend.js
+++ b/src/modules/usb/NativeBackend.js
@@ -195,8 +195,9 @@ export default class NativeBackend extends UsbBackend {
     if (!this.root) {
       return {available: false, permission: 'granted', configured: false};
     }
+    let probe;
     try {
-      await this.send({op: 'probe', root: this.root});
+      probe = await this.send({op: 'probe', root: this.root});
     } catch (e) {
       if (e instanceof DeviceUnavailableError || e instanceof NotFoundError) {
         return {available: false, permission: 'granted', configured: true};
@@ -206,7 +207,16 @@ export default class NativeBackend extends UsbBackend {
     // No permission model here: authority comes from having installed the host, so
     // there is no per-session grant to lose. Reported as granted so the state
     // machine never asks the user to reconnect.
-    return {available: true, permission: 'granted', configured: true};
+    //
+    // writable is forwarded rather than discarded: the helper can answer it directly
+    // where the File System Access API cannot, so this is the one path that knows a
+    // device is write-protected before attempting a write.
+    return {
+      available: true,
+      permission: 'granted',
+      configured: true,
+      writable: probe.writable !== false
+    };
   }
 
   async readFile(path) {

--- a/src/modules/usb/NativeBackend.js
+++ b/src/modules/usb/NativeBackend.js
@@ -1,0 +1,174 @@
+/**
+ * Copyright (C) 2026 Noam Rathaus
+ * Licensed under the GNU Affero General Public License version 3
+ *
+ * Native messaging backend, for browsers with no File System Access API.
+ *
+ * Firefox cannot reach a removable device from an extension at all: no
+ * showDirectoryPicker, and the origin-private file system is not the device. A small
+ * native host (native-host/mailvelope_usb_keystore.py) provides the same five
+ * operations the File System Access backend does, over stdio.
+ *
+ * Two consequences worth knowing, both of which make this path arguably better than
+ * the in-browser one:
+ *
+ *   - There is no directory picker, and none is needed: the host enumerates mounted
+ *     removable devices, so the UI can offer a list instead of a file dialog.
+ *   - The configured location is a real path, which the UI can show in full. The
+ *     File System Access API deliberately withholds that.
+ *
+ * The host is a program with the user's filesystem authority, so it -- not this
+ * class -- is where confinement is enforced. Nothing here should be treated as a
+ * security boundary; see the host's own security notes.
+ */
+
+import {MvError} from '../../lib/util';
+import {UsbBackend, NotFoundError, DeviceUnavailableError} from './backend';
+
+/** Must match the "name" in the installed native messaging manifest. */
+export const HOST_NAME = 'mailvelope_usb_keystore';
+
+/** Protocol version this client understands. */
+export const PROTOCOL_VERSION = 1;
+
+/** Host error codes that mean "the device is not there", rather than a fault. */
+const ABSENT_CODES = ['not_found', 'io_error', 'root_not_mounted'];
+
+export default class NativeBackend extends UsbBackend {
+  constructor() {
+    super();
+    this.root = null;
+    this.available = null; // null = not yet probed
+  }
+
+  /**
+   * Whether native messaging is reachable at all.
+   *
+   * Only checks that the API exists; whether the host is actually installed can
+   * only be discovered by talking to it, which probe() does.
+   * @return {Boolean}
+   */
+  static isSupported() {
+    return typeof chrome !== 'undefined' && Boolean(chrome.runtime?.sendNativeMessage);
+  }
+
+  /** The device path this backend operates on. Set from the stored configuration. */
+  setRoot(root) {
+    this.root = root;
+  }
+
+  clearCache() {
+    this.available = null;
+  }
+
+  /**
+   * One request/response exchange with the host.
+   *
+   * Uses sendNativeMessage rather than a long-lived connectNative port: every
+   * operation here is self-contained, and a one-shot exchange cannot leave a stale
+   * port to reason about. The cost is a process spawn per call, which is
+   * inconsequential next to reading a file from a USB stick.
+   * @param {Object} request
+   * @return {Promise<Object>} the host's result
+   */
+  async send(request) {
+    let response;
+    try {
+      response = await chrome.runtime.sendNativeMessage(HOST_NAME, request);
+    } catch (e) {
+      // No host installed, or it failed to start. Not the same as no device.
+      throw new MvError(
+        `The Mailvelope USB keystore helper is not available: ${e.message}`,
+        'USB_HOST_UNAVAILABLE'
+      );
+    }
+    if (!response) {
+      throw new MvError('The USB keystore helper returned no response', 'USB_HOST_UNAVAILABLE');
+    }
+    if (response.error) {
+      if (ABSENT_CODES.includes(response.error)) {
+        if (response.error === 'not_found') {
+          throw new NotFoundError(request.path ?? request.root ?? '');
+        }
+        throw new DeviceUnavailableError(response.message || 'device unavailable');
+      }
+      throw new MvError(response.message || response.error, `USB_HOST_${response.error.toUpperCase()}`);
+    }
+    return response.result ?? {};
+  }
+
+  /**
+   * Mounted removable devices, for the UI to offer instead of a picker.
+   * @return {Promise<Array<{path: String, label: String, writable: Boolean}>>}
+   */
+  async listDevices() {
+    const {devices} = await this.send({op: 'listDevices'});
+    return devices ?? [];
+  }
+
+  /**
+   * Check the host is present, speaks a version we understand, and that the
+   * configured device is mounted.
+   */
+  async probe() {
+    let hello;
+    try {
+      hello = await this.send({op: 'hello'});
+    } catch (e) {
+      // Distinguish "no helper installed" from "no device": the UI needs to tell
+      // the user to install something, not to plug something in.
+      return {available: false, permission: 'prompt', configured: false, hostMissing: true};
+    }
+    if (hello.version !== PROTOCOL_VERSION) {
+      throw new MvError(
+        `The USB keystore helper speaks version ${hello.version}, this extension expects ${PROTOCOL_VERSION}`,
+        'USB_HOST_VERSION'
+      );
+    }
+    if (!this.root) {
+      return {available: false, permission: 'granted', configured: false};
+    }
+    try {
+      await this.send({op: 'probe', root: this.root});
+    } catch (e) {
+      if (e instanceof DeviceUnavailableError || e instanceof NotFoundError) {
+        return {available: false, permission: 'granted', configured: true};
+      }
+      throw e;
+    }
+    // No permission model here: authority comes from having installed the host, so
+    // there is no per-session grant to lose. Reported as granted so the state
+    // machine never asks the user to reconnect.
+    return {available: true, permission: 'granted', configured: true};
+  }
+
+  async readFile(path) {
+    this.requireRoot();
+    const {content} = await this.send({op: 'read', root: this.root, path});
+    return content;
+  }
+
+  async writeFile(path, content) {
+    this.requireRoot();
+    // The host stages, fsyncs and renames, keeping the previous generation as .bak,
+    // so the atomicity guarantee matches the File System Access backend.
+    await this.send({op: 'write', root: this.root, path, content});
+  }
+
+  async removeFile(path) {
+    this.requireRoot();
+    await this.send({op: 'remove', root: this.root, path});
+  }
+
+  async listDir(path) {
+    this.requireRoot();
+    const {names} = await this.send({op: 'list', root: this.root, path});
+    return names ?? [];
+  }
+
+  requireRoot() {
+    if (!this.root) {
+      throw new DeviceUnavailableError('No USB keystore device configured');
+    }
+  }
+}

--- a/src/modules/usb/NativeBackend.js
+++ b/src/modules/usb/NativeBackend.js
@@ -31,6 +31,20 @@ export const HOST_NAME = 'mailvelope_usb_keystore';
 /** Protocol version this client understands. */
 export const PROTOCOL_VERSION = 1;
 
+/**
+ * Bytes of file content per message.
+ *
+ * A browser drops a message from the host that exceeds 1 MB before the extension
+ * sees it, so reads have to arrive in pieces -- and a whole public keyring is one
+ * file here, so pieces are the normal case, not an edge case. Writes use the same
+ * size: Firefox would take 4 GB in one message, but Chrome caps that direction at
+ * 1 MB too, and one code path for both is worth more than the saved round trips.
+ *
+ * The value is deliberately under half the cap: armored key text is a newline every
+ * 64 characters, and JSON escaping turns each into two bytes.
+ */
+const CHUNK_BYTES = 384 * 1024;
+
 /** Host error codes that mean "the device is not there", rather than a fault. */
 const ABSENT_CODES = ['not_found', 'io_error', 'root_not_mounted'];
 
@@ -77,6 +91,40 @@ function sendNative(request) {
       maybePromise.then(resolve, reject);
     }
   });
+}
+
+/**
+ * Split a string into chunks of at most limit bytes of UTF-8, with the byte offset
+ * of each.
+ *
+ * Byte offsets rather than character counts because the host writes bytes and
+ * checks that each chunk starts where the last one ended. A character must not be
+ * split across chunks either: each piece is sent as JSON text, so half a character
+ * cannot survive the trip.
+ * @param {String} content
+ * @param {Number} limit
+ * @return {Array<{offset: Number, text: String}>} always at least one chunk, so an
+ *   empty file is still written
+ */
+function splitByBytes(content, limit) {
+  const bytes = new TextEncoder().encode(content);
+  if (bytes.length <= limit) {
+    return [{offset: 0, text: content}];
+  }
+  const decoder = new TextDecoder();
+  const chunks = [];
+  let start = 0;
+  while (start < bytes.length) {
+    let end = Math.min(start + limit, bytes.length);
+    // Continuation bytes are 10xxxxxx: walk back off the character that straddles
+    // the boundary and leave it for the next chunk.
+    while (end > start && end < bytes.length && (bytes[end] & 0xc0) === 0x80) {
+      end -= 1;
+    }
+    chunks.push({offset: start, text: decoder.decode(bytes.subarray(start, end))});
+    start = end;
+  }
+  return chunks;
 }
 
 export default class NativeBackend extends UsbBackend {
@@ -219,17 +267,65 @@ export default class NativeBackend extends UsbBackend {
     };
   }
 
+  /**
+   * Read a file, one chunk per message, following the host's byte offsets.
+   * @param {String} path
+   * @return {Promise<String>}
+   */
   async readFile(path) {
     this.requireRoot();
-    const {content} = await this.send({op: 'read', root: this.root, path});
-    return content;
+    const parts = [];
+    let offset = 0;
+    for (;;) {
+      const chunk = await this.send({
+        op: 'read', root: this.root, path, offset, maxBytes: CHUNK_BYTES
+      });
+      parts.push(chunk.content ?? '');
+      if (chunk.eof !== false) {
+        break;
+      }
+      if (!(chunk.nextOffset > offset)) {
+        // A host that reports neither the end of the file nor any progress would
+        // otherwise be read forever.
+        throw new MvError(
+          `The USB keystore helper stopped making progress reading ${path}`,
+          'USB_HOST_PROTOCOL'
+        );
+      }
+      offset = chunk.nextOffset;
+    }
+    return parts.join('');
   }
 
+  /**
+   * Write a file, one chunk per message.
+   *
+   * The host appends each chunk to a staging file and renames it into place on the
+   * one marked final, so the atomicity guarantee matches the File System Access
+   * backend: an interrupted write leaves the old file, plus the previous generation
+   * as .bak, and never a half-written primary. Chunks must therefore go in order,
+   * which is why this awaits each one.
+   * @param {String} path
+   * @param {String} content
+   */
   async writeFile(path, content) {
     this.requireRoot();
-    // The host stages, fsyncs and renames, keeping the previous generation as .bak,
-    // so the atomicity guarantee matches the File System Access backend.
-    await this.send({op: 'write', root: this.root, path, content});
+    if (typeof content !== 'string') {
+      // TextEncoder would happily encode the string "undefined" and the device would
+      // end up holding it, so refuse rather than write something plausible.
+      throw new MvError(`Refusing to write ${typeof content} to ${path}`, 'USB_HOST_PROTOCOL');
+    }
+    const chunks = splitByBytes(content, CHUNK_BYTES);
+    for (let i = 0; i < chunks.length; i++) {
+      await this.send({
+        op: 'write',
+        root: this.root,
+        path,
+        content: chunks[i].text,
+        offset: chunks[i].offset,
+        final: i === chunks.length - 1
+      });
+    }
   }
 
   async removeFile(path) {

--- a/src/modules/usb/NativeBackend.js
+++ b/src/modules/usb/NativeBackend.js
@@ -34,6 +34,51 @@ export const PROTOCOL_VERSION = 1;
 /** Host error codes that mean "the device is not there", rather than a fault. */
 const ABSENT_CODES = ['not_found', 'io_error', 'root_not_mounted'];
 
+/**
+ * One native message, tolerating either calling convention.
+ *
+ * Firefox exposes chrome.* as an alias for browser.*, but the two namespaces have
+ * historically differed on whether a method returns a promise or takes a callback.
+ * Assuming promises would make a callback-only implementation resolve to undefined,
+ * which this class would then report as "the helper returned no response" -- a
+ * missing-helper message for a working helper.
+ *
+ * Prefer the promise if one comes back, fall back to the callback otherwise, so the
+ * difference cannot matter.
+ * @param {Object} request
+ * @return {Promise<Object>}
+ */
+function sendNative(request) {
+  const api = (typeof browser !== 'undefined' && browser.runtime?.sendNativeMessage)
+    ? browser.runtime.sendNativeMessage.bind(browser.runtime)
+    : chrome.runtime.sendNativeMessage.bind(chrome.runtime);
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const done = value => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      const error = chrome.runtime.lastError;
+      if (error) {
+        reject(new Error(error.message));
+      } else {
+        resolve(value);
+      }
+    };
+    let maybePromise;
+    try {
+      maybePromise = api(HOST_NAME, request, done);
+    } catch (e) {
+      reject(e);
+      return;
+    }
+    if (maybePromise && typeof maybePromise.then === 'function') {
+      maybePromise.then(resolve, reject);
+    }
+  });
+}
+
 export default class NativeBackend extends UsbBackend {
   constructor() {
     super();
@@ -42,14 +87,26 @@ export default class NativeBackend extends UsbBackend {
   }
 
   /**
-   * Whether native messaging is reachable at all.
+   * Whether this browser could reach a native host, given permission.
    *
-   * Only checks that the API exists; whether the host is actually installed can
-   * only be discovered by talking to it, which probe() does.
+   * Deliberately not a test for chrome.runtime.sendNativeMessage. Firefox hides
+   * permission-gated APIs until the permission is granted, and nativeMessaging is
+   * optional -- so testing for the function makes support read as false until
+   * granted, while the UI that asks for the grant is itself gated on support. That
+   * is unreachable by construction.
+   *
+   * So the question here is capability, not current state: can this browser talk to
+   * a native host at all? Whether the permission is held, and whether a host is
+   * actually installed, are separate questions answered by the picker UI and by
+   * probe() respectively -- and they need different remedies, so they must not be
+   * collapsed into this one.
    * @return {Boolean}
    */
   static isSupported() {
-    return typeof chrome !== 'undefined' && Boolean(chrome.runtime?.sendNativeMessage);
+    if (typeof chrome === 'undefined' || !chrome.runtime) {
+      return false;
+    }
+    return Boolean(chrome.runtime.sendNativeMessage) || Boolean(chrome.permissions?.request);
   }
 
   /** The device path this backend operates on. Set from the stored configuration. */
@@ -72,9 +129,19 @@ export default class NativeBackend extends UsbBackend {
    * @return {Promise<Object>} the host's result
    */
   async send(request) {
+    if (!chrome.runtime.sendNativeMessage) {
+      // Firefox exposes this only once nativeMessaging is granted, so its absence
+      // means the permission, not a missing helper. Distinct code: the remedies
+      // differ, and telling someone to install software they already have is worse
+      // than saying nothing.
+      throw new MvError(
+        'Permission to use the Mailvelope USB keystore helper has not been granted',
+        'USB_HOST_PERMISSION'
+      );
+    }
     let response;
     try {
-      response = await chrome.runtime.sendNativeMessage(HOST_NAME, request);
+      response = await sendNative(request);
     } catch (e) {
       // No host installed, or it failed to start. Not the same as no device.
       throw new MvError(

--- a/src/modules/usb/backend.js
+++ b/src/modules/usb/backend.js
@@ -1,0 +1,89 @@
+/**
+ * Copyright (C) 2026 Noam Rathaus
+ * Licensed under the GNU Affero General Public License version 3
+ *
+ * Backend interface for USB keystore I/O.
+ *
+ * Two implementations are planned:
+ *   - FsaBackend    File System Access API, Chromium only
+ *   - NativeBackend native messaging host, required for Firefox
+ *
+ * All paths are '/'-separated and relative to the device root directory
+ * (the directory the user picked), e.g. 'mailvelope-keystore/keystore.json'.
+ */
+
+import {MvError} from '../../lib/util';
+import {USB_KEYSTORE_UNAVAILABLE} from './constants';
+
+/** Thrown when a path does not exist on the device. */
+export class NotFoundError extends MvError {
+  constructor(path) {
+    super(`Not found on USB keystore: ${path}`, 'USB_NOT_FOUND');
+  }
+}
+
+/** Thrown when the device cannot be reached at all. */
+export class DeviceUnavailableError extends MvError {
+  constructor(message = 'USB keystore is not available') {
+    super(message, USB_KEYSTORE_UNAVAILABLE);
+  }
+}
+
+export class UsbBackend {
+  /**
+   * Whether this backend can work in the current browser.
+   * @return {Boolean}
+   */
+  static isSupported() {
+    return false;
+  }
+
+  /**
+   * Check that the device is reachable.
+   * @return {Promise<{available: Boolean, permission: String}>} permission is
+   *   'granted', 'prompt' or 'denied'
+   */
+  async probe() {
+    throw new Error('not implemented');
+  }
+
+  /**
+   * Read a UTF-8 text file.
+   * @param {String} path
+   * @return {Promise<String>}
+   * @throws {NotFoundError|DeviceUnavailableError}
+   */
+  async readFile(path) { // eslint-disable-line no-unused-vars
+    throw new Error('not implemented');
+  }
+
+  /**
+   * Write a UTF-8 text file, creating parent directories as needed.
+   * The write must be atomic from the reader's point of view: a device pulled
+   * mid-write must not leave a half-written file in place of the old one.
+   * @param {String} path
+   * @param {String} content
+   * @return {Promise<undefined>}
+   */
+  async writeFile(path, content) { // eslint-disable-line no-unused-vars
+    throw new Error('not implemented');
+  }
+
+  /**
+   * Remove a file. Missing files are not an error.
+   * @param {String} path
+   * @return {Promise<undefined>}
+   */
+  async removeFile(path) { // eslint-disable-line no-unused-vars
+    throw new Error('not implemented');
+  }
+
+  /**
+   * List the entry names of a directory. A missing directory yields [].
+   * @param {String} path
+   * @return {Promise<Array<String>>}
+   */
+  async listDir(path) { // eslint-disable-line no-unused-vars
+    throw new Error('not implemented');
+  }
+}

--- a/src/modules/usb/constants.js
+++ b/src/modules/usb/constants.js
@@ -1,0 +1,64 @@
+/**
+ * Copyright (C) 2026 Noam Rathaus
+ * Licensed under the GNU Affero General Public License version 3
+ *
+ * Constants for the USB-resident keystore.
+ *
+ * Deliberately kept out of src/lib/constants.js: this feature is developed on a
+ * branch that tracks upstream master, so all of its state lives in new files and
+ * existing files are only touched at small hook points. See doc/usb-keystore-plan.md.
+ */
+
+/** Availability states of the USB keystore. */
+export const USB_STATE = {
+  /** No USB keystore has been set up. */
+  NOT_CONFIGURED: 'NOT_CONFIGURED',
+  /** No usable backend in this browser (Firefox without the native host). */
+  UNSUPPORTED: 'UNSUPPORTED',
+  /** A directory handle is stored but the permission grant is missing. */
+  PERMISSION_REQUIRED: 'PERMISSION_REQUIRED',
+  /** Configured and permitted, but the device is not readable: not plugged in. */
+  ABSENT: 'ABSENT',
+  /** Readable, but it is not the device this profile was set up with. */
+  WRONG_DEVICE: 'WRONG_DEVICE',
+  /** I/O failure or a corrupt keystore. */
+  ERROR: 'ERROR',
+  /** Everything usable. */
+  READY: 'READY'
+};
+
+/** States in which key material must not be read or written. */
+export const UNUSABLE_STATES = [
+  USB_STATE.NOT_CONFIGURED,
+  USB_STATE.UNSUPPORTED,
+  USB_STATE.PERMISSION_REQUIRED,
+  USB_STATE.ABSENT,
+  USB_STATE.WRONG_DEVICE,
+  USB_STATE.ERROR
+];
+
+/** Error code raised whenever a crypto operation is attempted without the device. */
+export const USB_KEYSTORE_UNAVAILABLE = 'USB_KEYSTORE_UNAVAILABLE';
+
+/** chrome.storage.local key holding the USB keystore configuration (no key material). */
+export const USB_CONFIG_KEY = 'mvelo.usb.config';
+
+/** IndexedDB database and store holding the FileSystemDirectoryHandle. */
+export const HANDLE_DB_NAME = 'mvelo.usb';
+export const HANDLE_STORE_NAME = 'handles';
+export const HANDLE_KEY = 'keystoreDir';
+
+/** Root directory created on the device. */
+export const DEVICE_ROOT = 'mailvelope-keystore';
+/** Marker file used both as the presence probe and as the device identity. */
+export const MARKER_FILE = 'keystore.json';
+/** Subdirectory holding one directory per keyring. */
+export const KEYRINGS_DIR = 'keyrings';
+
+/** On-device layout version, so a future format change can be detected. */
+export const KEYSTORE_VERSION = 1;
+
+/** chrome.alarms name for the periodic presence probe. */
+export const PROBE_ALARM = 'mvelo.usb.probe';
+/** Probe period in minutes. 1 is the practical Chrome MV3 floor. */
+export const PROBE_PERIOD_MINUTES = 1;

--- a/src/modules/usb/constants.js
+++ b/src/modules/usb/constants.js
@@ -23,6 +23,14 @@ export const USB_STATE = {
   WRONG_DEVICE: 'WRONG_DEVICE',
   /** I/O failure or a corrupt keystore. */
   ERROR: 'ERROR',
+  /**
+   * Present and readable, but writes are refused.
+   *
+   * Not exotic: FAT mounts commonly carry errors=remount-ro, so a filesystem error
+   * silently makes a stick read-only. Without a state for it, a failed save
+   * surfaces as a raw platform error, and a delete appears to succeed.
+   */
+  READ_ONLY: 'READ_ONLY',
   /** Everything usable. */
   READY: 'READY'
 };
@@ -39,6 +47,9 @@ export const UNUSABLE_STATES = [
 
 /** Error code raised whenever a crypto operation is attempted without the device. */
 export const USB_KEYSTORE_UNAVAILABLE = 'USB_KEYSTORE_UNAVAILABLE';
+
+/** Raised when the device is readable but refuses writes. */
+export const USB_READ_ONLY = 'USB_READ_ONLY';
 
 /** chrome.storage.local key holding the USB keystore configuration (no key material). */
 export const USB_CONFIG_KEY = 'mvelo.usb.config';

--- a/src/modules/usb/constants.js
+++ b/src/modules/usb/constants.js
@@ -63,5 +63,25 @@ export const KEYSTORE_VERSION = 1;
 
 /** chrome.alarms name for the periodic presence probe. */
 export const PROBE_ALARM = 'mvelo.usb.probe';
-/** Probe period in minutes. 1 is the practical Chrome MV3 floor. */
-export const PROBE_PERIOD_MINUTES = 1;
+/**
+ * Probe period in minutes. 0.5 (30s) is Chrome's floor for a periodic alarm.
+ *
+ * This is only the backstop for when nobody is looking. A timer is the wrong
+ * instrument for "the user is watching the page" -- see FOCUS_PROBE_INTERVAL_MS.
+ */
+export const PROBE_PERIOD_MINUTES = 0.5;
+
+/**
+ * How often a *visible* Mailvelope page re-checks the device.
+ *
+ * Not subject to the alarm floor, and this is the number that governs perceived
+ * latency: detection only feels slow while someone is looking at the page. Each
+ * check is one small marker-file read, and polling stops the moment the page is
+ * hidden or the last subscriber goes away, so an idle browser does no device I/O
+ * beyond the 30-second alarm.
+ *
+ * The cost of 1s is that a visible page keeps a removable device from idling. That
+ * is a real but small price on flash media, and it only applies while a Mailvelope
+ * page is actually in front of the user.
+ */
+export const FOCUS_PROBE_INTERVAL_MS = 1000;

--- a/src/modules/usb/constants.js
+++ b/src/modules/usb/constants.js
@@ -52,6 +52,9 @@ export const HANDLE_KEY = 'keystoreDir';
 export const DEVICE_ROOT = 'mailvelope-keystore';
 /** Marker file used both as the presence probe and as the device identity. */
 export const MARKER_FILE = 'keystore.json';
+/** Plain-text explanation written alongside the keys, for recovery by hand. */
+export const README_FILE = 'README.txt';
+
 /** Subdirectory holding one directory per keyring. */
 export const KEYRINGS_DIR = 'keyrings';
 

--- a/src/modules/usb/debugLog.js
+++ b/src/modules/usb/debugLog.js
@@ -1,0 +1,160 @@
+/**
+ * Copyright (C) 2026 Noam Rathaus
+ * Licensed under the GNU Affero General Public License version 3
+ *
+ * A bounded diagnostic log for the USB keystore, written to chrome.storage.local.
+ *
+ * Why there rather than the console: the interesting failures happen in the service
+ * worker, which goes idle and takes its console with it, and reproducing them means
+ * asking someone to copy text out of DevTools. chrome.storage.local is readable
+ * directly from the browser profile on disk, so whoever is debugging can read the
+ * log themselves without the user relaying it.
+ *
+ * Deliberately NOT via chrome.downloads: that would need a new manifest permission,
+ * and widening an encryption extension's permissions for a debugging convenience is
+ * a bad trade.
+ *
+ * NEVER log key material. Paths, sizes, states, error names and codes only. The log
+ * lives in local storage, which is exactly where this feature exists to keep key
+ * material out of.
+ *
+ * DISABLED BY DEFAULT, and deliberately not exposed in the UI. Diagnostics that
+ * write to disk are a liability for an encryption extension: an always-on log is one
+ * more place for something sensitive to end up, and a visible switch is one more way
+ * to turn that on by accident. It has to be enabled explicitly, and disabling it
+ * erases whatever was captured.
+ */
+
+const STORAGE_KEY = 'mvelo.usb.debug';
+/** Ring buffer bound. Enough for several sessions, small enough to stay cheap. */
+const MAX_ENTRIES = 300;
+/** Guard against a runaway caller filling storage with one enormous entry. */
+const MAX_DETAIL_LENGTH = 500;
+
+const ENABLED_KEY = 'mvelo.usb.debugEnabled';
+
+let entries = [];
+let loaded = false;
+let writing = null;
+let enabled = null;  // null = not yet read from storage
+
+/**
+ * Whether logging is on. Cached after the first read; a disabled log must not cost
+ * a storage round-trip per call.
+ * @return {Promise<Boolean>}
+ */
+async function isEnabled() {
+  if (enabled === null) {
+    try {
+      const {[ENABLED_KEY]: stored} = await chrome.storage.local.get(ENABLED_KEY);
+      enabled = stored === true;
+    } catch (e) {
+      enabled = false;
+    }
+  }
+  return enabled;
+}
+
+/**
+ * Turn logging on or off. Disabling erases what was already captured, so switching
+ * it off is also a way to clean up.
+ * @param {Boolean} on
+ */
+export async function setEnabled(on) {
+  enabled = on === true;
+  await chrome.storage.local.set({[ENABLED_KEY]: enabled});
+  if (!enabled) {
+    await clearLog();
+  }
+}
+
+function clip(value) {
+  const text = typeof value === 'string' ? value : JSON.stringify(value ?? null);
+  if (!text) {
+    return text;
+  }
+  return text.length > MAX_DETAIL_LENGTH ? `${text.slice(0, MAX_DETAIL_LENGTH)}…` : text;
+}
+
+async function load() {
+  if (loaded) {
+    return;
+  }
+  loaded = true;
+  try {
+    const {[STORAGE_KEY]: stored} = await chrome.storage.local.get(STORAGE_KEY);
+    if (Array.isArray(stored)) {
+      entries = stored.slice(-MAX_ENTRIES);
+    }
+  } catch (e) {
+    // A log that cannot load is still usable for new entries.
+  }
+}
+
+/** Serialise writes so concurrent log calls cannot clobber each other. */
+async function flush() {
+  writing = (writing ?? Promise.resolve()).then(async () => {
+    try {
+      await chrome.storage.local.set({[STORAGE_KEY]: entries});
+    } catch (e) {
+      // Never let logging break the operation being logged.
+    }
+  });
+  return writing;
+}
+
+/**
+ * Record a diagnostic event.
+ * @param {String} event - short stable identifier, e.g. 'probe' or 'provision.refused'
+ * @param {Object} [detail] - small plain object; must contain no key material
+ */
+export async function log(event, detail) {
+  if (!await isEnabled()) {
+    return;
+  }
+  await load();
+  entries.push({
+    t: new Date().toISOString(),
+    event,
+    ...(detail !== undefined && {detail: clip(detail)})
+  });
+  if (entries.length > MAX_ENTRIES) {
+    entries = entries.slice(-MAX_ENTRIES);
+  }
+  await flush();
+}
+
+/**
+ * Record a failure, keeping the parts that identify it rather than the stack.
+ * @param {String} event
+ * @param {Error} error
+ * @param {Object} [detail]
+ */
+export function logError(event, error, detail) {
+  // Routed through log(), so the enabled check applies here too.
+  return log(event, {
+    ...detail,
+    error: error?.name ?? 'Error',
+    code: error?.code,
+    message: clip(error?.message ?? String(error))
+  });
+}
+
+/**
+ * The whole log, for display or export.
+ * @return {Promise<Array<Object>>}
+ */
+export async function getLog() {
+  await load();
+  return entries.slice();
+}
+
+/** Drop the log. */
+export async function clearLog() {
+  entries = [];
+  loaded = true;
+  await flush();
+}
+
+/** Storage keys, so the router can keep them local and out of the crypto paths. */
+export const DEBUG_STORAGE_KEYS = [STORAGE_KEY, ENABLED_KEY];

--- a/src/modules/usb/guard.js
+++ b/src/modules/usb/guard.js
@@ -1,0 +1,42 @@
+/**
+ * Copyright (C) 2026 Noam Rathaus
+ * Licensed under the GNU Affero General Public License version 3
+ *
+ * Guards for the paths that would copy key material off the USB device.
+ *
+ * Storage redirection is handled centrally by install.js, but two paths do not go
+ * through storage at all — they upload key material to a remote sync server:
+ *
+ *   - PrivateKeyController.createPrivateKeyBackup, which encrypts the private key
+ *     under a backup code and uploads it. Triggered by a webmail provider page
+ *     through the client API, not by Mailvelope's own UI, so it has to be refused
+ *     here rather than hidden in the interface.
+ *   - SyncController.triggerSync, which uploads the encrypted keyring.
+ *
+ * Both are incompatible with keeping key material only on the device.
+ */
+
+import {MvError} from '../../lib/util';
+import {USB_KEYSTORE_UNAVAILABLE} from './constants';
+import {isEnabled} from './state';
+
+/**
+ * May key material be sent to a remote store?
+ * @return {Boolean} false while a USB keystore is configured
+ */
+export function isRemoteKeyStorageAllowed() {
+  return !isEnabled();
+}
+
+/**
+ * Throw if key material may not be sent to a remote store.
+ * @param {String} what - operation name, for the error message
+ */
+export function assertRemoteKeyStorageAllowed(what) {
+  if (!isRemoteKeyStorageAllowed()) {
+    throw new MvError(
+      `${what} is not available while keys are stored on a USB device: it would copy key material off the device`,
+      USB_KEYSTORE_UNAVAILABLE
+    );
+  }
+}

--- a/src/modules/usb/guard.js
+++ b/src/modules/usb/guard.js
@@ -18,7 +18,36 @@
 
 import {MvError} from '../../lib/util';
 import {USB_KEYSTORE_UNAVAILABLE} from './constants';
-import {isEnabled} from './state';
+import {isEnabled, assertUsable} from './state';
+
+/**
+ * Refuse a crypto operation when the device holding the keys is not connected.
+ *
+ * Without this the failure surfaces as "key not found", because reads degrade to an
+ * empty keyring and the lookup legitimately finds nothing. That is honest at the
+ * keyring layer and misleading at the user layer: it says the key does not exist,
+ * when the truth is that it is not reachable. For a keystore that is deliberately
+ * the only copy, "not found" is the message most likely to make someone think they
+ * have lost the key -- or generate a replacement and abandon a perfectly good one.
+ *
+ * Applied at the crypto entry points rather than in the UI so the message is right
+ * wherever the operation runs, including the editor embedded in a webmail page,
+ * which never renders Mailvelope's own status banner.
+ * @throws {MvError} with code USB_KEYSTORE_UNAVAILABLE
+ */
+export async function assertKeystoreForCrypto() {
+  if (!isEnabled()) {
+    return;
+  }
+  try {
+    await assertUsable();
+  } catch (e) {
+    throw new MvError(
+      'The USB keystore is not available. Connect the device to use your keys.',
+      USB_KEYSTORE_UNAVAILABLE
+    );
+  }
+}
 
 /**
  * Require a passphrase whenever keys live on a removable device.

--- a/src/modules/usb/guard.js
+++ b/src/modules/usb/guard.js
@@ -21,6 +21,27 @@ import {USB_KEYSTORE_UNAVAILABLE} from './constants';
 import {isEnabled} from './state';
 
 /**
+ * Require a passphrase whenever keys live on a removable device.
+ *
+ * The device provides separation and portability, not confidentiality: a private
+ * key written to it is protected only by its OpenPGP passphrase. Without one, a
+ * lost device hands over the identity outright, which turns the accepted "losing
+ * the device is survivable" into a compromise.
+ *
+ * Enforced in the background rather than only in the generate form, because key
+ * generation is also reachable from a webmail page through the client API.
+ * @param {String} passphrase
+ */
+export function assertPassphrase(passphrase) {
+  if (isEnabled() && !passphrase) {
+    throw new MvError(
+      'A passphrase is required when keys are stored on a USB device: it is the only protection if the device is lost',
+      'USB_KEYSTORE_PASSPHRASE_REQUIRED'
+    );
+  }
+}
+
+/**
  * May key material be sent to a remote store?
  * @return {Boolean} false while a USB keystore is configured
  */

--- a/src/modules/usb/handleStore.js
+++ b/src/modules/usb/handleStore.js
@@ -1,0 +1,68 @@
+/**
+ * Copyright (C) 2026 Noam Rathaus
+ * Licensed under the GNU Affero General Public License version 3
+ *
+ * IndexedDB persistence for the FileSystemDirectoryHandle of the USB keystore.
+ *
+ * Why IndexedDB rather than passing the handle over a port: runtime messages are
+ * JSON-serialized, so a FileSystemHandle cannot survive chrome.runtime messaging.
+ * IndexedDB stores it by structured clone, and the app page and the service worker
+ * share one chrome-extension:// origin, so the page writes the handle and the
+ * background reads it back. The port message only carries the signal, not the handle.
+ */
+
+import {HANDLE_DB_NAME, HANDLE_STORE_NAME, HANDLE_KEY} from './constants';
+
+function openDb() {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(HANDLE_DB_NAME, 1);
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(HANDLE_STORE_NAME)) {
+        db.createObjectStore(HANDLE_STORE_NAME);
+      }
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+async function transact(mode, fn) {
+  const db = await openDb();
+  try {
+    return await new Promise((resolve, reject) => {
+      const tx = db.transaction(HANDLE_STORE_NAME, mode);
+      const request = fn(tx.objectStore(HANDLE_STORE_NAME));
+      tx.onabort = () => reject(tx.error);
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => reject(request.error);
+    });
+  } finally {
+    db.close();
+  }
+}
+
+/**
+ * Persist the directory handle. Called from the app page, which is the only
+ * context that can run showDirectoryPicker().
+ * @param {FileSystemDirectoryHandle} handle
+ */
+export async function put(handle) {
+  await transact('readwrite', store => store.put(handle, HANDLE_KEY));
+}
+
+/**
+ * Retrieve the stored directory handle.
+ * @return {Promise<FileSystemDirectoryHandle|undefined>}
+ */
+export function get() {
+  return transact('readonly', store => store.get(HANDLE_KEY));
+}
+
+/**
+ * Forget the stored handle. Note this only drops our reference; it does not
+ * revoke the browser's permission grant.
+ */
+export async function remove() {
+  await transact('readwrite', store => store.delete(HANDLE_KEY));
+}

--- a/src/modules/usb/handlers.js
+++ b/src/modules/usb/handlers.js
@@ -1,0 +1,39 @@
+/**
+ * Copyright (C) 2026 Noam Rathaus
+ * Licensed under the GNU Affero General Public License version 3
+ *
+ * Port event handlers for the USB keystore, attached to an existing controller.
+ *
+ * Packaged as one registration call so the controller only needs a single added
+ * line rather than an entry per event.
+ */
+
+import * as state from './state';
+import * as provision from './provision';
+
+/**
+ * Attach USB keystore events to a controller and forward state changes to its port.
+ * @param {SubController} controller
+ */
+export function registerUsbHandlers(controller) {
+  controller.on('usb-get-status', () => state.getStatus());
+  controller.on('usb-probe', () => provision.reprobe());
+  controller.on('usb-provision', ({label} = {}) => provision.provision({label}));
+  controller.on('usb-disable', () => provision.disable());
+  controller.on('usb-diagnostics', () => provision.diagnostics());
+  controller.on('usb-inspect-local', () => provision.inspectLocalKeyMaterial());
+  controller.on('usb-migrate', () => provision.migrateLocalKeyMaterial());
+
+  const unregister = state.addStateListener((next, previous, status) => {
+    const port = controller.ports?.[controller.mainType];
+    if (!port) {
+      return;
+    }
+    try {
+      port.emit('usb-status-changed', status);
+    } catch (e) {
+      // The view is gone; stop forwarding to it.
+      unregister();
+    }
+  });
+}

--- a/src/modules/usb/handlers.js
+++ b/src/modules/usb/handlers.js
@@ -21,7 +21,11 @@ export function registerUsbHandlers(controller) {
   // alarm has not fired. One small file read.
   controller.on('usb-get-status', () => provision.reprobe());
   controller.on('usb-probe', () => provision.reprobe());
-  controller.on('usb-provision', ({label} = {}) => provision.provision({label}));
+  // Forward adopt explicitly. Dropping it silently made the "use this folder
+  // anyway" override impossible: provisioning always saw adopt as undefined, so the
+  // identity guard refused every attempt, including the one the user had just
+  // authorised.
+  controller.on('usb-provision', ({label, adopt} = {}) => provision.provision({label, adopt}));
   controller.on('usb-disable', () => provision.disable());
   controller.on('usb-diagnostics', () => provision.diagnostics());
   controller.on('usb-inspect-local', () => provision.inspectLocalKeyMaterial());

--- a/src/modules/usb/handlers.js
+++ b/src/modules/usb/handlers.js
@@ -16,7 +16,10 @@ import * as provision from './provision';
  * @param {SubController} controller
  */
 export function registerUsbHandlers(controller) {
-  controller.on('usb-get-status', () => state.getStatus());
+  // Probe rather than answer from cache: a view opening or refreshing is a natural
+  // moment to re-check, and it means the UI self-corrects even if the periodic
+  // alarm has not fired. One small file read.
+  controller.on('usb-get-status', () => provision.reprobe());
   controller.on('usb-probe', () => provision.reprobe());
   controller.on('usb-provision', ({label} = {}) => provision.provision({label}));
   controller.on('usb-disable', () => provision.disable());

--- a/src/modules/usb/handlers.js
+++ b/src/modules/usb/handlers.js
@@ -10,6 +10,37 @@
 
 import * as state from './state';
 import * as provision from './provision';
+import {encodeKeyringId} from './router';
+import {getAll as getAllKeyrings} from '../keyring';
+
+/**
+ * How many keys the running extension is holding, per keyring directory.
+ *
+ * Counted here rather than in provision.js, which the settings page imports for the
+ * directory picker and which therefore must stay clear of the keyring subsystem.
+ *
+ * Raced against a timeout for the same reason the other keyring callers are:
+ * getAll() waits on keyring initialisation, and diagnostics must answer regardless.
+ * @return {Promise<Object>}
+ */
+async function loadedKeyCounts() {
+  const counts = {};
+  try {
+    const keyrings = await Promise.race([
+      getAllKeyrings(),
+      new Promise(resolve => setTimeout(() => resolve(null), 2000))
+    ]);
+    for (const keyring of keyrings ?? []) {
+      counts[encodeKeyringId(keyring.id)] = {
+        publicKeys: keyring.keystore.publicKeys.keys.length,
+        privateKeys: keyring.keystore.privateKeys.keys.length
+      };
+    }
+  } catch (e) {
+    // Diagnostics degrade to "not counted" rather than failing the whole panel.
+  }
+  return counts;
+}
 
 /**
  * Attach USB keystore events to a controller and forward state changes to its port.
@@ -27,7 +58,7 @@ export function registerUsbHandlers(controller) {
   // authorised.
   controller.on('usb-provision', ({label, adopt} = {}) => provision.provision({label, adopt}));
   controller.on('usb-disable', () => provision.disable());
-  controller.on('usb-diagnostics', () => provision.diagnostics());
+  controller.on('usb-diagnostics', async () => provision.diagnostics({loaded: await loadedKeyCounts()}));
   // Native-host only: Firefox cannot open a directory picker, so it offers the
   // mounted devices the helper reports instead.
   controller.on('usb-list-devices', () => provision.listDevices());

--- a/src/modules/usb/handlers.js
+++ b/src/modules/usb/handlers.js
@@ -28,6 +28,10 @@ export function registerUsbHandlers(controller) {
   controller.on('usb-provision', ({label, adopt} = {}) => provision.provision({label, adopt}));
   controller.on('usb-disable', () => provision.disable());
   controller.on('usb-diagnostics', () => provision.diagnostics());
+  // Native-host only: Firefox cannot open a directory picker, so it offers the
+  // mounted devices the helper reports instead.
+  controller.on('usb-list-devices', () => provision.listDevices());
+  controller.on('usb-select-device', ({devicePath} = {}) => provision.selectDevice(devicePath));
   controller.on('usb-inspect-local', () => provision.inspectLocalKeyMaterial());
   controller.on('usb-migrate', () => provision.migrateLocalKeyMaterial());
 

--- a/src/modules/usb/install.js
+++ b/src/modules/usb/install.js
@@ -30,6 +30,10 @@ import {clear as clearPwdCache} from '../pwdCache';
 let installed = false;
 const original = {};
 
+// Registered here, at module scope, because background.js imports this module during
+// its synchronous evaluation. See registerProbeListener for why that timing matters.
+state.registerProbeListener();
+
 /**
  * Read a device-backed value.
  * @param {Object} route - result of router.classify()
@@ -82,7 +86,14 @@ async function wrappedGet(id) {
   }
   const route = router.classify(id);
   if (route.target === router.TARGET.DEVICE) {
-    return readDevice(route);
+    const value = await readDevice(route);
+    // Seeing keys on the device is as good a signal as writing them, and a better
+    // one in practice: keys are written rarely but read on every startup, so a
+    // profile set up before this flag existed would otherwise never record it.
+    if (id.endsWith('.privateKeys') && value?.length) {
+      await state.setHadKeys(true);
+    }
+    return value;
   }
   if (route.target === router.TARGET.SPLIT) {
     const local = await original.get(id);
@@ -109,7 +120,13 @@ async function wrappedSet(id, value) {
   }
   const route = router.classify(id);
   if (route.target === router.TARGET.DEVICE) {
-    return writeDevice(route, value);
+    await writeDevice(route, value);
+    // Remember that this device has held a private key, so a later detached
+    // session can tell "keys are on the device" from "never set up".
+    if (id.endsWith('.privateKeys') && value?.length) {
+      await state.setHadKeys(true);
+    }
+    return;
   }
   if (route.target === router.TARGET.SPLIT) {
     const {device, local} = router.splitAttributes(value);
@@ -209,10 +226,42 @@ async function purgeInMemoryKeyMaterial() {
   }
 }
 
+/**
+ * Load the keyrings back from the device once it is reachable again.
+ *
+ * Reads degrade to "empty" while the device is away, so every keyring in memory is
+ * blank by the time it returns. Without this the warning would clear while the UI
+ * still showed no keys, which reads as data loss.
+ *
+ * Raced against a timeout for the same reason as the purge: at startup this runs
+ * before keyring initialisation, and init() loads from the device itself, so there
+ * is nothing to do here yet.
+ */
+async function reloadKeyringsFromDevice() {
+  try {
+    const keyrings = await Promise.race([
+      getAllKeyrings(),
+      new Promise(resolve => setTimeout(() => resolve(null), 2000))
+    ]);
+    if (!keyrings) {
+      return;
+    }
+    for (const keyring of keyrings) {
+      keyring.keystore.clear();
+      await keyring.keystore.load();
+    }
+  } catch (e) {
+    console.log('USB keystore: reloading keyrings failed', e);
+  }
+}
+
 function onStateChange(next, previous) {
   refreshBadge();
   if (next !== USB_STATE.READY && previous === USB_STATE.READY) {
     purgeInMemoryKeyMaterial();
+  }
+  if (next === USB_STATE.READY && previous !== USB_STATE.READY) {
+    reloadKeyringsFromDevice();
   }
 }
 

--- a/src/modules/usb/install.js
+++ b/src/modules/usb/install.js
@@ -274,8 +274,10 @@ async function reloadKeyringsFromDevice() {
       return;
     }
     for (const keyring of keyrings) {
-      keyring.keystore.clear();
-      await keyring.keystore.load();
+      // reload(), not clear() then load(): this runs while pages are reading the
+      // keyring, and a keyring of any size takes long enough to refill that a reader
+      // would otherwise see a fraction of it.
+      await keyring.keystore.reload();
     }
     // Tell the views the keys are actually available now. The READY broadcast went
     // out before this finished, so anything that refreshed on it saw an empty

--- a/src/modules/usb/install.js
+++ b/src/modules/usb/install.js
@@ -70,9 +70,36 @@ async function readDevice(route) {
 
 async function writeDevice(route, value) {
   // Reprobe before writing: a stale READY reading would otherwise let a write be
-  // attempted against a device that has just been pulled.
-  await state.assertUsable(true);
-  await state.getBackend().writeFile(route.path, router.serialize(value, route.format));
+  // attempted against a device that has just been pulled. assertWritable also
+  // refuses a device that is present but write-protected, before the caller has
+  // mutated anything.
+  await state.assertWritable(true);
+  try {
+    await state.getBackend().writeFile(route.path, router.serialize(value, route.format));
+  } catch (e) {
+    if (isReadOnlyFailure(e)) {
+      // The File System Access API cannot report writability in advance, so this is
+      // where a write-protected device is discovered. Record it so the state, and
+      // therefore the message, is right from now on.
+      state.markReadOnly();
+    }
+    // Callers mutate the in-memory keyring before persisting, so a failed write
+    // leaves memory disagreeing with the device -- a deleted key appears gone while
+    // it is still there. Reload so what the user sees is what is actually stored,
+    // which matters most for a delete they believe succeeded.
+    reloadKeyringsFromDevice();
+    throw e;
+  }
+}
+
+/** Whether a write failure looks like a write-protected device. */
+function isReadOnlyFailure(error) {
+  const name = error?.name ?? '';
+  const message = error?.message ?? '';
+  return error?.code === 'USB_READ_ONLY' ||
+    name === 'NoModificationAllowedError' ||
+    name === 'NotAllowedError' ||
+    /read-only|readonly|EROFS|not permitted/i.test(message);
 }
 
 async function removeDevice(route) {

--- a/src/modules/usb/install.js
+++ b/src/modules/usb/install.js
@@ -36,17 +36,31 @@ const original = {};
  * @return {Promise<Any>} undefined if the file does not exist yet
  */
 async function readDevice(route) {
-  await state.assertUsable();
+  // A read must never throw because the device is missing.
+  //
+  // keyring.init() treats a failing keystore load as a broken keyring and deletes
+  // it from the attribute map, so an unplugged device at startup would deregister
+  // the keyring entirely -- recoverable for the main keyring, permanent for
+  // client-API keyrings, whose keys would be stranded on the device. Degrade to
+  // "empty" instead. Writes still fail closed, so nothing can be destroyed by
+  // reading empty and storing it back.
+  if (!state.isUsable()) {
+    await state.probe();
+    if (!state.isUsable()) {
+      return undefined;
+    }
+  }
   try {
     const content = await state.getBackend().readFile(route.path);
     return router.deserialize(content, route.format);
   } catch (e) {
-    if (e instanceof NotFoundError) {
-      // Nothing written yet: indistinguishable from an empty store, which is what
-      // KeyStoreLocal expects for a fresh keyring.
-      return undefined;
+    if (!(e instanceof NotFoundError)) {
+      // Not merely absent data: log it, but still degrade rather than take the
+      // destructive path above. The state machine reports ERROR to the user
+      // independently, so the failure is not hidden from them.
+      console.log('USB keystore: read failed', route.path, e);
     }
-    throw e;
+    return undefined;
   }
 }
 

--- a/src/modules/usb/install.js
+++ b/src/modules/usb/install.js
@@ -1,0 +1,239 @@
+/**
+ * Copyright (C) 2026 Noam Rathaus
+ * Licensed under the GNU Affero General Public License version 3
+ *
+ * Installs the USB keystore by wrapping mvelo.storage.
+ *
+ * Every crypto persistence path in Mailvelope funnels through
+ * mvelo.storage.{get,set,remove}: armored keys via KeyStoreLocal, key metadata via
+ * KeyringAttrMap, Autocrypt records via autocryptWrapper.Store. Wrapping those three
+ * functions here routes crypto material to the USB device and lets everything else
+ * pass through to chrome.storage.local — so KeyStoreLocal, KeyringAttrMap and
+ * autocryptWrapper.Store keep working unmodified.
+ *
+ * The redirection is therefore invisible at those call sites, which is a deliberate
+ * trade: this branch tracks upstream master, and an additive hook in one file
+ * rebases where edits scattered across the keyring layer would conflict. It also
+ * puts the "nothing stored outside the device" rule in a single auditable place
+ * instead of re-implementing it per call site. See doc/usb-keystore-plan.md §4.
+ */
+
+import mvelo from '../../lib/lib-mvelo';
+import {USB_STATE} from './constants';
+import * as state from './state';
+import * as router from './router';
+import {NotFoundError} from './backend';
+import {MvError} from '../../lib/util';
+import {getAll as getAllKeyrings} from '../keyring';
+import {clear as clearPwdCache} from '../pwdCache';
+
+let installed = false;
+const original = {};
+
+/**
+ * Read a device-backed value.
+ * @param {Object} route - result of router.classify()
+ * @return {Promise<Any>} undefined if the file does not exist yet
+ */
+async function readDevice(route) {
+  await state.assertUsable();
+  try {
+    const content = await state.getBackend().readFile(route.path);
+    return router.deserialize(content, route.format);
+  } catch (e) {
+    if (e instanceof NotFoundError) {
+      // Nothing written yet: indistinguishable from an empty store, which is what
+      // KeyStoreLocal expects for a fresh keyring.
+      return undefined;
+    }
+    throw e;
+  }
+}
+
+async function writeDevice(route, value) {
+  // Reprobe before writing: a stale READY reading would otherwise let a write be
+  // attempted against a device that has just been pulled.
+  await state.assertUsable(true);
+  await state.getBackend().writeFile(route.path, router.serialize(value, route.format));
+}
+
+async function removeDevice(route) {
+  await state.assertUsable();
+  await state.getBackend().removeFile(route.path);
+}
+
+async function wrappedGet(id) {
+  if (!state.isEnabled()) {
+    return original.get(id);
+  }
+  const route = router.classify(id);
+  if (route.target === router.TARGET.DEVICE) {
+    return readDevice(route);
+  }
+  if (route.target === router.TARGET.SPLIT) {
+    const local = await original.get(id);
+    if (!state.isUsable()) {
+      // Without the device the keyring registry is still readable, so the keyring
+      // subsystem can initialise; the crypto attributes simply appear unset.
+      return local;
+    }
+    let device;
+    try {
+      device = await readDevice(route);
+    } catch (e) {
+      console.log('USB keystore: reading keyring attributes failed', e);
+      return local;
+    }
+    return router.mergeAttributes(local, device);
+  }
+  return original.get(id);
+}
+
+async function wrappedSet(id, value) {
+  if (!state.isEnabled()) {
+    return original.set(id, value);
+  }
+  const route = router.classify(id);
+  if (route.target === router.TARGET.DEVICE) {
+    return writeDevice(route, value);
+  }
+  if (route.target === router.TARGET.SPLIT) {
+    const {device, local} = router.splitAttributes(value);
+    await original.set(id, local);
+    // Only touch the device when there is crypto metadata to store. This is what
+    // lets a fresh profile create its main keyring with no device attached.
+    if (Object.keys(device).length) {
+      await writeDevice(route, device);
+    }
+    return;
+  }
+  // Unknown storage key. Pass it through, but refuse to let key material reach
+  // local storage under a key this router does not recognise — the safety net for
+  // an upstream change that adds a new crypto storage key.
+  if (!router.isAllowedLocal(id) && router.containsKeyMaterial(value)) {
+    throw new MvError(
+      `Refusing to write OpenPGP key material to local storage under '${id}' while a USB keystore is active`,
+      'USB_KEYSTORE_LEAK_BLOCKED'
+    );
+  }
+  return original.set(id, value);
+}
+
+async function wrappedRemove(id) {
+  if (!state.isEnabled()) {
+    return original.remove(id);
+  }
+  const route = router.classify(id);
+  if (route.target === router.TARGET.DEVICE) {
+    return removeDevice(route);
+  }
+  if (route.target === router.TARGET.SPLIT) {
+    await original.remove(id);
+    if (state.isUsable()) {
+      await removeDevice(route);
+    }
+    return;
+  }
+  return original.remove(id);
+}
+
+/**
+ * Badge arbitration.
+ *
+ * uiLog already owns the toolbar badge: it shows a green 'Ok' on user interaction
+ * and clears it unconditionally two seconds later, which would wipe a USB warning.
+ * Wrapping mvelo.action.state keeps that logic in uiLog untouched — a request to
+ * clear the badge restores the USB warning instead of blanking it.
+ */
+function usbBadge() {
+  if (!state.isEnabled() || state.isUsable()) {
+    return null;
+  }
+  return {badge: '!', badgeColor: '#d32f2f'};
+}
+
+function wrappedActionState(options = {}) {
+  const warning = usbBadge();
+  if (warning && options.badge === '') {
+    return original.actionState(warning);
+  }
+  return original.actionState(options);
+}
+
+function refreshBadge() {
+  const warning = usbBadge();
+  original.actionState(warning || {badge: ''});
+}
+
+/**
+ * Clear every trace of key material from memory when the device goes away.
+ *
+ * Raced against a timeout because keyring.getAll() waits on keyring initialisation:
+ * if the device disappears before that finishes, awaiting it here would hang and
+ * keep this task alive indefinitely.
+ */
+async function purgeInMemoryKeyMaterial() {
+  try {
+    clearPwdCache();
+  } catch (e) {
+    console.log('USB keystore: clearing password cache failed', e);
+  }
+  try {
+    const keyrings = await Promise.race([
+      getAllKeyrings(),
+      new Promise(resolve => setTimeout(() => resolve(null), 2000))
+    ]);
+    if (!keyrings) {
+      // Keyring subsystem not initialised yet, so it holds no key material anyway.
+      return;
+    }
+    for (const keyring of keyrings) {
+      keyring.keystore.clear();
+    }
+  } catch (e) {
+    console.log('USB keystore: clearing in-memory keyrings failed', e);
+  }
+}
+
+function onStateChange(next, previous) {
+  refreshBadge();
+  if (next !== USB_STATE.READY && previous === USB_STATE.READY) {
+    purgeInMemoryKeyMaterial();
+  }
+}
+
+/**
+ * Install the USB keystore hooks and start monitoring the device.
+ * Idempotent. Must run before the keyring subsystem is initialised.
+ * @return {Promise<Object>} the initial status
+ */
+export async function installUsbKeystore() {
+  if (installed) {
+    return state.getStatus();
+  }
+  installed = true;
+  original.get = mvelo.storage.get.bind(mvelo.storage);
+  original.set = mvelo.storage.set.bind(mvelo.storage);
+  original.remove = mvelo.storage.remove.bind(mvelo.storage);
+  original.actionState = mvelo.action.state.bind(mvelo.action);
+  mvelo.storage.get = wrappedGet;
+  mvelo.storage.set = wrappedSet;
+  mvelo.storage.remove = wrappedRemove;
+  mvelo.action.state = wrappedActionState;
+  state.addStateListener(onStateChange);
+  const status = await state.init();
+  refreshBadge();
+  return status;
+}
+
+/** Test seam: undo the hooks. */
+export function uninstallUsbKeystore() {
+  if (!installed) {
+    return;
+  }
+  mvelo.storage.get = original.get;
+  mvelo.storage.set = original.set;
+  mvelo.storage.remove = original.remove;
+  mvelo.action.state = original.actionState;
+  installed = false;
+}

--- a/src/modules/usb/install.js
+++ b/src/modules/usb/install.js
@@ -250,6 +250,10 @@ async function reloadKeyringsFromDevice() {
       keyring.keystore.clear();
       await keyring.keystore.load();
     }
+    // Tell the views the keys are actually available now. The READY broadcast went
+    // out before this finished, so anything that refreshed on it saw an empty
+    // keyring and reported no keys.
+    state.republish();
   } catch (e) {
     console.log('USB keystore: reloading keyrings failed', e);
   }

--- a/src/modules/usb/provision.js
+++ b/src/modules/usb/provision.js
@@ -237,11 +237,24 @@ export async function provision({label, adopt: adoptArg} = {}) {
       // Guidance is not worth failing provisioning over.
       console.log('USB keystore: could not write README', e);
     }
-    await state.setConfig({keystoreId: created.keystoreId, label: created.label, provisioned: created.created});
+    // Merge, do not replace: devicePath is set separately by selectDevice() on the
+    // native path, and dropping it leaves the backend with no root -- which reports
+    // as "no keystore configured" even though one plainly is.
+    await state.setConfig({
+      ...(existing ?? {}),
+      keystoreId: created.keystoreId,
+      label: created.label,
+      provisioned: created.created
+    });
     await state.reload();
     return state.getStatus();
   }
-  await state.setConfig({keystoreId: marker.keystoreId, label: marker.label, provisioned: marker.created});
+  await state.setConfig({
+    ...(existing ?? {}),
+    keystoreId: marker.keystoreId,
+    label: marker.label,
+    provisioned: marker.created
+  });
   await state.reload();
   return state.getStatus();
 }

--- a/src/modules/usb/provision.js
+++ b/src/modules/usb/provision.js
@@ -15,6 +15,7 @@ import {
   DEVICE_ROOT, MARKER_FILE, README_FILE, KEYRINGS_DIR, KEYSTORE_VERSION, USB_STATE
 } from './constants';
 import * as state from './state';
+import {usesNativeHost} from './state';
 import * as router from './router';
 import * as handleStore from './handleStore';
 import {NotFoundError} from './backend';
@@ -136,6 +137,40 @@ export async function regrantPermission() {
   }
   const permission = await handle.requestPermission({mode: 'readwrite'});
   return {granted: permission === 'granted', name: handle.name};
+}
+
+/**
+ * Removable devices the native host can see.
+ *
+ * Only meaningful on the native path: Firefox has no directory picker, so the user
+ * chooses from a list of mounted devices instead of a file dialog.
+ * @return {Promise<Array<{path: String, label: String, writable: Boolean}>>}
+ */
+export async function listDevices() {
+  const backend = state.getBackend();
+  if (!backend?.listDevices) {
+    return [];
+  }
+  return backend.listDevices();
+}
+
+/**
+ * Select a device by path, for the native host path.
+ *
+ * The File System Access backend gets its location from a stored handle produced by
+ * the picker; here the path itself is the configuration, so it is recorded before
+ * provisioning can look at the device.
+ * @param {String} devicePath - as reported by listDevices()
+ * @return {Promise<Object>} status after selection
+ */
+export async function selectDevice(devicePath) {
+  if (!usesNativeHost()) {
+    throw new MvError('Selecting a device by path requires the native helper', 'USB_NOT_NATIVE');
+  }
+  const config = await state.getConfig();
+  await state.setConfig({...(config ?? {}), devicePath});
+  await state.reload();
+  return state.getStatus();
 }
 
 /**

--- a/src/modules/usb/provision.js
+++ b/src/modules/usb/provision.js
@@ -400,10 +400,41 @@ export async function reprobe() {
 }
 
 /**
+ * Count the armored keys in one file on the device.
+ * @param {UsbBackend} backend
+ * @param {String} path
+ * @return {Promise<Number>} 0 for a file that is not there
+ */
+async function countKeysOnDevice(backend, path) {
+  try {
+    return router.deserialize(await backend.readFile(path), 'asc').length;
+  } catch (e) {
+    if (e instanceof NotFoundError) {
+      return 0;
+    }
+    throw e;
+  }
+}
+
+/**
  * Diagnostics for the settings page: what is on the device right now.
+ *
+ * Reports the keys on the device alongside the keys the extension actually loaded,
+ * because the gap between those two numbers is the failure this feature is most
+ * exposed to and the hardest to notice. A read that returns part of a file leaves a
+ * keyring that looks ordinary -- just shorter -- and nothing else in the UI can tell
+ * you that 132 of 412 keys arrived.
+ *
+ * It costs a full read of the key files, so it is not something to run on a timer;
+ * the settings page asks for it when the device state changes.
+ *
+ * The loaded counts are passed in rather than read here: this module is imported by
+ * the settings page for the directory picker, and importing the keyring would drag
+ * the whole crypto stack into the app bundle with it.
+ * @param {Object} [loaded] - keys held in memory, keyed by encoded keyring directory
  * @return {Promise<Object>}
  */
-export async function diagnostics() {
+export async function diagnostics({loaded = {}} = {}) {
   const status = state.getStatus();
   const config = await state.getConfig();
   const result = {...status, label: config?.label ?? null, provisioned: config?.provisioned ?? null, keyrings: []};
@@ -416,8 +447,17 @@ export async function diagnostics() {
       if (!/^[0-9a-f]+$/.test(dir)) {
         continue;
       }
-      const files = await backend.listDir(`${DEVICE_ROOT}/${KEYRINGS_DIR}/${dir}`);
-      result.keyrings.push({dir, files});
+      const base = `${DEVICE_ROOT}/${KEYRINGS_DIR}/${dir}`;
+      const files = await backend.listDir(base);
+      result.keyrings.push({
+        dir,
+        files,
+        onDevice: {
+          publicKeys: await countKeysOnDevice(backend, `${base}/public.asc`),
+          privateKeys: await countKeysOnDevice(backend, `${base}/private.asc`)
+        },
+        loaded: loaded[dir] ?? null
+      });
     }
   } catch (e) {
     result.detail = e.message;

--- a/src/modules/usb/provision.js
+++ b/src/modules/usb/provision.js
@@ -10,9 +10,9 @@
  * where the backend lives.
  */
 
-import {getUUID} from '../../lib/util';
+import {getUUID, MvError} from '../../lib/util';
 import {
-  DEVICE_ROOT, MARKER_FILE, KEYRINGS_DIR, KEYSTORE_VERSION, USB_STATE
+  DEVICE_ROOT, MARKER_FILE, README_FILE, KEYRINGS_DIR, KEYSTORE_VERSION, USB_STATE
 } from './constants';
 import * as state from './state';
 import * as router from './router';
@@ -49,35 +49,162 @@ export async function pickDirectory() {
 }
 
 /**
+ * Explanation left on the device itself.
+ *
+ * This keystore is intended to be the only copy of its private keys, so whoever
+ * finds this folder may be doing so precisely because Mailvelope is unavailable —
+ * a new machine, a broken extension, no browser at all. The instructions for
+ * getting the keys out by hand therefore belong on the device, not only in the
+ * extension's UI.
+ * @return {String}
+ */
+function readmeText() {
+  return [
+    'Mailvelope USB keystore',
+    '=======================',
+    '',
+    'This folder holds the OpenPGP keys for a Mailvelope installation. It is',
+    'deliberately the only copy: nothing is stored on the computer.',
+    '',
+    'Layout',
+    '------',
+    '  keystore.json          identifies this keystore. Do not delete it.',
+    '  keyrings/<id>/         one folder per keyring',
+    '    private.asc          private keys, armored',
+    '    public.asc           public keys, armored',
+    '    attributes.json      which key is the default, and similar settings',
+    '    *.bak                previous version of a file, kept in case a save',
+    '                         was interrupted',
+    '',
+    'Recovering the keys without Mailvelope',
+    '--------------------------------------',
+    'The .asc files are ordinary armored OpenPGP keys, so any OpenPGP tool can',
+    'read them:',
+    '',
+    '  gpg --import keyrings/*/private.asc',
+    '',
+    'The private keys are protected by the passphrase set when they were created.',
+    'That passphrase is the only thing protecting them if this device is lost or',
+    'stolen -- there is no other copy and no way to reset it.',
+    '',
+    'Reconnecting in Mailvelope',
+    '--------------------------',
+    'In Mailvelope, open Settings -> Key Storage and select the folder that',
+    'CONTAINS this one (usually the root of the device), not this folder itself.',
+    ''
+  ].join('\n');
+}
+
+/**
+ * Read and parse a marker file, or undefined if it is absent or unreadable.
+ * @param {UsbBackend} backend
+ * @param {String} path
+ * @return {Promise<Object|undefined>}
+ */
+async function readMarker(backend, path) {
+  try {
+    const marker = JSON.parse(await backend.readFile(path));
+    return marker?.keystoreId ? marker : undefined;
+  } catch (e) {
+    if (e instanceof NotFoundError) {
+      return undefined;
+    }
+    // A corrupt or unreadable marker is not a usable keystore identity either.
+    return undefined;
+  }
+}
+
+/**
+ * Re-grant access to the directory already stored for this profile.
+ *
+ * A permission grant does not survive an extension reload, and in all likelihood
+ * not a browser restart either, so this is a routine action rather than an edge
+ * case. Re-prompting for the stored handle asks the user to approve one dialog;
+ * calling showDirectoryPicker() again would make them navigate to the directory
+ * from scratch every session. App page only: requestPermission needs a user
+ * gesture.
+ * @return {Promise<{granted: Boolean, name: String|undefined}>}
+ */
+export async function regrantPermission() {
+  const handle = await handleStore.get();
+  if (!handle) {
+    // Nothing stored to re-grant; the caller falls back to a full pick.
+    return {granted: false, name: undefined};
+  }
+  if (await handle.queryPermission({mode: 'readwrite'}) === 'granted') {
+    return {granted: true, name: handle.name};
+  }
+  const permission = await handle.requestPermission({mode: 'readwrite'});
+  return {granted: permission === 'granted', name: handle.name};
+}
+
+/**
  * Create the keystore on the device and record it as this profile's keystore.
  * Reuses an existing marker file if the device already holds one, so a device set
  * up on another machine can simply be adopted.
  * @param {String} [label] - human-readable label stored in the marker file
  * @return {Promise<Object>} status after provisioning
  */
-export async function provision({label} = {}) {
+export async function provision({label, adopt: adoptArg} = {}) {
+  // Strict coercion: this arrives over a port from a view, and only an explicit
+  // true counts as consent to switch keystore. Anything else -- a stray object, a
+  // truthy string -- must not bypass the identity check below.
+  const adopt = adoptArg === true;
   const backend = state.getBackend();
   if (!backend) {
     throw new Error('No USB keystore backend available in this browser');
   }
   backend.clearCache?.();
+
+  // Reject the keystore directory itself. Picking it would nest a second keystore
+  // inside the first, and it is the natural thing to choose when reconnecting
+  // because it is the folder the user can actually see.
+  if (await readMarker(backend, MARKER_FILE)) {
+    throw new MvError(
+      `The selected folder is already a Mailvelope keystore. Select the folder that contains '${DEVICE_ROOT}' instead, such as the root of the device.`,
+      'USB_KEYSTORE_NESTED_PICK'
+    );
+  }
+
   const markerPath = `${DEVICE_ROOT}/${MARKER_FILE}`;
-  let marker;
-  try {
-    marker = JSON.parse(await backend.readFile(markerPath));
-  } catch (e) {
-    if (!(e instanceof NotFoundError)) {
-      throw e;
+  const marker = await readMarker(backend, markerPath);
+  const existing = await state.getConfig();
+
+  // Never repoint a configured profile at a different keystore without being told
+  // to. Doing so silently would leave the user looking at an empty keyring while
+  // their keys sat on the previous device.
+  if (existing?.keystoreId && !adopt) {
+    if (!marker?.keystoreId) {
+      throw new MvError(
+        'This folder holds no Mailvelope keystore. Select the device this profile was set up with, or choose to switch to this folder instead.',
+        'USB_KEYSTORE_NOT_CONFIGURED_DEVICE'
+      );
+    }
+    if (marker.keystoreId !== existing.keystoreId) {
+      throw new MvError(
+        'This is a different Mailvelope keystore from the one this profile uses. Switching to it will leave the keys on the previous device inaccessible from here.',
+        'USB_KEYSTORE_DIFFERENT_DEVICE'
+      );
     }
   }
+
   if (!marker?.keystoreId) {
-    marker = {
+    const created = {
       version: KEYSTORE_VERSION,
       keystoreId: getUUID(),
       created: new Date().toISOString(),
       label: label || 'Mailvelope USB keystore'
     };
-    await backend.writeFile(markerPath, JSON.stringify(marker, null, 2));
+    await backend.writeFile(markerPath, JSON.stringify(created, null, 2));
+    try {
+      await backend.writeFile(`${DEVICE_ROOT}/${README_FILE}`, readmeText());
+    } catch (e) {
+      // Guidance is not worth failing provisioning over.
+      console.log('USB keystore: could not write README', e);
+    }
+    await state.setConfig({keystoreId: created.keystoreId, label: created.label, provisioned: created.created});
+    await state.reload();
+    return state.getStatus();
   }
   await state.setConfig({keystoreId: marker.keystoreId, label: marker.label, provisioned: marker.created});
   await state.reload();

--- a/src/modules/usb/provision.js
+++ b/src/modules/usb/provision.js
@@ -314,13 +314,24 @@ export async function migrateLocalKeyMaterial() {
   const all = await readLocalStorage();
   const moved = [];
   const failed = [];
+  let addedTotal = 0;
   for (const [key, value] of Object.entries(all)) {
     const route = router.classify(key);
     if (route.target !== router.TARGET.DEVICE) {
       continue;
     }
     try {
-      const serialized = router.serialize(value, route.format);
+      // Merge with whatever the device already holds. Writing the local value
+      // straight over the path destroyed an existing keystore's keys, recoverable
+      // only from the .bak the atomic write happens to leave behind.
+      let onDevice;
+      try {
+        onDevice = router.deserialize(await backend.readFile(route.path), route.format);
+      } catch (e) {
+        onDevice = undefined; // nothing there yet
+      }
+      const {value: combined, added} = router.mergeForDevice(onDevice, value, route.format);
+      const serialized = router.serialize(combined, route.format);
       await backend.writeFile(route.path, serialized);
       const readBack = await backend.readFile(route.path);
       if (readBack !== serialized) {
@@ -328,6 +339,7 @@ export async function migrateLocalKeyMaterial() {
       }
       await chrome.storage.local.remove(key);
       moved.push(key);
+      addedTotal += added;
     } catch (e) {
       failed.push({key, error: e.message});
     }
@@ -341,7 +353,16 @@ export async function migrateLocalKeyMaterial() {
       const {device, local} = router.splitAttributes(attributes);
       if (Object.keys(device).length) {
         const route = router.classify(router.KEYRING_ATTRIBUTES_KEY);
-        const serialized = router.serialize(device, route.format);
+        let onDevice;
+        try {
+          onDevice = router.deserialize(await backend.readFile(route.path), route.format);
+        } catch (e) {
+          onDevice = undefined;
+        }
+        // Device wins on conflict, so migrating does not repoint an existing
+        // keystore's default key at a key that has just arrived.
+        const {value: combined} = router.mergeForDevice(onDevice, device, route.format);
+        const serialized = router.serialize(combined, route.format);
         await backend.writeFile(route.path, serialized);
         if (await backend.readFile(route.path) !== serialized) {
           throw new Error('verification after write failed');
@@ -353,7 +374,7 @@ export async function migrateLocalKeyMaterial() {
       failed.push({key: router.KEYRING_ATTRIBUTES_KEY, error: e.message});
     }
   }
-  return {moved, failed};
+  return {moved, failed, added: addedTotal};
 }
 
 /**

--- a/src/modules/usb/provision.js
+++ b/src/modules/usb/provision.js
@@ -1,0 +1,230 @@
+/**
+ * Copyright (C) 2026 Noam Rathaus
+ * Licensed under the GNU Affero General Public License version 3
+ *
+ * Setting up, migrating to, and tearing down a USB keystore.
+ *
+ * Split across two contexts by necessity: showDirectoryPicker() and
+ * requestPermission() need a document and a user gesture, so pickDirectory() runs
+ * in the app page. Everything that touches the device runs in the background,
+ * where the backend lives.
+ */
+
+import {getUUID} from '../../lib/util';
+import {
+  DEVICE_ROOT, MARKER_FILE, KEYRINGS_DIR, KEYSTORE_VERSION, USB_STATE
+} from './constants';
+import * as state from './state';
+import * as router from './router';
+import * as handleStore from './handleStore';
+import {NotFoundError} from './backend';
+
+/**
+ * Whether this context can open a directory picker. False in the service worker
+ * and in Firefox, which has no File System Access picker at all.
+ * @return {Boolean}
+ */
+export function isPickerAvailable() {
+  return typeof self !== 'undefined' && typeof self.showDirectoryPicker === 'function';
+}
+
+/**
+ * Ask the user for the keystore directory and persist the handle. App page only.
+ * @return {Promise<{name: String}>} the chosen directory's name
+ */
+export async function pickDirectory() {
+  if (!isPickerAvailable()) {
+    throw new Error('Directory picker is not available in this browser');
+  }
+  // 'readwrite' asks for write access up front, so no second prompt is needed on
+  // the first save. 'documents' is a neutral starting point; removable volumes are
+  // reachable from the picker regardless.
+  const handle = await self.showDirectoryPicker({mode: 'readwrite', id: 'mvelo-usb-keystore'});
+  const permission = await handle.requestPermission({mode: 'readwrite'});
+  if (permission !== 'granted') {
+    throw new Error('Write permission for the keystore directory was not granted');
+  }
+  await handleStore.put(handle);
+  return {name: handle.name};
+}
+
+/**
+ * Create the keystore on the device and record it as this profile's keystore.
+ * Reuses an existing marker file if the device already holds one, so a device set
+ * up on another machine can simply be adopted.
+ * @param {String} [label] - human-readable label stored in the marker file
+ * @return {Promise<Object>} status after provisioning
+ */
+export async function provision({label} = {}) {
+  const backend = state.getBackend();
+  if (!backend) {
+    throw new Error('No USB keystore backend available in this browser');
+  }
+  backend.clearCache?.();
+  const markerPath = `${DEVICE_ROOT}/${MARKER_FILE}`;
+  let marker;
+  try {
+    marker = JSON.parse(await backend.readFile(markerPath));
+  } catch (e) {
+    if (!(e instanceof NotFoundError)) {
+      throw e;
+    }
+  }
+  if (!marker?.keystoreId) {
+    marker = {
+      version: KEYSTORE_VERSION,
+      keystoreId: getUUID(),
+      created: new Date().toISOString(),
+      label: label || 'Mailvelope USB keystore'
+    };
+    await backend.writeFile(markerPath, JSON.stringify(marker, null, 2));
+  }
+  await state.setConfig({keystoreId: marker.keystoreId, label: marker.label, provisioned: marker.created});
+  await state.reload();
+  return state.getStatus();
+}
+
+/**
+ * Every local storage key that holds crypto material, read straight from
+ * chrome.storage.local.
+ *
+ * Deliberately bypasses mvelo.storage: by the time migration runs the wrapper is
+ * active, so a wrapped read would look on the device for values that are still
+ * only local.
+ * @return {Promise<Object>} raw storage contents
+ */
+async function readLocalStorage() {
+  return chrome.storage.local.get(null);
+}
+
+/**
+ * Report what a migration would move, without changing anything.
+ * @return {Promise<{keyrings: Array<String>, publicKeys: Number, privateKeys: Number, autocrypt: Number}>}
+ */
+export async function inspectLocalKeyMaterial() {
+  const all = await readLocalStorage();
+  const summary = {keyrings: new Set(), publicKeys: 0, privateKeys: 0, autocrypt: 0};
+  for (const [key, value] of Object.entries(all)) {
+    const route = router.classify(key);
+    if (route.target !== router.TARGET.DEVICE) {
+      continue;
+    }
+    summary.keyrings.add(route.keyringId);
+    if (key.endsWith('.privateKeys')) {
+      summary.privateKeys += (value || []).length;
+    } else if (key.endsWith('.publicKeys')) {
+      summary.publicKeys += (value || []).length;
+    } else {
+      summary.autocrypt += Object.keys(value || {}).length;
+    }
+  }
+  return {...summary, keyrings: Array.from(summary.keyrings)};
+}
+
+/**
+ * Move all locally stored crypto material onto the device, then delete the local
+ * copies.
+ *
+ * Each value is written, read back and compared before its local copy is removed,
+ * so an interrupted migration never loses key material. Note that deleting from
+ * chrome.storage.local does not erase the bytes from disk — LevelDB appends a
+ * tombstone rather than overwriting — so a migrated key may stay recoverable from
+ * the browser profile until compaction. Generating a fresh key onto the device is
+ * the only path that avoids this entirely; see doc/usb-keystore-plan.md §3.1.
+ * @return {Promise<{moved: Array<String>, failed: Array<{key: String, error: String}>}>}
+ */
+export async function migrateLocalKeyMaterial() {
+  await state.assertUsable(true);
+  const backend = state.getBackend();
+  const all = await readLocalStorage();
+  const moved = [];
+  const failed = [];
+  for (const [key, value] of Object.entries(all)) {
+    const route = router.classify(key);
+    if (route.target !== router.TARGET.DEVICE) {
+      continue;
+    }
+    try {
+      const serialized = router.serialize(value, route.format);
+      await backend.writeFile(route.path, serialized);
+      const readBack = await backend.readFile(route.path);
+      if (readBack !== serialized) {
+        throw new Error('verification after write failed');
+      }
+      await chrome.storage.local.remove(key);
+      moved.push(key);
+    } catch (e) {
+      failed.push({key, error: e.message});
+    }
+  }
+  // The keyring attribute map is split rather than moved: crypto fields go to the
+  // device, the keyring registry stays local so the keyring subsystem can still
+  // initialise without the device attached.
+  const attributes = all[router.KEYRING_ATTRIBUTES_KEY];
+  if (attributes) {
+    try {
+      const {device, local} = router.splitAttributes(attributes);
+      if (Object.keys(device).length) {
+        const route = router.classify(router.KEYRING_ATTRIBUTES_KEY);
+        const serialized = router.serialize(device, route.format);
+        await backend.writeFile(route.path, serialized);
+        if (await backend.readFile(route.path) !== serialized) {
+          throw new Error('verification after write failed');
+        }
+      }
+      await chrome.storage.local.set({[router.KEYRING_ATTRIBUTES_KEY]: local});
+      moved.push(router.KEYRING_ATTRIBUTES_KEY);
+    } catch (e) {
+      failed.push({key: router.KEYRING_ATTRIBUTES_KEY, error: e.message});
+    }
+  }
+  return {moved, failed};
+}
+
+/**
+ * Stop using the USB keystore. Key material on the device is left untouched; only
+ * this profile's reference to it is dropped, so the extension returns to local
+ * storage with no keys.
+ * @return {Promise<Object>} status after teardown
+ */
+export async function disable() {
+  await state.clearConfig();
+  await handleStore.remove();
+  await state.reload();
+  return state.getStatus();
+}
+
+/**
+ * Re-check the device after the user has re-granted permission in the app page.
+ * @return {Promise<Object>}
+ */
+export async function reprobe() {
+  await state.reload();
+  return state.getStatus();
+}
+
+/**
+ * Diagnostics for the settings page: what is on the device right now.
+ * @return {Promise<Object>}
+ */
+export async function diagnostics() {
+  const status = state.getStatus();
+  const config = await state.getConfig();
+  const result = {...status, label: config?.label ?? null, provisioned: config?.provisioned ?? null, keyrings: []};
+  if (status.state !== USB_STATE.READY) {
+    return result;
+  }
+  const backend = state.getBackend();
+  try {
+    for (const dir of await backend.listDir(`${DEVICE_ROOT}/${KEYRINGS_DIR}`)) {
+      if (!/^[0-9a-f]+$/.test(dir)) {
+        continue;
+      }
+      const files = await backend.listDir(`${DEVICE_ROOT}/${KEYRINGS_DIR}/${dir}`);
+      result.keyrings.push({dir, files});
+    }
+  } catch (e) {
+    result.detail = e.message;
+  }
+  return result;
+}

--- a/src/modules/usb/router.js
+++ b/src/modules/usb/router.js
@@ -43,7 +43,11 @@ const CRYPTO_ATTR_FIELDS = ['default_key', 'primary_key', 'sync_data', 'key_bind
 const LOCAL_ALLOWLIST = [
   'mvelo.preferences',
   'mvelo.watchlist',
-  USB_CONFIG_KEY
+  USB_CONFIG_KEY,
+  // Diagnostics, off by default, and by policy free of key material. Allowlisted so
+  // the leak safety net does not have to guess about them.
+  'mvelo.usb.debug',
+  'mvelo.usb.debugEnabled'
 ];
 const LOCAL_ALLOWLIST_PREFIXES = ['mvelo.oauth.'];
 

--- a/src/modules/usb/router.js
+++ b/src/modules/usb/router.js
@@ -211,6 +211,58 @@ export function serialize(value, format) {
 }
 
 /**
+ * Combine a value already on the device with one being migrated into it.
+ *
+ * Migration used to write the local value straight over the device path, so moving
+ * keys onto a device that already held a keystore destroyed what was there. Only
+ * the atomic-write .bak rotation made that recoverable, which is not a guarantee to
+ * rely on.
+ *
+ * Existing device content always wins a conflict: migration is additive by
+ * definition, and a device's own keystore is not the thing being moved.
+ * @param {Any} existing - value already on the device, or undefined
+ * @param {Any} incoming - value being migrated in
+ * @param {String} format - 'asc' or 'json'
+ * @return {{value: Any, added: Number}} merged value, and how much was new
+ */
+export function mergeForDevice(existing, incoming, format) {
+  if (existing === undefined || existing === null) {
+    const added = format === 'asc' ? (incoming ?? []).length : 1;
+    return {value: incoming, added};
+  }
+  if (format === 'asc') {
+    const blocks = [...(existing ?? [])];
+    let added = 0;
+    for (const block of incoming ?? []) {
+      // Exact-text comparison. Two different armorings of the same key would not
+      // dedupe, but openpgp reconciles duplicate fingerprints when the keyring
+      // loads, so the cost is a redundant block rather than a wrong keyring.
+      if (!blocks.includes(block)) {
+        blocks.push(block);
+        added += 1;
+      }
+    }
+    return {value: blocks, added};
+  }
+  if (typeof existing !== 'object' || typeof incoming !== 'object') {
+    return {value: existing, added: 0};
+  }
+  // Per-entry merge with the device winning, which keeps a device's own default_key
+  // and its own Autocrypt records intact.
+  const merged = {...existing};
+  let added = 0;
+  for (const [key, value] of Object.entries(incoming ?? {})) {
+    if (!(key in merged)) {
+      merged[key] = value;
+      added += 1;
+    } else if (value && typeof value === 'object' && typeof merged[key] === 'object') {
+      merged[key] = {...value, ...merged[key]};
+    }
+  }
+  return {value: merged, added};
+}
+
+/**
  * Parse a device file back into a storage value.
  * @param {String} content
  * @param {String} format - 'asc' or 'json'

--- a/src/modules/usb/router.js
+++ b/src/modules/usb/router.js
@@ -1,0 +1,227 @@
+/**
+ * Copyright (C) 2026 Noam Rathaus
+ * Licensed under the GNU Affero General Public License version 3
+ *
+ * Decides, for every chrome.storage.local key Mailvelope touches, whether the
+ * value is crypto material that belongs on the USB device or ordinary settings
+ * that stay local.
+ *
+ * This module is the single enforcement point for the requirement that no crypto
+ * information is stored anywhere but the device. Keeping that decision in one
+ * place means it cannot drift per call site, and an upstream commit that adds a
+ * new crypto storage key is caught here rather than silently writing to disk.
+ */
+
+import {DEVICE_ROOT, KEYRINGS_DIR, USB_CONFIG_KEY} from './constants';
+
+/** Storage key holding the keyring attribute map. Split; see below. */
+export const KEYRING_ATTRIBUTES_KEY = 'mvelo.keyring.attributes';
+
+/** Armored key arrays, one storage key per keyring and type. */
+const KEY_ARRAY_RE = /^mvelo\.keyring\.(.+)\.(publicKeys|privateKeys)$/;
+
+/** Autocrypt records: public keys harvested from message headers. */
+const AUTOCRYPT_RE = /^mvelo\.autocrypt\.(.+)$/;
+
+/**
+ * Attribute fields inside KEYRING_ATTRIBUTES_KEY that are crypto information and
+ * move to the device. Everything else in that map — notably the set of keyring
+ * IDs itself and the 'sanitized' flag — stays local.
+ *
+ * The split exists for a practical reason as well as a privacy one: keyring.init()
+ * reads this map at startup to learn which keyrings exist. Were the whole map on
+ * the device, starting the browser without it would leave the keyring subsystem
+ * unable to initialise at all, rather than merely without keys.
+ */
+const CRYPTO_ATTR_FIELDS = ['default_key', 'primary_key', 'sync_data', 'key_binding'];
+
+/**
+ * Storage keys known to hold no crypto material. Anything not matched by the
+ * crypto patterns and not on this list still passes through to local storage, but
+ * its value is screened for key material first (see containsKeyMaterial).
+ */
+const LOCAL_ALLOWLIST = [
+  'mvelo.preferences',
+  'mvelo.watchlist',
+  USB_CONFIG_KEY
+];
+const LOCAL_ALLOWLIST_PREFIXES = ['mvelo.oauth.'];
+
+/** Armor headers that identify OpenPGP key material in a serialized value. */
+const ARMOR_MARKERS = [
+  '-----BEGIN PGP PRIVATE KEY BLOCK-----',
+  '-----BEGIN PGP PUBLIC KEY BLOCK-----'
+];
+
+export const TARGET = {DEVICE: 'device', LOCAL: 'local', SPLIT: 'split'};
+
+/**
+ * Encode a keyring ID for use as a directory name.
+ *
+ * Hex rather than base64: keyring IDs contain '|' (KEYRING_DELIMITER is '|#|'),
+ * which is illegal on Windows/FAT/exFAT, and those filesystems are also
+ * case-insensitive — so a case-sensitive encoding such as base64 could map two
+ * distinct keyring IDs onto one directory. Hex is single-case and safe.
+ * @param {String} keyringId
+ * @return {String}
+ */
+export function encodeKeyringId(keyringId) {
+  return Array.from(new TextEncoder().encode(keyringId))
+  .map(byte => byte.toString(16).padStart(2, '0'))
+  .join('');
+}
+
+function keyringDir(keyringId) {
+  return `${DEVICE_ROOT}/${KEYRINGS_DIR}/${encodeKeyringId(keyringId)}`;
+}
+
+/**
+ * Classify a storage key.
+ * @param {String} storageKey
+ * @return {{target: String, path?: String, format?: String, keyringId?: String}}
+ *   format is 'asc' for concatenated armored keys, 'json' otherwise
+ */
+export function classify(storageKey) {
+  if (storageKey === KEYRING_ATTRIBUTES_KEY) {
+    return {
+      target: TARGET.SPLIT,
+      path: `${DEVICE_ROOT}/${KEYRINGS_DIR}/attributes.json`,
+      format: 'json'
+    };
+  }
+  const keyArray = KEY_ARRAY_RE.exec(storageKey);
+  if (keyArray) {
+    const [, keyringId, type] = keyArray;
+    const name = type === 'publicKeys' ? 'public.asc' : 'private.asc';
+    return {
+      target: TARGET.DEVICE,
+      path: `${keyringDir(keyringId)}/${name}`,
+      format: 'asc',
+      keyringId
+    };
+  }
+  const autocrypt = AUTOCRYPT_RE.exec(storageKey);
+  if (autocrypt) {
+    const [, keyringId] = autocrypt;
+    return {
+      target: TARGET.DEVICE,
+      path: `${keyringDir(keyringId)}/autocrypt.json`,
+      format: 'json',
+      keyringId
+    };
+  }
+  return {target: TARGET.LOCAL};
+}
+
+/**
+ * Is this storage key known to be free of crypto material?
+ * @param {String} storageKey
+ * @return {Boolean}
+ */
+export function isAllowedLocal(storageKey) {
+  return LOCAL_ALLOWLIST.includes(storageKey) ||
+    LOCAL_ALLOWLIST_PREFIXES.some(prefix => storageKey.startsWith(prefix));
+}
+
+/**
+ * Safety net for storage keys this module does not know about: refuse to let
+ * OpenPGP key material reach local storage even if it arrives under an
+ * unrecognised key. Cheap enough to run on every unknown write.
+ * @param {Any} value
+ * @return {Boolean}
+ */
+export function containsKeyMaterial(value) {
+  if (value === undefined || value === null) {
+    return false;
+  }
+  let serialized;
+  if (typeof value === 'string') {
+    serialized = value;
+  } else {
+    try {
+      serialized = JSON.stringify(value);
+    } catch (e) {
+      // Unserializable values cannot be armored key text.
+      return false;
+    }
+  }
+  return ARMOR_MARKERS.some(marker => serialized.includes(marker));
+}
+
+/**
+ * Split a keyring attribute map into the part that belongs on the device and the
+ * part that stays local.
+ * @param {Object} attributes - map of keyringId to attribute map
+ * @return {{device: Object, local: Object}}
+ */
+export function splitAttributes(attributes = {}) {
+  const device = {};
+  const local = {};
+  for (const [keyringId, attrs] of Object.entries(attributes || {})) {
+    const deviceAttrs = {};
+    const localAttrs = {};
+    for (const [field, value] of Object.entries(attrs || {})) {
+      if (CRYPTO_ATTR_FIELDS.includes(field)) {
+        deviceAttrs[field] = value;
+      } else {
+        localAttrs[field] = value;
+      }
+    }
+    // Always record the keyring in the local map, even with no local attributes:
+    // the set of keyring IDs is what lets keyring.init() work without the device.
+    local[keyringId] = localAttrs;
+    if (Object.keys(deviceAttrs).length) {
+      device[keyringId] = deviceAttrs;
+    }
+  }
+  return {device, local};
+}
+
+/**
+ * Recombine the two halves of a keyring attribute map.
+ * @param {Object} local
+ * @param {Object} device
+ * @return {Object}
+ */
+export function mergeAttributes(local = {}, device = {}) {
+  const merged = {};
+  for (const keyringId of new Set([...Object.keys(local || {}), ...Object.keys(device || {})])) {
+    merged[keyringId] = {...(local?.[keyringId] || {}), ...(device?.[keyringId] || {})};
+  }
+  return merged;
+}
+
+/**
+ * Serialize a storage value for the device.
+ * @param {Any} value
+ * @param {String} format - 'asc' or 'json'
+ * @return {String}
+ */
+export function serialize(value, format) {
+  if (format === 'asc') {
+    // The value is an array of armored keys. Concatenating them keeps the file
+    // importable with `gpg --import` straight off the device.
+    return (value || []).join('\n');
+  }
+  return JSON.stringify(value ?? null);
+}
+
+/**
+ * Parse a device file back into a storage value.
+ * @param {String} content
+ * @param {String} format - 'asc' or 'json'
+ * @return {Any}
+ */
+export function deserialize(content, format) {
+  if (format === 'asc') {
+    if (!content?.trim()) {
+      return [];
+    }
+    const blocks = content.match(/-----BEGIN PGP [^-]+-----[\s\S]*?-----END PGP [^-]+-----/g);
+    return blocks || [];
+  }
+  if (!content?.trim()) {
+    return undefined;
+  }
+  return JSON.parse(content);
+}

--- a/src/modules/usb/state.js
+++ b/src/modules/usb/state.js
@@ -190,6 +190,26 @@ async function computeState() {
 }
 
 /**
+ * Re-publish the current status without a state change.
+ *
+ * transition() notifies listeners synchronously, so anything it triggers that is
+ * asynchronous -- reloading the keyrings from the device, for one -- has not
+ * finished by the time a view reacts. The view then reads a keyring that is still
+ * empty and concludes there are no keys. This lets the slow work announce its own
+ * completion.
+ */
+export function republish() {
+  const status = getStatus();
+  for (const listener of listeners) {
+    try {
+      listener(state, state, status);
+    } catch (e) {
+      console.log('USB keystore state listener failed', e);
+    }
+  }
+}
+
+/**
  * Probe the device and publish any state change.
  * @return {Promise<String>} the current state
  */

--- a/src/modules/usb/state.js
+++ b/src/modules/usb/state.js
@@ -25,6 +25,8 @@ let backend = null;
 let state = USB_STATE.NOT_CONFIGURED;
 let detail = null;
 let enabled = false;
+let label = null;
+let keystoreId = null;
 const listeners = new Set();
 
 /**
@@ -50,7 +52,10 @@ export function getState() {
 }
 
 export function getStatus() {
-  return {state, detail, supported: Boolean(backend), enabled};
+  // label is the picked folder's name. Chrome does not expose a handle's full path,
+  // so this is the most specific location the UI can show -- enough to tell one
+  // configured device from another.
+  return {state, detail, supported: Boolean(backend), enabled, label, keystoreId};
 }
 
 export function isUsable() {
@@ -146,6 +151,8 @@ function transition(nextState, nextDetail = null) {
 async function computeState() {
   const config = await getConfig();
   enabled = Boolean(config?.keystoreId);
+  label = config?.label ?? null;
+  keystoreId = config?.keystoreId ?? null;
   // Not opting in takes precedence over an unsupported browser: an unconfigured
   // profile is simply upstream Mailvelope, and the setup UI reports separately
   // (via getStatus().supported) whether this browser could support the feature.

--- a/src/modules/usb/state.js
+++ b/src/modules/usb/state.js
@@ -20,6 +20,7 @@ import {
 } from './constants';
 import {NotFoundError, DeviceUnavailableError} from './backend';
 import FsaBackend from './FsaBackend';
+import NativeBackend from './NativeBackend';
 
 let backend = null;
 let state = USB_STATE.NOT_CONFIGURED;
@@ -28,6 +29,7 @@ let enabled = false;
 let label = null;
 let keystoreId = null;
 let checkedAt = null;
+let devicePath = null;
 const listeners = new Set();
 
 /**
@@ -38,10 +40,28 @@ const listeners = new Set();
  * @return {UsbBackend|null}
  */
 function selectBackend() {
+  // File System Access first where it exists: it needs no separate install, so it
+  // is the lower-friction path on Chromium. The native host is the only option in
+  // Firefox, and also a fallback for a Chromium build without the API.
   if (FsaBackend.isSupported()) {
     return new FsaBackend();
   }
+  if (NativeBackend.isSupported()) {
+    return new NativeBackend();
+  }
   return null;
+}
+
+/**
+ * Whether the active backend reaches the device through the native host.
+ *
+ * The two differ in ways the UI has to know about: the native path enumerates
+ * devices instead of opening a picker, has a real path to display, and has no
+ * per-session permission to re-grant.
+ * @return {Boolean}
+ */
+export function usesNativeHost() {
+  return backend instanceof NativeBackend;
 }
 
 export function getBackend() {
@@ -56,7 +76,11 @@ export function getStatus() {
   // label is the picked folder's name. Chrome does not expose a handle's full path,
   // so this is the most specific location the UI can show -- enough to tell one
   // configured device from another.
-  return {state, detail, supported: Boolean(backend), enabled, label, keystoreId, checkedAt};
+  return {
+    state, detail, supported: Boolean(backend), enabled, label, keystoreId, checkedAt,
+    native: usesNativeHost(),
+    devicePath
+  };
 }
 
 export function isUsable() {
@@ -154,6 +178,10 @@ async function computeState() {
   enabled = Boolean(config?.keystoreId);
   label = config?.label ?? null;
   keystoreId = config?.keystoreId ?? null;
+  // The File System Access backend recovers its location from the stored handle;
+  // the native host has no handle, so the path travels in the config.
+  devicePath = config?.devicePath ?? null;
+  backend?.setRoot?.(devicePath);
   // Not opting in takes precedence over an unsupported browser: an unconfigured
   // profile is simply upstream Mailvelope, and the setup UI reports separately
   // (via getStatus().supported) whether this browser could support the feature.

--- a/src/modules/usb/state.js
+++ b/src/modules/usb/state.js
@@ -1,0 +1,208 @@
+/**
+ * Copyright (C) 2026 Noam Rathaus
+ * Licensed under the GNU Affero General Public License version 3
+ *
+ * Availability state machine for the USB keystore.
+ *
+ * There is no filesystem "device removed" event, so presence is always established
+ * by actively reading the marker file: on a timer, and before every keystore
+ * operation. Resolving the directory handle alone is not enough — automounters
+ * differ in whether the mount point disappears on removal or is left behind as an
+ * empty directory, and only reading the marker covers both.
+ *
+ * Kept free of Mailvelope app imports so it can be unit tested in isolation and
+ * cannot form an import cycle. Consumers react through addStateListener().
+ */
+
+import {
+  USB_STATE, UNUSABLE_STATES, USB_CONFIG_KEY, DEVICE_ROOT, MARKER_FILE,
+  PROBE_ALARM, PROBE_PERIOD_MINUTES
+} from './constants';
+import {NotFoundError, DeviceUnavailableError} from './backend';
+import FsaBackend from './FsaBackend';
+
+let backend = null;
+let state = USB_STATE.NOT_CONFIGURED;
+let detail = null;
+let enabled = false;
+const listeners = new Set();
+
+/**
+ * Select a backend for this browser. Chromium gets the File System Access
+ * implementation; Firefox has no picker and will need the native messaging host,
+ * until which point the feature reports UNSUPPORTED rather than silently falling
+ * back to local storage.
+ * @return {UsbBackend|null}
+ */
+function selectBackend() {
+  if (FsaBackend.isSupported()) {
+    return new FsaBackend();
+  }
+  return null;
+}
+
+export function getBackend() {
+  return backend;
+}
+
+export function getState() {
+  return state;
+}
+
+export function getStatus() {
+  return {state, detail, supported: Boolean(backend), enabled};
+}
+
+export function isUsable() {
+  return state === USB_STATE.READY;
+}
+
+/**
+ * Whether a USB keystore has been set up for this profile.
+ *
+ * This gates the storage redirection: until the user opts in, Mailvelope must
+ * behave exactly as upstream and keep using local storage. Once opted in, crypto
+ * keys go to the device or fail — never silently back to local storage.
+ * @return {Boolean}
+ */
+export function isEnabled() {
+  return enabled;
+}
+
+/**
+ * Read the USB keystore configuration. Uses chrome.storage.local directly rather
+ * than mvelo.storage, which this feature wraps — avoiding any re-entrancy.
+ * @return {Promise<Object|undefined>}
+ */
+export async function getConfig() {
+  const {[USB_CONFIG_KEY]: config} = await chrome.storage.local.get(USB_CONFIG_KEY);
+  return config;
+}
+
+export async function setConfig(config) {
+  await chrome.storage.local.set({[USB_CONFIG_KEY]: config});
+}
+
+export async function clearConfig() {
+  await chrome.storage.local.remove(USB_CONFIG_KEY);
+}
+
+/**
+ * Register a callback invoked on every state transition.
+ * @param {Function} listener - (nextState, previousState, status) => void
+ * @return {Function} unregister
+ */
+export function addStateListener(listener) {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+function transition(nextState, nextDetail = null) {
+  if (nextState === state && nextDetail === detail) {
+    return false;
+  }
+  const previous = state;
+  state = nextState;
+  detail = nextDetail;
+  for (const listener of listeners) {
+    try {
+      listener(state, previous, getStatus());
+    } catch (e) {
+      console.log('USB keystore state listener failed', e);
+    }
+  }
+  return true;
+}
+
+/**
+ * Determine the current state by talking to the device.
+ * @return {Promise<{state: String, detail: String|null}>}
+ */
+async function computeState() {
+  const config = await getConfig();
+  enabled = Boolean(config?.keystoreId);
+  // Not opting in takes precedence over an unsupported browser: an unconfigured
+  // profile is simply upstream Mailvelope, and the setup UI reports separately
+  // (via getStatus().supported) whether this browser could support the feature.
+  if (!enabled) {
+    return {state: USB_STATE.NOT_CONFIGURED, detail: null};
+  }
+  if (!backend) {
+    return {state: USB_STATE.UNSUPPORTED, detail: 'no_backend'};
+  }
+  let probe;
+  try {
+    probe = await backend.probe();
+  } catch (e) {
+    return {state: USB_STATE.ERROR, detail: e.message};
+  }
+  if (!probe.configured) {
+    return {state: USB_STATE.NOT_CONFIGURED, detail: null};
+  }
+  if (probe.permission !== 'granted') {
+    return {state: USB_STATE.PERMISSION_REQUIRED, detail: probe.permission};
+  }
+  let marker;
+  try {
+    marker = JSON.parse(await backend.readFile(`${DEVICE_ROOT}/${MARKER_FILE}`));
+  } catch (e) {
+    if (e instanceof NotFoundError || e instanceof DeviceUnavailableError) {
+      return {state: USB_STATE.ABSENT, detail: null};
+    }
+    return {state: USB_STATE.ERROR, detail: e.message};
+  }
+  if (marker?.keystoreId !== config.keystoreId) {
+    return {state: USB_STATE.WRONG_DEVICE, detail: marker?.label ?? null};
+  }
+  return {state: USB_STATE.READY, detail: null};
+}
+
+/**
+ * Probe the device and publish any state change.
+ * @return {Promise<String>} the current state
+ */
+export async function probe() {
+  const next = await computeState();
+  transition(next.state, next.detail);
+  return state;
+}
+
+/**
+ * Throw unless key material may be touched right now. Every crypto path inherits
+ * this through the storage wrapper, so callers do not implement it individually.
+ * @param {Boolean} [reprobe] - probe first; used before write operations
+ */
+export async function assertUsable(reprobe = false) {
+  if (reprobe || UNUSABLE_STATES.includes(state)) {
+    await probe();
+  }
+  if (!isUsable()) {
+    throw new DeviceUnavailableError(`USB keystore is not available (${state})`);
+  }
+}
+
+/**
+ * Drop the cached directory handle and re-probe, after the configuration changed.
+ */
+export async function reload() {
+  backend?.clearCache?.();
+  return probe();
+}
+
+/**
+ * Initialise the state machine: select a backend, take a first reading, and start
+ * the periodic probe.
+ */
+export async function init() {
+  backend = selectBackend();
+  await probe();
+  if (chrome.alarms) {
+    chrome.alarms.create(PROBE_ALARM, {periodInMinutes: PROBE_PERIOD_MINUTES});
+    chrome.alarms.onAlarm.addListener(alarm => {
+      if (alarm.name === PROBE_ALARM) {
+        probe().catch(e => console.log('USB keystore probe failed', e));
+      }
+    });
+  }
+  return getStatus();
+}

--- a/src/modules/usb/state.js
+++ b/src/modules/usb/state.js
@@ -27,6 +27,7 @@ let detail = null;
 let enabled = false;
 let label = null;
 let keystoreId = null;
+let checkedAt = null;
 const listeners = new Set();
 
 /**
@@ -55,7 +56,7 @@ export function getStatus() {
   // label is the picked folder's name. Chrome does not expose a handle's full path,
   // so this is the most specific location the UI can show -- enough to tell one
   // configured device from another.
-  return {state, detail, supported: Boolean(backend), enabled, label, keystoreId};
+  return {state, detail, supported: Boolean(backend), enabled, label, keystoreId, checkedAt};
 }
 
 export function isUsable() {
@@ -215,6 +216,7 @@ export function republish() {
  */
 export async function probe() {
   const next = await computeState();
+  checkedAt = Date.now();
   transition(next.state, next.detail);
   return state;
 }

--- a/src/modules/usb/state.js
+++ b/src/modules/usb/state.js
@@ -156,6 +156,20 @@ export async function hadKeys() {
   return Boolean((await getConfig())?.hadKeys);
 }
 
+/**
+ * Whether a USB keystore is configured, read from storage rather than from the
+ * in-memory flag.
+ *
+ * isEnabled() answers from state set during the first probe, so it reads false until
+ * init() has run. Callers on the crypto path can be reached before that, and there a
+ * false negative would permit exactly the behaviour it is meant to prevent -- so this
+ * pays a storage read to be right regardless of ordering.
+ * @return {Promise<Boolean>}
+ */
+export async function isConfigured() {
+  return Boolean((await getConfig())?.keystoreId);
+}
+
 export async function clearConfig() {
   await chrome.storage.local.remove(USB_CONFIG_KEY);
 }

--- a/src/modules/usb/state.js
+++ b/src/modules/usb/state.js
@@ -83,6 +83,31 @@ export async function setConfig(config) {
   await chrome.storage.local.set({[USB_CONFIG_KEY]: config});
 }
 
+/**
+ * Record that the device has held a private key at some point.
+ *
+ * Needed because a detached device cannot be asked. Without it, "configured but
+ * detached" is indistinguishable from "configured and never used", so the toolbar
+ * menu cannot tell whether to offer onboarding. A boolean carries no key material,
+ * so it belongs in the local config.
+ * @param {Boolean} hadKeys
+ */
+export async function setHadKeys(hadKeys) {
+  const config = await getConfig();
+  if (!config || config.hadKeys === hadKeys) {
+    return;
+  }
+  await setConfig({...config, hadKeys});
+}
+
+/**
+ * Whether the configured device is known to have held a private key.
+ * @return {Promise<Boolean>}
+ */
+export async function hadKeys() {
+  return Boolean((await getConfig())?.hadKeys);
+}
+
 export async function clearConfig() {
   await chrome.storage.local.remove(USB_CONFIG_KEY);
 }
@@ -190,19 +215,35 @@ export async function reload() {
 }
 
 /**
+ * Register the periodic-probe alarm listener.
+ *
+ * MUST be called during the synchronous evaluation of the background script, not
+ * from init(). An MV3 service worker only receives events whose listeners were
+ * registered in that first turn; a listener added after an await is silently never
+ * called on a woken worker, so the periodic presence check would never run and the
+ * device could only be noticed on startup or by an explicit user action.
+ *
+ * Separate from init() because init() is async by nature -- it has to read the
+ * device -- so anything after its first await is already too late.
+ */
+export function registerProbeListener() {
+  if (!chrome.alarms?.onAlarm) {
+    return;
+  }
+  chrome.alarms.onAlarm.addListener(alarm => {
+    if (alarm.name === PROBE_ALARM) {
+      probe().catch(e => console.log('USB keystore probe failed', e));
+    }
+  });
+}
+
+/**
  * Initialise the state machine: select a backend, take a first reading, and start
- * the periodic probe.
+ * the periodic probe. The listener itself is registered by registerProbeListener().
  */
 export async function init() {
   backend = selectBackend();
   await probe();
-  if (chrome.alarms) {
-    chrome.alarms.create(PROBE_ALARM, {periodInMinutes: PROBE_PERIOD_MINUTES});
-    chrome.alarms.onAlarm.addListener(alarm => {
-      if (alarm.name === PROBE_ALARM) {
-        probe().catch(e => console.log('USB keystore probe failed', e));
-      }
-    });
-  }
+  chrome.alarms?.create(PROBE_ALARM, {periodInMinutes: PROBE_PERIOD_MINUTES});
   return getStatus();
 }

--- a/src/modules/usb/state.js
+++ b/src/modules/usb/state.js
@@ -16,8 +16,9 @@
 
 import {
   USB_STATE, UNUSABLE_STATES, USB_CONFIG_KEY, DEVICE_ROOT, MARKER_FILE,
-  PROBE_ALARM, PROBE_PERIOD_MINUTES
+  PROBE_ALARM, PROBE_PERIOD_MINUTES, USB_READ_ONLY
 } from './constants';
+import {MvError} from '../../lib/util';
 import {NotFoundError, DeviceUnavailableError} from './backend';
 import FsaBackend from './FsaBackend';
 import NativeBackend from './NativeBackend';
@@ -83,7 +84,24 @@ export function getStatus() {
   };
 }
 
+/**
+ * Whether key material may be read. A read-only device is still readable, so it
+ * counts here -- keys on a write-protected stick must remain usable for decryption.
+ * @return {Boolean}
+ */
 export function isUsable() {
+  return state === USB_STATE.READY || state === USB_STATE.READ_ONLY;
+}
+
+/**
+ * Whether key material may be written.
+ *
+ * Separate from isUsable() because a delete or a save that silently fails is worse
+ * than one that refuses: a key deleted because it was compromised, appearing to
+ * vanish while still on the device, leaves the user believing it is gone.
+ * @return {Boolean}
+ */
+export function isWritable() {
   return state === USB_STATE.READY;
 }
 
@@ -215,6 +233,11 @@ async function computeState() {
   if (marker?.keystoreId !== config.keystoreId) {
     return {state: USB_STATE.WRONG_DEVICE, detail: marker?.label ?? null};
   }
+  // The native host reports writability directly. The File System Access API cannot,
+  // so there READ_ONLY is reached reactively, when a write is refused.
+  if (probe.writable === false) {
+    return {state: USB_STATE.READ_ONLY, detail: null};
+  }
   return {state: USB_STATE.READY, detail: null};
 }
 
@@ -260,6 +283,27 @@ export async function assertUsable(reprobe = false) {
   }
   if (!isUsable()) {
     throw new DeviceUnavailableError(`USB keystore is not available (${state})`);
+  }
+}
+
+/**
+ * Throw unless key material may be written right now.
+ * @param {Boolean} [reprobe]
+ */
+export async function assertWritable(reprobe = false) {
+  await assertUsable(reprobe);
+  if (!isWritable()) {
+    throw new MvError(
+      'The USB device is write-protected, so this change cannot be saved.',
+      USB_READ_ONLY
+    );
+  }
+}
+
+/** Record that a write was refused, so the state reflects it until the next probe. */
+export function markReadOnly() {
+  if (state === USB_STATE.READY) {
+    transition(USB_STATE.READ_ONLY, null);
   }
 }
 

--- a/src/modules/usb/strings.js
+++ b/src/modules/usb/strings.js
@@ -105,6 +105,11 @@ export const strings = {
   // it beats a control that silently does nothing.
   cache_disabled: 'Turned off because your keys are on a USB device. Caching a passphrase makes the browser record the key\u2019s fingerprint in this computer\u2019s profile, which would leave a trace of the key here.',
 
+  // Shown next to the greyed-out "remember password" box in the passphrase dialog.
+  // Shorter than cache_disabled, which sits on the settings page where there is room
+  // to explain; here the user is mid-task and wants the reason in one line.
+  cache_unavailable: 'Not available while your keys are on a USB device: caching would record the key\u2019s fingerprint on this computer.',
+
   generate_blocked_heading: 'Your keys are on a device that is not available',
   generate_blocked_text: 'Connect the device holding your keys before generating or importing, so no key material is written to this computer.'
 };

--- a/src/modules/usb/strings.js
+++ b/src/modules/usb/strings.js
@@ -32,6 +32,10 @@ export const strings = {
   setup_card_button: 'Set up USB keystore',
 
   status_heading: 'Device status',
+  status_folder: 'Folder',
+  status_folder_unknown: 'not selected yet',
+  status_path_note: 'Keys are kept in a “mailvelope-keystore” folder inside it. Browsers only report the folder name, not its full path.',
+  status_keystore_id: 'Keystore ID',
   status_ready: 'Connected and ready.',
   status_not_configured: 'No USB keystore has been set up.',
   status_unsupported: 'This browser cannot access a USB keystore. Chrome or another Chromium browser is required; Firefox support needs the Mailvelope native helper.',
@@ -46,6 +50,8 @@ export const strings = {
   action_menu_unavailable: 'USB keystore not connected',
 
   choose_directory: 'Choose directory…',
+  choose_other_directory: 'Select a different folder…',
+  choose_other_directory_hint: 'Use this if the device is mounted somewhere new, or to point this profile at a different device.',
   choose_directory_hint: 'Select the drive or folder that will contain the keystore — typically the root of the device. Mailvelope creates a “mailvelope-keystore” folder inside it, so do not select that folder itself.',
   reconnect: 'Reconnect',
   disable: 'Stop using the USB keystore',

--- a/src/modules/usb/strings.js
+++ b/src/modules/usb/strings.js
@@ -32,6 +32,10 @@ export const strings = {
   setup_card_button: 'Set up USB keystore',
 
   status_heading: 'Device status',
+  status_checked_now: 'checked just now',
+  status_checked_ago: 'checked $1s ago',
+  status_checking_live: 'rechecking every second while this page is open',
+  status_checking_background: 'rechecking every 30 seconds in the background',
   status_folder: 'Folder',
   status_folder_unknown: 'not selected yet',
   status_path_note: 'Keys are kept in a “mailvelope-keystore” folder inside it. Browsers only report the folder name, not its full path.',

--- a/src/modules/usb/strings.js
+++ b/src/modules/usb/strings.js
@@ -54,6 +54,22 @@ export const strings = {
   action_menu_unavailable: 'USB keystore not connected',
 
   choose_directory: 'Choose directory…',
+
+  // Native-host path: Firefox has no directory picker, so a device is chosen from
+  // the list the helper reports.
+  devices_heading: 'Connected devices',
+  devices_refresh: 'Refresh list',
+  devices_none: 'No removable devices found. Connect one and refresh.',
+  devices_use: 'Use this device',
+  devices_read_only: 'read-only',
+  devices_hint: 'Mailvelope creates a “mailvelope-keystore” folder on the device you choose.',
+  helper_needed_heading: 'Helper required',
+  helper_needed: 'This browser reaches a USB device through a small helper program that has to be installed separately. See native-host/install.sh in the Mailvelope source.',
+  helper_permission_heading: 'Permission required',
+  helper_permission: 'Mailvelope needs permission to talk to the helper program.',
+  helper_permission_grant: 'Grant permission',
+  helper_ready: 'Helper installed and reachable.',
+
   choose_other_directory: 'Select a different folder…',
   choose_other_directory_hint: 'Use this if the device is mounted somewhere new, or to point this profile at a different device.',
   choose_directory_hint: 'Select the drive or folder that will contain the keystore — typically the root of the device. Mailvelope creates a “mailvelope-keystore” folder inside it, so do not select that folder itself.',

--- a/src/modules/usb/strings.js
+++ b/src/modules/usb/strings.js
@@ -24,6 +24,7 @@ export const strings = {
   storage_indicator_local: 'Stored on this computer',
   storage_indicator_usb: 'Stored on USB device',
   storage_indicator_usb_disconnected: 'USB device disconnected',
+  storage_indicator_usb_read_only: 'USB device write-protected',
   storage_switch_to_usb: 'Choose the USB device',
   storage_switch_back_warning: 'Switching back to this computer does not copy any keys back. The keys stay on the device and this profile loses access to them.',
 
@@ -31,6 +32,7 @@ export const strings = {
   setup_card_text: 'Keep your keys on a removable USB device instead of on this computer. Encryption is only possible while the device is connected.',
   setup_card_button: 'Set up USB keystore',
 
+  operation_failed: 'That change could not be saved',
   status_heading: 'Device status',
   status_checked_now: 'checked just now',
   status_checked_ago: 'checked $1s ago',
@@ -46,6 +48,7 @@ export const strings = {
   status_permission_required: 'Permission to access the keystore directory is needed. Click “Reconnect” to restore it.',
   status_absent: 'The USB keystore is not available. Connect the device to use your keys.',
   status_wrong_device: 'The connected device is not this profile’s keystore.',
+  status_read_only: 'The device is write-protected. Your keys can be used, but changes cannot be saved.',
   status_error: 'The USB keystore could not be read.',
 
   banner_unavailable_heading: 'USB keystore not available',
@@ -115,6 +118,7 @@ export function describeState(state) {
     case USB_STATE.PERMISSION_REQUIRED: return strings.status_permission_required;
     case USB_STATE.ABSENT: return strings.status_absent;
     case USB_STATE.WRONG_DEVICE: return strings.status_wrong_device;
+    case USB_STATE.READ_ONLY: return strings.status_read_only;
     default: return strings.status_error;
   }
 }

--- a/src/modules/usb/strings.js
+++ b/src/modules/usb/strings.js
@@ -1,0 +1,92 @@
+/**
+ * Copyright (C) 2026 Noam Rathaus
+ * Licensed under the GNU Affero General Public License version 3
+ *
+ * UI strings for the USB keystore.
+ *
+ * Deliberately not in locales/en/messages.json: that file is regenerated wholesale
+ * upstream (see the 'Normalize l10n files to Weblate format' and 'drop orphan and
+ * untranslated keys' commits), so keys added there conflict on every translation
+ * sync. English-only here costs nothing on a feature branch; moving these into
+ * messages.json is mechanical if the feature is ever upstreamed.
+ */
+
+import {USB_STATE} from './constants';
+
+export const strings = {
+  settings_tab: 'Key Storage',
+
+  storage_heading: 'Where your keys are stored',
+  storage_local_label: 'This computer (default)',
+  storage_local_description: 'Keys are stored in this browser profile, on this computer.',
+  storage_usb_label: 'USB device',
+  storage_usb_description: 'Keys are stored on a removable device. Encryption, decryption and signing only work while it is connected.',
+  storage_indicator_local: 'Stored on this computer',
+  storage_indicator_usb: 'Stored on USB device',
+  storage_indicator_usb_disconnected: 'USB device disconnected',
+  storage_switch_to_usb: 'Choose the USB device',
+  storage_switch_back_warning: 'Switching back to this computer does not copy any keys back. The keys stay on the device and this profile loses access to them.',
+
+  setup_card_title: 'USB keystore',
+  setup_card_text: 'Keep your keys on a removable USB device instead of on this computer. Encryption is only possible while the device is connected.',
+  setup_card_button: 'Set up USB keystore',
+
+  status_heading: 'Device status',
+  status_ready: 'Connected and ready.',
+  status_not_configured: 'No USB keystore has been set up.',
+  status_unsupported: 'This browser cannot access a USB keystore. Chrome or another Chromium browser is required; Firefox support needs the Mailvelope native helper.',
+  status_permission_required: 'Permission to access the keystore directory is needed. Click “Reconnect” to restore it.',
+  status_absent: 'The USB keystore is not available. Connect the device to use your keys.',
+  status_wrong_device: 'The connected device is not this profile’s keystore.',
+  status_error: 'The USB keystore could not be read.',
+
+  banner_unavailable_heading: 'USB keystore not available',
+  banner_unavailable_text: 'Your keys are stored on a USB device that is not currently connected. Encryption, decryption and signing are unavailable until you reconnect it.',
+  banner_reconnect: 'Reconnect',
+  action_menu_unavailable: 'USB keystore not connected',
+
+  choose_directory: 'Choose directory…',
+  choose_directory_hint: 'Select a folder on the USB device. Mailvelope creates a “mailvelope-keystore” folder inside it.',
+  reconnect: 'Reconnect',
+  disable: 'Stop using the USB keystore',
+  disable_hint: 'Keys already on the device are left untouched. This browser profile will no longer have access to them.',
+
+  migrate_heading: 'Keys on this computer',
+  migrate_text: 'These keys are currently stored in the browser profile. Moving them to the device deletes the local copies.',
+  migrate_button: 'Move keys to the device',
+  migrate_none: 'No keys are stored on this computer.',
+  migrate_done: 'Moved $1 item(s) to the device.',
+  migrate_failed: 'Some items could not be moved: $1',
+  migrate_private: '$1 private key(s)',
+  migrate_public: '$1 public key(s)',
+  migrate_autocrypt: '$1 Autocrypt record(s)',
+  check_again: 'Check again',
+  migrate_residue_warning: 'Deleting local data does not erase it from the disk: a migrated private key may stay recoverable from the browser profile until the browser reclaims that space. For keys that must never touch this computer, generate a new key directly onto the device and revoke the old one.',
+
+  passphrase_required: 'A passphrase is required when keys are stored on a USB device — it is the only thing protecting them if the device is lost.',
+  encrypted_volume_hint: 'For protection at rest, put an encrypted volume on the device (VeraCrypt, or LUKS on Linux) and select it once unlocked. Mailvelope reports a locked volume as disconnected.',
+  formatting_hint: 'exFAT is the best choice if the device moves between computers. ext4 adds journaling and file permissions but is practically Linux-only.',
+
+  generate_first_heading: 'Set up the device first',
+  generate_first_text: 'Set up the USB keystore before generating or importing a key, so no key material is ever written to this computer.'
+};
+
+/**
+ * Message describing a state, for the status panel and banners.
+ * @param {String} state - one of USB_STATE
+ * @return {String}
+ */
+export function describeState(state) {
+  if (!state) {
+    return '';
+  }
+  switch (state) {
+    case USB_STATE.READY: return strings.status_ready;
+    case USB_STATE.NOT_CONFIGURED: return strings.status_not_configured;
+    case USB_STATE.UNSUPPORTED: return strings.status_unsupported;
+    case USB_STATE.PERMISSION_REQUIRED: return strings.status_permission_required;
+    case USB_STATE.ABSENT: return strings.status_absent;
+    case USB_STATE.WRONG_DEVICE: return strings.status_wrong_device;
+    default: return strings.status_error;
+  }
+}

--- a/src/modules/usb/strings.js
+++ b/src/modules/usb/strings.js
@@ -101,6 +101,10 @@ export const strings = {
   // Shown only when a keystore is configured but not reachable, so the wording must
   // not tell the user to set one up: they already have, and the remedy is to make the
   // configured device available -- or, for a wrong device, to connect the right one.
+  // Shown beside the passphrase-cache setting, which USB mode overrides. Explaining
+  // it beats a control that silently does nothing.
+  cache_disabled: 'Turned off because your keys are on a USB device. Caching a passphrase makes the browser record the key\u2019s fingerprint in this computer\u2019s profile, which would leave a trace of the key here.',
+
   generate_blocked_heading: 'Your keys are on a device that is not available',
   generate_blocked_text: 'Connect the device holding your keys before generating or importing, so no key material is written to this computer.'
 };

--- a/src/modules/usb/strings.js
+++ b/src/modules/usb/strings.js
@@ -42,6 +42,15 @@ export const strings = {
   status_folder_unknown: 'not selected yet',
   status_path_note: 'Keys are kept in a “mailvelope-keystore” folder inside it. Browsers only report the folder name, not its full path.',
   status_keystore_id: 'Keystore ID',
+  status_keys: 'Keys',
+  // "$1 public keys, $2 key pairs". Shown whenever the device is READY, because the
+  // number of keys the extension is holding is the one thing no other part of the UI
+  // reports -- and a keyring that arrived incomplete looks exactly like a small one.
+  status_keys_counts: '$1 public, $2 key pairs',
+  // Shown when fewer keys were loaded than the device holds. Always a fault: reads
+  // are whole-file, so a shortfall means part of the keyring never arrived.
+  status_keys_incomplete: 'Only $1 of $2 keys on the device were loaded. Part of the keyring did not arrive — if the extension was rebuilt recently, reload it; otherwise this is a read failure worth reporting.',
+  status_keys_unknown: 'not counted yet',
   status_ready: 'Connected and ready.',
   status_not_configured: 'No USB keystore has been set up.',
   status_unsupported: 'This browser cannot access a USB keystore. Chrome or another Chromium browser is required; Firefox support needs the Mailvelope native helper.',

--- a/src/modules/usb/strings.js
+++ b/src/modules/usb/strings.js
@@ -46,7 +46,7 @@ export const strings = {
   action_menu_unavailable: 'USB keystore not connected',
 
   choose_directory: 'Choose directory…',
-  choose_directory_hint: 'Select a folder on the USB device. Mailvelope creates a “mailvelope-keystore” folder inside it.',
+  choose_directory_hint: 'Select the drive or folder that will contain the keystore — typically the root of the device. Mailvelope creates a “mailvelope-keystore” folder inside it, so do not select that folder itself.',
   reconnect: 'Reconnect',
   disable: 'Stop using the USB keystore',
   disable_hint: 'Keys already on the device are left untouched. This browser profile will no longer have access to them.',
@@ -61,6 +61,8 @@ export const strings = {
   migrate_public: '$1 public key(s)',
   migrate_autocrypt: '$1 Autocrypt record(s)',
   check_again: 'Check again',
+  adopt_anyway: 'Use this folder anyway',
+  adopt_hint: 'The keys on the folder this profile used before will no longer be reachable from this browser.',
   migrate_residue_warning: 'Deleting local data does not erase it from the disk: a migrated private key may stay recoverable from the browser profile until the browser reclaims that space. For keys that must never touch this computer, generate a new key directly onto the device and revoke the old one.',
 
   passphrase_required: 'A passphrase is required when keys are stored on a USB device — it is the only thing protecting them if the device is lost.',

--- a/src/modules/usb/strings.js
+++ b/src/modules/usb/strings.js
@@ -98,8 +98,11 @@ export const strings = {
   encrypted_volume_hint: 'For protection at rest, put an encrypted volume on the device (VeraCrypt, or LUKS on Linux) and select it once unlocked. Mailvelope reports a locked volume as disconnected.',
   formatting_hint: 'exFAT is the best choice if the device moves between computers. ext4 adds journaling and file permissions but is practically Linux-only.',
 
-  generate_first_heading: 'Set up the device first',
-  generate_first_text: 'Set up the USB keystore before generating or importing a key, so no key material is ever written to this computer.'
+  // Shown only when a keystore is configured but not reachable, so the wording must
+  // not tell the user to set one up: they already have, and the remedy is to make the
+  // configured device available -- or, for a wrong device, to connect the right one.
+  generate_blocked_heading: 'Your keys are on a device that is not available',
+  generate_blocked_text: 'Connect the device holding your keys before generating or importing, so no key material is written to this computer.'
 };
 
 /**

--- a/test/unit/components/enter-password/PasswordDialog.usb.test.js
+++ b/test/unit/components/enter-password/PasswordDialog.usb.test.js
@@ -1,0 +1,58 @@
+/**
+ * Copyright (C) 2026 Noam Rathaus
+ * Licensed under the GNU Affero General Public License version 3
+ *
+ * "Remember password" cannot work while keys live on a USB device -- pwdCache.set()
+ * refuses to cache, because the alarm it would create writes the key's fingerprint
+ * into this computer's profile. The box was still offered, and checked, so it
+ * promised something that never happened.
+ */
+
+import React from 'react';
+import {render, screen, act} from '@testing-library/react';
+import * as l10n from 'lib/l10n';
+import PasswordDialog from 'components/enter-password/PasswordDialog';
+import {strings as usbStrings} from 'modules/usb/strings';
+
+jest.mock('../../../../src/lib/EventHandler', () => require('../../__mocks__/lib/EventHandler').default);
+
+describe('PasswordDialog cache checkbox', () => {
+  beforeAll(() => {
+    l10n.mapToLocal();
+  });
+
+  async function setup(initData) {
+    const ref = React.createRef();
+    render(<PasswordDialog ref={ref} id="pwd-dialog-test" />);
+    await act(async () => {
+      ref.current.setInitData({
+        keyId: 'A1B2C3D4',
+        userId: 'Tester <tester@test.com>',
+        reason: '',
+        ...initData
+      });
+    });
+    return screen.getByRole('checkbox');
+  }
+
+  it('offers the box when the passphrase can actually be cached', async () => {
+    const checkbox = await setup({cache: true, cacheDisabled: false});
+    expect(checkbox).toBeChecked();
+    expect(checkbox).toBeEnabled();
+    expect(screen.queryByText(usbStrings.cache_unavailable)).not.toBeInTheDocument();
+  });
+
+  // The bug: checked, clickable, and caching nothing.
+  it('shows the box unchecked, disabled and explained on a USB keystore', async () => {
+    const checkbox = await setup({cache: false, cacheDisabled: true});
+    expect(checkbox).not.toBeChecked();
+    expect(checkbox).toBeDisabled();
+    expect(screen.getByText(usbStrings.cache_unavailable)).toBeInTheDocument();
+  });
+
+  // The field is optional, and its absence must not disable a working box.
+  it('leaves the box usable when the controller says nothing about it', async () => {
+    const checkbox = await setup({cache: true});
+    expect(checkbox).toBeEnabled();
+  });
+});

--- a/test/unit/components/usb/UsbDevicePicker.test.js
+++ b/test/unit/components/usb/UsbDevicePicker.test.js
@@ -1,0 +1,110 @@
+/**
+ * Copyright (C) 2026 Noam Rathaus
+ * Licensed under the GNU Affero General Public License version 3
+ *
+ * Two prerequisites can be missing on the native path and they need different
+ * remedies: the optional nativeMessaging permission, which the user can grant here,
+ * and the helper program, which has to be installed outside the browser. Collapsing
+ * them into one "unavailable" would tell someone to install software they already
+ * have, so the distinction is worth pinning down.
+ */
+
+import React from 'react';
+import {render, screen, waitFor} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const mockSend = jest.fn();
+jest.mock('../../../../src/app/app', () => ({port: {send: (...args) => mockSend(...args)}}));
+
+import UsbDevicePicker from '../../../../src/components/usb/UsbDevicePicker';
+import {strings} from '../../../../src/modules/usb/strings';
+
+const DEVICES = [
+  {path: '/run/media/noamr/STICK', label: 'STICK', writable: true},
+  {path: '/run/media/noamr/LOCKED', label: 'LOCKED', writable: false}
+];
+
+function grantState(granted) {
+  global.chrome.permissions = {
+    contains: jest.fn((_p, cb) => cb(granted)),
+    request: jest.fn((_p, cb) => cb(true))
+  };
+}
+
+describe('UsbDevicePicker', () => {
+  let onSelect;
+
+  beforeEach(() => {
+    mockSend.mockReset();
+    onSelect = jest.fn();
+    grantState(true);
+  });
+
+  it('lists the devices the helper reports, with their real paths', async () => {
+    mockSend.mockResolvedValue(DEVICES);
+    render(<UsbDevicePicker onSelect={onSelect} />);
+    expect(await screen.findByText('STICK')).toBeInTheDocument();
+    // The real path is shown because the native path can, unlike the picker path.
+    expect(screen.getByText('/run/media/noamr/STICK')).toBeInTheDocument();
+  });
+
+  it('selects a device by path', async () => {
+    mockSend.mockResolvedValue(DEVICES);
+    render(<UsbDevicePicker onSelect={onSelect} />);
+    const buttons = await screen.findAllByText(strings.devices_use);
+    await userEvent.click(buttons[0]);
+    expect(onSelect).toHaveBeenCalledWith('/run/media/noamr/STICK');
+  });
+
+  // A keystore on a read-only device would fail at the first write, so do not
+  // offer it.
+  it('will not offer a read-only device', async () => {
+    mockSend.mockResolvedValue(DEVICES);
+    render(<UsbDevicePicker onSelect={onSelect} />);
+    await screen.findByText('LOCKED');
+    expect(screen.getByText(strings.devices_read_only)).toBeInTheDocument();
+    const buttons = screen.getAllByText(strings.devices_use);
+    expect(buttons[1].closest('button')).toBeDisabled();
+  });
+
+  it('says so when nothing is connected', async () => {
+    mockSend.mockResolvedValue([]);
+    render(<UsbDevicePicker onSelect={onSelect} />);
+    expect(await screen.findByText(strings.devices_none)).toBeInTheDocument();
+  });
+
+  describe('missing prerequisites', () => {
+    it('asks for the permission rather than blaming the helper', async () => {
+      grantState(false);
+      render(<UsbDevicePicker onSelect={onSelect} />);
+      expect(await screen.findByText(strings.helper_permission)).toBeInTheDocument();
+      expect(screen.queryByText(strings.helper_needed)).not.toBeInTheDocument();
+      // Nothing should have been asked of the helper without permission to do so.
+      expect(mockSend).not.toHaveBeenCalled();
+    });
+
+    it('lists devices once the permission is granted', async () => {
+      grantState(false);
+      mockSend.mockResolvedValue(DEVICES);
+      render(<UsbDevicePicker onSelect={onSelect} />);
+      await userEvent.click(await screen.findByText(strings.helper_permission_grant));
+      expect(await screen.findByText('STICK')).toBeInTheDocument();
+    });
+
+    it('reports a missing helper rather than a permission problem', async () => {
+      const error = new Error('no such native application');
+      error.code = 'USB_HOST_UNAVAILABLE';
+      mockSend.mockRejectedValue(error);
+      render(<UsbDevicePicker onSelect={onSelect} />);
+      expect(await screen.findByText(strings.helper_needed)).toBeInTheDocument();
+      expect(screen.queryByText(strings.helper_permission)).not.toBeInTheDocument();
+    });
+
+    it('shows other failures as errors, not as a missing helper', async () => {
+      mockSend.mockRejectedValue(Object.assign(new Error('disk on fire'), {code: 'USB_HOST_IO_ERROR'}));
+      render(<UsbDevicePicker onSelect={onSelect} />);
+      await waitFor(() => expect(screen.getByText('disk on fire')).toBeInTheDocument());
+      expect(screen.queryByText(strings.helper_needed)).not.toBeInTheDocument();
+    });
+  });
+});

--- a/test/unit/components/usb/UsbKeyActionGate.test.js
+++ b/test/unit/components/usb/UsbKeyActionGate.test.js
@@ -35,7 +35,7 @@ describe('UsbKeyActionGate', () => {
   it('allows key creation when no keystore is configured', () => {
     renderGate({enabled: false, state: USB_STATE.NOT_CONFIGURED});
     expect(screen.getByText(CHILDREN)).toBeInTheDocument();
-    expect(screen.queryByText(strings.generate_first_heading)).not.toBeInTheDocument();
+    expect(screen.queryByText(strings.generate_blocked_heading)).not.toBeInTheDocument();
   });
 
   it('allows key creation while the device is connected', () => {
@@ -51,8 +51,19 @@ describe('UsbKeyActionGate', () => {
   it('blocks and explains when the configured device is absent', () => {
     renderGate({enabled: true, state: USB_STATE.ABSENT});
     expect(screen.queryByText(CHILDREN)).not.toBeInTheDocument();
-    expect(screen.getByText(strings.generate_first_heading)).toBeInTheDocument();
+    expect(screen.getByText(strings.generate_blocked_heading)).toBeInTheDocument();
     expect(screen.getByText(strings.status_absent)).toBeInTheDocument();
+  });
+
+  // The gate renders only when a keystore is configured, so its wording must never
+  // tell the user to set one up. This case is where that was found: a device whose
+  // marker names a different keystore is present and readable, and being told to
+  // "set up the device" or to "connect" it names neither of the two real remedies.
+  it('names the state rather than telling the user to set up a keystore they have', () => {
+    renderGate({enabled: true, state: USB_STATE.WRONG_DEVICE});
+    expect(screen.queryByText(CHILDREN)).not.toBeInTheDocument();
+    expect(screen.getByText(strings.status_wrong_device)).toBeInTheDocument();
+    expect(screen.queryByText(/set up/i)).not.toBeInTheDocument();
   });
 
   it('blocks when the permission grant is missing', () => {

--- a/test/unit/components/usb/UsbKeyActionGate.test.js
+++ b/test/unit/components/usb/UsbKeyActionGate.test.js
@@ -1,0 +1,74 @@
+/**
+ * Copyright (C) 2026 Noam Rathaus
+ * Licensed under the GNU Affero General Public License version 3
+ *
+ * The gate's condition is easy to get wrong in a way that would either break
+ * ordinary local key generation or fail to warn when the device is missing, so it
+ * is worth pinning down: block only when a keystore is configured *and* unusable.
+ */
+
+import React from 'react';
+import {render, screen} from '@testing-library/react';
+import {MemoryRouter} from 'react-router-dom';
+
+// The component reads the shared app port; a stub keeps app.js out of the test.
+jest.mock('../../../../src/app/app', () => ({port: {on: jest.fn(), send: jest.fn(() => new Promise(() => {}))}}));
+
+import UsbKeyActionGate from '../../../../src/components/usb/UsbKeyActionGate';
+import {USB_STATE} from '../../../../src/modules/usb/constants';
+import {strings} from '../../../../src/modules/usb/strings';
+
+function renderGate(status) {
+  return render(
+    <MemoryRouter>
+      <UsbKeyActionGate status={status}>
+        <div>generate and import cards</div>
+      </UsbKeyActionGate>
+    </MemoryRouter>
+  );
+}
+
+const CHILDREN = 'generate and import cards';
+
+describe('UsbKeyActionGate', () => {
+  // Blocking here would break Mailvelope for everyone not using the feature.
+  it('allows key creation when no keystore is configured', () => {
+    renderGate({enabled: false, state: USB_STATE.NOT_CONFIGURED});
+    expect(screen.getByText(CHILDREN)).toBeInTheDocument();
+    expect(screen.queryByText(strings.generate_first_heading)).not.toBeInTheDocument();
+  });
+
+  it('allows key creation while the device is connected', () => {
+    renderGate({enabled: true, state: USB_STATE.READY});
+    expect(screen.getByText(CHILDREN)).toBeInTheDocument();
+  });
+
+  it('allows key creation before the status has loaded, rather than flashing a warning', () => {
+    renderGate(null);
+    expect(screen.getByText(CHILDREN)).toBeInTheDocument();
+  });
+
+  it('blocks and explains when the configured device is absent', () => {
+    renderGate({enabled: true, state: USB_STATE.ABSENT});
+    expect(screen.queryByText(CHILDREN)).not.toBeInTheDocument();
+    expect(screen.getByText(strings.generate_first_heading)).toBeInTheDocument();
+    expect(screen.getByText(strings.status_absent)).toBeInTheDocument();
+  });
+
+  it('blocks when the permission grant is missing', () => {
+    renderGate({enabled: true, state: USB_STATE.PERMISSION_REQUIRED});
+    expect(screen.queryByText(CHILDREN)).not.toBeInTheDocument();
+    expect(screen.getByText(strings.status_permission_required)).toBeInTheDocument();
+  });
+
+  it('blocks when the wrong device is connected', () => {
+    renderGate({enabled: true, state: USB_STATE.WRONG_DEVICE});
+    expect(screen.queryByText(CHILDREN)).not.toBeInTheDocument();
+  });
+
+  it('offers a route to the key storage settings so the user can act on it', () => {
+    renderGate({enabled: true, state: USB_STATE.ABSENT});
+    expect(screen.getByText(strings.banner_reconnect).closest('a'))
+    .toHaveAttribute('href', '/settings/key-storage');
+  });
+});

--- a/test/unit/components/usb/UsbSetupCard.test.js
+++ b/test/unit/components/usb/UsbSetupCard.test.js
@@ -1,0 +1,65 @@
+/**
+ * Copyright (C) 2026 Noam Rathaus
+ * Licensed under the GNU Affero General Public License version 3
+ *
+ * The card serves two different audiences with one component: someone who has not
+ * set up a keystore, and someone whose configured device is not reachable. It showed
+ * a single hardcoded "not available. Connect the device" line for every unreachable
+ * state, which names the wrong remedy for most of them -- the device is already
+ * connected when it is the wrong one, or write-protected.
+ */
+
+import React from 'react';
+import {render, screen} from '@testing-library/react';
+import {MemoryRouter} from 'react-router-dom';
+
+jest.mock('../../../../src/app/app', () => ({port: {on: jest.fn(), send: jest.fn(() => new Promise(() => {}))}}));
+
+import UsbSetupCard from '../../../../src/components/usb/UsbSetupCard';
+import {USB_STATE} from '../../../../src/modules/usb/constants';
+import {strings} from '../../../../src/modules/usb/strings';
+
+function renderCard(status) {
+  return render(<MemoryRouter><UsbSetupCard status={status} /></MemoryRouter>);
+}
+
+describe('UsbSetupCard', () => {
+  it('offers setup when no keystore is configured', () => {
+    renderCard({enabled: false, state: USB_STATE.NOT_CONFIGURED});
+    expect(screen.getByText(strings.setup_card_title)).toBeInTheDocument();
+    // Nothing is wrong yet, so no warning belongs here.
+    expect(screen.queryByText(strings.status_absent)).not.toBeInTheDocument();
+  });
+
+  // Keys are reachable, so there is nothing to offer and nothing to warn about.
+  it('disappears once the device is connected', () => {
+    const {container} = renderCard({enabled: true, state: USB_STATE.READY});
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  // A write-protected device is readable, so the keys work; the card must not
+  // reappear claiming the keystore is missing.
+  it('disappears on a write-protected device, which is still usable', () => {
+    const {container} = renderCard({enabled: true, state: USB_STATE.READ_ONLY});
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('warns that the device is absent when it is', () => {
+    renderCard({enabled: true, state: USB_STATE.ABSENT});
+    expect(screen.getByText(strings.status_absent)).toBeInTheDocument();
+  });
+
+  // The case the generic wording got wrong: a device is present and readable, and
+  // telling the user to connect one is a dead end.
+  it('names the wrong-device state instead of asking for a device already connected', () => {
+    renderCard({enabled: true, state: USB_STATE.WRONG_DEVICE});
+    expect(screen.getByText(strings.status_wrong_device)).toBeInTheDocument();
+    expect(screen.queryByText(strings.status_absent)).not.toBeInTheDocument();
+  });
+
+  it('names the error state rather than reporting absence', () => {
+    renderCard({enabled: true, state: USB_STATE.ERROR});
+    expect(screen.getByText(strings.status_error)).toBeInTheDocument();
+    expect(screen.queryByText(strings.status_absent)).not.toBeInTheDocument();
+  });
+});

--- a/test/unit/components/usb/UsbStatusBadge.test.js
+++ b/test/unit/components/usb/UsbStatusBadge.test.js
@@ -1,0 +1,55 @@
+/**
+ * Copyright (C) 2026 Noam Rathaus
+ * Licensed under the GNU Affero General Public License version 3
+ *
+ * This badge is the only indication the keyring page carries about where keys live,
+ * so a wrong label here is the user's whole picture. It used to be binary --
+ * anything other than READY read as "disconnected" -- which is plainly false for a
+ * device that is connected but write-protected.
+ */
+
+import React from 'react';
+import {render, screen} from '@testing-library/react';
+
+jest.mock('../../../../src/app/app', () => ({port: {on: jest.fn(), send: jest.fn(() => new Promise(() => {}))}}));
+
+import UsbStatusBadge from '../../../../src/components/usb/UsbStatusBadge';
+import {USB_STATE} from '../../../../src/modules/usb/constants';
+import {strings} from '../../../../src/modules/usb/strings';
+
+/** Render in isolation and unmount, so repeated calls in one test cannot stack. */
+const label = state => {
+  const {container, unmount} = render(<UsbStatusBadge status={{enabled: true, state}} />);
+  const text = container.textContent;
+  unmount();
+  return text;
+};
+
+describe('UsbStatusBadge', () => {
+  it('says where keys are when no device is configured', () => {
+    render(<UsbStatusBadge status={{enabled: false, state: USB_STATE.NOT_CONFIGURED}} />);
+    expect(screen.getByText(strings.storage_indicator_local)).toBeInTheDocument();
+  });
+
+  it('says the keys are on the device when it is ready', () => {
+    expect(label(USB_STATE.READY)).toBe(strings.storage_indicator_usb);
+  });
+
+  // The case that was wrong: connected, readable, but refusing writes.
+  it('distinguishes write-protected from disconnected', () => {
+    expect(label(USB_STATE.READ_ONLY)).toBe(strings.storage_indicator_usb_read_only);
+    expect(label(USB_STATE.READ_ONLY)).not.toBe(strings.storage_indicator_usb_disconnected);
+  });
+
+  it('reports genuinely unreachable states as disconnected', () => {
+    for (const state of [USB_STATE.ABSENT, USB_STATE.PERMISSION_REQUIRED,
+      USB_STATE.WRONG_DEVICE, USB_STATE.ERROR]) {
+      expect(label(state)).toBe(strings.storage_indicator_usb_disconnected);
+    }
+  });
+
+  it('renders nothing before the status is known', () => {
+    const {container} = render(<UsbStatusBadge status={null} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/test/unit/components/usb/canModifyKeys.test.js
+++ b/test/unit/components/usb/canModifyKeys.test.js
@@ -1,0 +1,59 @@
+/**
+ * Copyright (C) 2026 Noam Rathaus
+ * Licensed under the GNU Affero General Public License version 3
+ *
+ * Destructive controls are disabled rather than offered and then refused. Clicking
+ * Delete, watching the key vanish because the keyring mutates memory before
+ * persisting, and then seeing it reappear is worse than not being able to click --
+ * particularly for a key being deleted because it is compromised.
+ */
+
+jest.mock('../../../../src/app/app', () => ({port: {on: jest.fn(), send: jest.fn()}}));
+
+import {canModifyKeys, whyCannotModify} from '../../../../src/components/usb/usbStatus';
+import {USB_STATE} from '../../../../src/modules/usb/constants';
+import {strings} from '../../../../src/modules/usb/strings';
+
+describe('canModifyKeys', () => {
+  // Ordinary local operation must be untouched by a feature nobody opted into.
+  it('allows changes when no keystore is configured', () => {
+    expect(canModifyKeys({enabled: false, state: USB_STATE.NOT_CONFIGURED})).toBe(true);
+    expect(canModifyKeys(null)).toBe(true);
+    expect(canModifyKeys(undefined)).toBe(true);
+  });
+
+  it('allows changes on a connected, writable device', () => {
+    expect(canModifyKeys({enabled: true, state: USB_STATE.READY})).toBe(true);
+  });
+
+  // The case that prompted this: the device is present and the keys are readable,
+  // so nothing looked wrong, but no write could succeed.
+  it('refuses changes on a write-protected device', () => {
+    expect(canModifyKeys({enabled: true, state: USB_STATE.READ_ONLY})).toBe(false);
+  });
+
+  it('refuses changes when the device is not reachable', () => {
+    for (const state of [USB_STATE.ABSENT, USB_STATE.PERMISSION_REQUIRED,
+      USB_STATE.WRONG_DEVICE, USB_STATE.ERROR, USB_STATE.UNSUPPORTED]) {
+      expect(canModifyKeys({enabled: true, state})).toBe(false);
+    }
+  });
+
+  describe('whyCannotModify', () => {
+    it('says nothing when changes are possible', () => {
+      expect(whyCannotModify({enabled: true, state: USB_STATE.READY})).toBeUndefined();
+    });
+
+    // Used as the tooltip on a disabled control, so it has to explain rather than
+    // just deny.
+    it('explains write protection', () => {
+      expect(whyCannotModify({enabled: true, state: USB_STATE.READ_ONLY}))
+      .toBe(strings.status_read_only);
+    });
+
+    it('explains a disconnected device', () => {
+      expect(whyCannotModify({enabled: true, state: USB_STATE.ABSENT}))
+      .toBe(strings.status_absent);
+    });
+  });
+});

--- a/test/unit/controller/menu.controller.usb.test.js
+++ b/test/unit/controller/menu.controller.usb.test.js
@@ -1,0 +1,85 @@
+/**
+ * Copyright (C) 2026 Noam Rathaus
+ * Licensed under the GNU Affero General Public License version 3
+ *
+ * The toolbar menu decides between the normal menu and the onboarding one from
+ * whether a private key can be found. With a USB keystore that reads as "no keys"
+ * whenever the device is detached, which would offer onboarding -- and so invite
+ * someone whose key is safe on the device to generate a replacement.
+ */
+
+jest.mock('../../../src/modules/keyring', () => ({hasAnyPrivateKey: jest.fn()}));
+jest.mock('../../../src/modules/usb/state', () => ({isEnabled: jest.fn(), isUsable: jest.fn(), hadKeys: jest.fn()}));
+jest.mock('../../../src/modules/prefs', () => ({prefs: {}}));
+jest.mock('../../../src/lib/analytics', () => ({shouldSeeConsentDialog: jest.fn()}));
+jest.mock('../../../src/controller/sub.controller', () => ({
+  SubController: class {
+    constructor() {
+      this.handlers = new Map();
+    }
+
+    on(event, handler) {
+      this.handlers.set(event, handler.bind(this));
+    }
+  },
+  reloadFrames: jest.fn(),
+  setAppDataSlot: jest.fn()
+}));
+
+describe('menu controller setup state with a USB keystore', () => {
+  let MenuController; let keyring; let usbState; let controller;
+
+  beforeEach(() => {
+    jest.resetModules();
+    keyring = require('../../../src/modules/keyring');
+    usbState = require('../../../src/modules/usb/state');
+    MenuController = require('../../../src/controller/menu.controller').default;
+    controller = new MenuController();
+  });
+
+  function getIsSetupDone() {
+    return controller.handlers.get('get-is-setup-done')();
+  }
+
+  it('reports setup done when a private key is readable', async () => {
+    usbState.isEnabled.mockReturnValue(false);
+    keyring.hasAnyPrivateKey.mockResolvedValue(true);
+    await expect(getIsSetupDone()).resolves.toEqual({isSetupDone: true});
+  });
+
+  it('reports setup not done on a fresh profile with no keystore', async () => {
+    usbState.isEnabled.mockReturnValue(false);
+    keyring.hasAnyPrivateKey.mockResolvedValue(false);
+    await expect(getIsSetupDone()).resolves.toEqual({isSetupDone: false});
+  });
+
+  // The case that matters: keys exist but sit on a detached device, so the storage
+  // read reports none. Offering onboarding here would invite a replacement key.
+  it('still reports setup done when a device known to hold keys is detached', async () => {
+    usbState.isEnabled.mockReturnValue(true);
+    usbState.isUsable.mockReturnValue(false);
+    usbState.hadKeys.mockResolvedValue(true);
+    keyring.hasAnyPrivateKey.mockResolvedValue(false);
+    await expect(getIsSetupDone()).resolves.toEqual({isSetupDone: true});
+    // It must not even ask: the answer cannot be trusted while detached.
+    expect(keyring.hasAnyPrivateKey).not.toHaveBeenCalled();
+  });
+
+  // ...but a keystore that was configured and never used is genuinely unset up, so
+  // onboarding must still be offered rather than suppressed for every detached case.
+  it('offers onboarding when a detached device never held a key', async () => {
+    usbState.isEnabled.mockReturnValue(true);
+    usbState.isUsable.mockReturnValue(false);
+    usbState.hadKeys.mockResolvedValue(false);
+    await expect(getIsSetupDone()).resolves.toEqual({isSetupDone: false});
+  });
+
+  // With the device connected the read is trustworthy again, so a genuinely empty
+  // keystore should still offer onboarding.
+  it('reports setup not done when the device is connected and holds no keys', async () => {
+    usbState.isEnabled.mockReturnValue(true);
+    usbState.isUsable.mockReturnValue(true);
+    keyring.hasAnyPrivateKey.mockResolvedValue(false);
+    await expect(getIsSetupDone()).resolves.toEqual({isSetupDone: false});
+  });
+});

--- a/test/unit/controller/pwd.controller.usb.test.js
+++ b/test/unit/controller/pwd.controller.usb.test.js
@@ -1,0 +1,90 @@
+/**
+ * Copyright (C) 2026 Noam Rathaus
+ * Licensed under the GNU Affero General Public License version 3
+ *
+ * The passphrase dialog's "remember password" box was offered from the stored
+ * preference, which defaults to on -- but pwdCache.set() refuses to cache anything
+ * while keys live on a USB device, so the box was checked and did nothing.
+ *
+ * The second half matters as much: the dialog now reports the box off, and taking
+ * that as the user's choice would overwrite their preference with a value they were
+ * never offered, so disabling the keystore would not restore it.
+ */
+
+jest.mock('../../../src/modules/usb/state', () => ({isConfigured: jest.fn()}));
+jest.mock('../../../src/modules/prefs', () => ({
+  prefs: {security: {password_cache: true}},
+  update: jest.fn()
+}));
+jest.mock('../../../src/modules/pwdCache', () => ({unlock: jest.fn(), get: jest.fn()}));
+jest.mock('../../../src/modules/key', () => ({getUserInfo: jest.fn()}));
+jest.mock('../../../src/modules/uiLog', () => ({push: jest.fn()}));
+jest.mock('../../../src/controller/sub.controller', () => ({
+  SubController: class {
+    constructor() {
+      this.handlers = new Map();
+    }
+
+    on(event, handler) {
+      this.handlers.set(event, handler.bind(this));
+    }
+  }
+}));
+
+describe('passphrase dialog with a USB keystore', () => {
+  let controller; let usbState; let prefs; let pwdCache; let key;
+
+  const KEY = {getKeyID: () => ({toHex: () => 'a1b2c3d4'})};
+
+  beforeEach(() => {
+    jest.resetModules();
+    usbState = require('../../../src/modules/usb/state');
+    prefs = require('../../../src/modules/prefs');
+    pwdCache = require('../../../src/modules/pwdCache');
+    key = require('../../../src/modules/key');
+    key.getUserInfo.mockResolvedValue({userId: 'Tester <tester@test.com>'});
+    prefs.prefs.security.password_cache = true;
+    const PwdController = require('../../../src/controller/pwd.controller').default;
+    controller = new PwdController();
+    controller.options = {key: KEY, reason: ''};
+    controller.ports = {pwdDialog: {emit: jest.fn()}};
+  });
+
+  function initData() {
+    return controller.handlers.get('pwd-dialog-init')()
+    .then(() => controller.ports.pwdDialog.emit.mock.calls[0][1]);
+  }
+
+  async function confirm(cache) {
+    controller.passwordRequest = Promise.withResolvers();
+    pwdCache.unlock.mockResolvedValue(KEY);
+    await controller.handlers.get('pwd-dialog-ok')({password: 'secret', cache});
+    return controller.passwordRequest.promise;
+  }
+
+  it('offers the box from the preference when no keystore is configured', async () => {
+    usbState.isConfigured.mockResolvedValue(false);
+    await expect(initData()).resolves.toMatchObject({cache: true, cacheDisabled: false});
+  });
+
+  // The bug: checked, and caching nothing.
+  it('offers the box off and disabled while keys are on a USB device', async () => {
+    usbState.isConfigured.mockResolvedValue(true);
+    await expect(initData()).resolves.toMatchObject({cache: false, cacheDisabled: true});
+  });
+
+  it('records a changed choice as the preference in the normal case', async () => {
+    usbState.isConfigured.mockResolvedValue(false);
+    await confirm(false);
+    expect(prefs.update).toHaveBeenCalledWith({security: {password_cache: false}});
+  });
+
+  // Otherwise the dialog's forced-off box silently turns the user's own setting off,
+  // and turning the keystore off later would leave it that way.
+  it('leaves the preference alone while keys are on a USB device', async () => {
+    usbState.isConfigured.mockResolvedValue(true);
+    await confirm(false);
+    expect(prefs.update).not.toHaveBeenCalled();
+    expect(prefs.prefs.security.password_cache).toBe(true);
+  });
+});

--- a/test/unit/modules/keyStore.test.js
+++ b/test/unit/modules/keyStore.test.js
@@ -1,0 +1,79 @@
+/**
+ * Copyright (C) 2026 Noam Rathaus
+ * Licensed under the GNU Affero General Public License version 3
+ *
+ * A keyring is reloaded by clearing it and loading it again, and both call sites did
+ * exactly that. With two keys the gap between the two is invisible; with four hundred
+ * read off a USB device it lasts seconds, and anything reading in that window sees a
+ * fraction of the keyring -- a key list missing most of its rows, or a decryption
+ * that cannot find a key that is present. Nothing asks again afterwards, because a
+ * short list does not look wrong.
+ */
+
+import {KeyStoreBase} from '../../../src/modules/keyStore';
+
+/** A store whose load() arrives one key at a time, as the real ones do. */
+class SlowStore extends KeyStoreBase {
+  constructor(id) {
+    super(id);
+    this.generation = SlowStore.generation;
+    this.defaultKeyFpr = '';
+  }
+
+  async load() {
+    for (const key of SlowStore.contents) {
+      await Promise.resolve();
+      this.publicKeys.push(`${key}-${this.generation}`);
+    }
+    this.defaultKeyFpr = `default-${this.generation}`;
+  }
+}
+SlowStore.contents = ['a', 'b', 'c', 'd'];
+SlowStore.generation = 1;
+
+describe('KeyStoreBase.reload', () => {
+  let store;
+
+  beforeEach(async () => {
+    SlowStore.generation = 1;
+    store = new SlowStore('localhost|#|mailvelope');
+    await store.load();
+    SlowStore.generation = 2;
+  });
+
+  it('leaves the previous keys in place until the new ones have all arrived', async () => {
+    const observed = [];
+    const reloading = store.reload();
+    // Watch the keyring the way a page does: read it repeatedly while the reload runs.
+    for (let i = 0; i < SlowStore.contents.length * 2; i++) {
+      await Promise.resolve();
+      observed.push(store.publicKeys.keys.length);
+    }
+    await reloading;
+    // Never a count between the two generations, and never zero.
+    expect(observed.every(count => count === SlowStore.contents.length)).toBe(true);
+  });
+
+  it('replaces the keys with the new generation', async () => {
+    await store.reload();
+    expect(store.publicKeys.keys).toEqual(['a-2', 'b-2', 'c-2', 'd-2']);
+  });
+
+  // KeyStoreGPG's load() also sets defaultKeyFpr, which a swap of only the key arrays
+  // would leave behind on the discarded store.
+  it('carries over everything else load() populates', async () => {
+    await store.reload();
+    expect(store.defaultKeyFpr).toBe('default-2');
+    expect(store.id).toBe('localhost|#|mailvelope');
+  });
+
+  it('reflects a keyring that has become empty', async () => {
+    SlowStore.contents = [];
+    try {
+      await store.reload();
+      expect(store.publicKeys.keys).toEqual([]);
+    } finally {
+      SlowStore.contents = ['a', 'b', 'c', 'd'];
+    }
+  });
+});

--- a/test/unit/modules/keyring.test.js
+++ b/test/unit/modules/keyring.test.js
@@ -9,6 +9,7 @@ jest.mock('openpgp', () => ({
 jest.mock('@openpgp/web-stream-tools', () => ({readToEnd: jest.fn()}), {virtual: true});
 jest.mock('../../../src/modules/KeyringGPG', () => ({default: class {}}));
 jest.mock('../../../src/modules/KeyStoreGPG', () => ({default: class {}}));
+jest.mock('../../../src/modules/usb/state', () => ({isEnabled: jest.fn(() => false)}));
 jest.mock('../../../src/lib/browser.runtime', () => ({
   gpgme: null,
   initNativeMessaging: jest.fn()
@@ -83,5 +84,95 @@ describe('keyring hasAnyPrivateKey', () => {
       [`mvelo.keyring.${otherKeyringId}.privateKeys`]: ['-----BEGIN PGP PRIVATE KEY BLOCK-----']
     });
     await expect(hasAnyPrivateKey()).resolves.toBe(true);
+  });
+});
+
+// GnuPG keeps secret keys in the OS home directory, which is exactly what a USB
+// keystore exists to avoid, so it must disappear from key selection and from the
+// keyring listing while that backend is active.
+//
+// The module-level mocks below make gpgme unavailable, which makes initGPG() delete
+// the GnuPG keyring outright -- so these tests override them per-case, otherwise the
+// keyring would never be registered and the assertions would pass vacuously.
+describe('keyring GnuPG exclusion in USB mode', () => {
+  let keyring; let usbState;
+
+  function loadWithGnupgAvailable() {
+    jest.resetModules();
+    jest.doMock('../../../src/lib/browser.runtime', () => ({
+      gpgme: {Keyring: {}},
+      initNativeMessaging: jest.fn()
+    }));
+    jest.doMock('../../../src/modules/KeyStoreGPG', () => ({
+      __esModule: true,
+      default: class {
+        constructor(id) {
+          this.id = id;
+        }
+
+        async load() {}
+
+        clear() {}
+
+        getAllKeys() {
+          return [];
+        }
+      }
+    }));
+    jest.doMock('../../../src/modules/KeyringGPG', () => ({
+      __esModule: true,
+      default: class {
+        constructor(id, keystore) {
+          this.id = id;
+          this.keystore = keystore;
+        }
+
+        getAttr() {
+          return {};
+        }
+      }
+    }));
+    usbState = require('../../../src/modules/usb/state');
+    keyring = require('../../../src/modules/keyring');
+  }
+
+  beforeEach(() => {
+    chrome.storage.local.get.mockReset();
+    chrome.storage.local.set.mockReset();
+    // init() only awaits initGPG() when this is not the first load of the session;
+    // on a first load it is fired and forgotten, so the GnuPG keyring would not yet
+    // be registered when the assertions run.
+    chrome.storage.session.get.mockResolvedValue({keyringLoaded: true});
+  });
+
+  async function withBothKeyrings() {
+    seedStorage({'mvelo.keyring.attributes': {[MAIN_KEYRING_ID]: {}, [GNUPG_KEYRING_ID]: {}}});
+    await keyring.init();
+  }
+
+  it('registers and lists the GnuPG keyring when keys are stored locally', async () => {
+    loadWithGnupgAvailable();
+    usbState.isEnabled.mockReturnValue(false);
+    await withBothKeyrings();
+    expect(Object.keys(await keyring.getAllKeyringAttr())).toContain(GNUPG_KEYRING_ID);
+    expect((await keyring.getAll()).map(k => k.id)).toContain(GNUPG_KEYRING_ID);
+  });
+
+  it('hides the GnuPG keyring from the listing in USB mode', async () => {
+    loadWithGnupgAvailable();
+    usbState.isEnabled.mockReturnValue(true);
+    await withBothKeyrings();
+    const attrs = await keyring.getAllKeyringAttr();
+    expect(Object.keys(attrs)).not.toContain(GNUPG_KEYRING_ID);
+    expect(Object.keys(attrs)).toContain(MAIN_KEYRING_ID);
+  });
+
+  it('excludes the GnuPG keyring from getAll in USB mode', async () => {
+    loadWithGnupgAvailable();
+    usbState.isEnabled.mockReturnValue(true);
+    await withBothKeyrings();
+    const ids = (await keyring.getAll()).map(k => k.id);
+    expect(ids).not.toContain(GNUPG_KEYRING_ID);
+    expect(ids).toContain(MAIN_KEYRING_ID);
   });
 });

--- a/test/unit/modules/keyring.test.js
+++ b/test/unit/modules/keyring.test.js
@@ -9,7 +9,7 @@ jest.mock('openpgp', () => ({
 jest.mock('@openpgp/web-stream-tools', () => ({readToEnd: jest.fn()}), {virtual: true});
 jest.mock('../../../src/modules/KeyringGPG', () => ({default: class {}}));
 jest.mock('../../../src/modules/KeyStoreGPG', () => ({default: class {}}));
-jest.mock('../../../src/modules/usb/state', () => ({isEnabled: jest.fn(() => false)}));
+jest.mock('../../../src/modules/usb/state', () => ({isEnabled: jest.fn(() => false), isUsable: jest.fn(() => true)}));
 jest.mock('../../../src/lib/browser.runtime', () => ({
   gpgme: null,
   initNativeMessaging: jest.fn()
@@ -174,5 +174,52 @@ describe('keyring GnuPG exclusion in USB mode', () => {
     const ids = (await keyring.getAll()).map(k => k.id);
     expect(ids).not.toContain(GNUPG_KEYRING_ID);
     expect(ids).toContain(MAIN_KEYRING_ID);
+  });
+});
+
+// init() treats a failure while building a keyring as a broken keyring and deletes
+// it from the attribute map. Sanitising writes the keyring back, and that write
+// fails when the USB device holding it is absent -- so an unplugged device at
+// startup could deregister the keyring, permanently for client-API keyrings whose
+// keys would then be stranded on the device.
+describe('keyring sanitisation with an absent USB keystore', () => {
+  let keyring; let usbState;
+
+  const API_KEYRING = 'example.com|#|someapp';
+
+  beforeEach(() => {
+    jest.resetModules();
+    chrome.storage.local.get.mockReset();
+    chrome.storage.local.set.mockReset();
+    chrome.storage.session.get.mockResolvedValue({keyringLoaded: true});
+    usbState = require('../../../src/modules/usb/state');
+    keyring = require('../../../src/modules/keyring');
+    // A keyring that has never been sanitised, so sanitiseKeyring() will try to write.
+    seedStorage({'mvelo.keyring.attributes': {[MAIN_KEYRING_ID]: {}, [API_KEYRING]: {}}});
+  });
+
+  it('keeps the keyring registered when the device is absent', async () => {
+    usbState.isEnabled.mockReturnValue(true);
+    usbState.isUsable.mockReturnValue(false);
+    await keyring.init();
+    const attrs = await keyring.getAllKeyringAttr();
+    expect(Object.keys(attrs)).toContain(API_KEYRING);
+    // Deferred, not done: the flag stays unset so it happens on a later start.
+    expect(attrs[API_KEYRING].sanitized).toBeUndefined();
+  });
+
+  it('sanitises normally when the device is present', async () => {
+    usbState.isEnabled.mockReturnValue(true);
+    usbState.isUsable.mockReturnValue(true);
+    await keyring.init();
+    const attrs = await keyring.getAllKeyringAttr();
+    expect(attrs[API_KEYRING].sanitized).toBe(true);
+  });
+
+  it('sanitises normally with no USB keystore configured', async () => {
+    usbState.isEnabled.mockReturnValue(false);
+    await keyring.init();
+    const attrs = await keyring.getAllKeyringAttr();
+    expect(attrs[API_KEYRING].sanitized).toBe(true);
   });
 });

--- a/test/unit/modules/pwdCache.usb.test.js
+++ b/test/unit/modules/pwdCache.usb.test.js
@@ -1,0 +1,74 @@
+/**
+ * Copyright (C) 2026 Noam Rathaus
+ * Licensed under the GNU Affero General Public License version 3
+ *
+ * The passphrase cache must not run while keys live on a USB device.
+ *
+ * Caching an entry makes chrome.alarms hold an alarm named PWD_ALARM_<fingerprint>,
+ * and Chrome persists alarm names to disk with persistAcrossSessions. That writes the
+ * fingerprint of a device-resident key into the local profile, where LevelDB's
+ * append-only log keeps it readable long after the alarm is cleared -- found on a real
+ * profile seven hours after the alarm had fired.
+ */
+
+jest.mock('../../../src/modules/usb/state', () => ({
+  isConfigured: jest.fn()
+}));
+
+jest.mock('../../../src/modules/prefs', () => ({
+  prefs: {security: {password_cache: true, password_timeout: 30}},
+  addUpdateHandler: jest.fn()
+}));
+
+import * as pwdCache from '../../../src/modules/pwdCache';
+import {isConfigured} from '../../../src/modules/usb/state';
+
+// Enough of a key for the cache: it only ever asks for the fingerprint.
+const KEY = {getFingerprint: () => '853078005387ddf48abb3f2aa038e019ea980beb'};
+
+describe('pwdCache with a USB keystore', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    pwdCache.initSession();
+    pwdCache.init();
+  });
+
+  it('caches normally when no USB keystore is configured', async () => {
+    isConfigured.mockResolvedValue(false);
+    await pwdCache.set({key: KEY, password: 'secret'});
+    expect(await pwdCache.isCached(KEY.getFingerprint())).toBe(true);
+  });
+
+  it('does not cache while keys are on a USB device', async () => {
+    isConfigured.mockResolvedValue(true);
+    await pwdCache.set({key: KEY, password: 'secret'});
+    expect(await pwdCache.isCached(KEY.getFingerprint())).toBe(false);
+  });
+
+  // The fingerprint reaches disk through the alarm name, so the test that matters is
+  // that no alarm is created at all -- not merely that the entry is absent.
+  it('creates no fingerprint-named alarm while keys are on a USB device', async () => {
+    isConfigured.mockResolvedValue(true);
+    await pwdCache.set({key: KEY, password: 'secret'});
+    const calls = chrome.alarms.create.mock.calls || [];
+    const named = calls.filter(([name]) =>
+      typeof name === 'string' && name.includes(KEY.getFingerprint()));
+    expect(named).toHaveLength(0);
+  });
+
+  // unlock() has its own `active` check, but privateKey.controller calls set()
+  // directly and bypasses it -- which is why the gate lives in set().
+  it('gates set() itself, not only the unlock path', async () => {
+    isConfigured.mockResolvedValue(true);
+    await pwdCache.set({key: KEY, password: 'secret', reservedOperations: 0});
+    expect(isConfigured).toHaveBeenCalled();
+  });
+
+  // A storage read is used rather than the in-memory enabled flag, because the flag
+  // reads false until the first probe and a false negative here permits the leak.
+  it('asks storage rather than trusting an uninitialised flag', async () => {
+    isConfigured.mockResolvedValue(true);
+    await pwdCache.set({key: KEY, password: 'secret'});
+    expect(isConfigured).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/unit/modules/usb/FsaBackend.support.test.js
+++ b/test/unit/modules/usb/FsaBackend.support.test.js
@@ -1,0 +1,46 @@
+/**
+ * Copyright (C) 2026 Noam Rathaus
+ * Licensed under the GNU Affero General Public License version 3
+ *
+ * Firefox implements FileSystemDirectoryHandle for the origin-private file system
+ * but has no showDirectoryPicker, so a feature test on the handle alone reports
+ * support in a browser that cannot reach a USB device at all. The picker cannot be
+ * tested for directly -- it does not exist in the background context in any browser
+ * -- so the browser itself is the signal.
+ */
+
+describe('FsaBackend.isSupported', () => {
+  let FsaBackend;
+
+  function load({chrome: isChrome, handle}) {
+    jest.resetModules();
+    jest.doMock('../../../../src/lib/browser', () => ({isChrome, isFirefox: !isChrome}));
+    if (handle) {
+      global.FileSystemDirectoryHandle = class {};
+    } else {
+      delete global.FileSystemDirectoryHandle;
+    }
+    FsaBackend = require('../../../../src/modules/usb/FsaBackend').default;
+  }
+
+  afterEach(() => {
+    delete global.FileSystemDirectoryHandle;
+    jest.dontMock('../../../../src/lib/browser');
+  });
+
+  it('is supported on Chromium with the API present', () => {
+    load({chrome: true, handle: true});
+    expect(FsaBackend.isSupported()).toBe(true);
+  });
+
+  // The case that matters: Firefox has the handle class but no picker.
+  it('is not supported on Firefox even though the handle class exists', () => {
+    load({chrome: false, handle: true});
+    expect(FsaBackend.isSupported()).toBe(false);
+  });
+
+  it('is not supported on Chromium without the API', () => {
+    load({chrome: true, handle: false});
+    expect(FsaBackend.isSupported()).toBe(false);
+  });
+});

--- a/test/unit/modules/usb/FsaBackend.test.js
+++ b/test/unit/modules/usb/FsaBackend.test.js
@@ -1,0 +1,293 @@
+/**
+ * Copyright (C) 2026 Noam Rathaus
+ * Licensed under the GNU Affero General Public License version 3
+ *
+ * Covers the File System Access backend against a fake filesystem.
+ *
+ * Worth testing here rather than by hand: the write path stages to a .tmp file,
+ * verifies it round-trips, rotates the previous generation to .bak and only then
+ * moves the staged file into place. A device pulled mid-save must leave either the
+ * old file or a recoverable .bak, never a truncated primary — and that is precisely
+ * what a tmpfs test directory cannot demonstrate.
+ */
+
+jest.mock('../../../../src/modules/usb/handleStore', () => ({
+  get: jest.fn(),
+  put: jest.fn(),
+  remove: jest.fn()
+}));
+
+/** Minimal stand-in for the FileSystemDirectoryHandle tree. */
+function makeDir(name = '') {
+  const entries = new Map();
+  const dir = {
+    kind: 'directory',
+    name,
+    entries,
+    permission: 'granted',
+    async queryPermission() {
+      return dir.permission;
+    },
+    async getDirectoryHandle(childName, {create = false} = {}) {
+      if (!entries.has(childName)) {
+        if (!create) {
+          throw Object.assign(new Error('missing'), {name: 'NotFoundError'});
+        }
+        entries.set(childName, makeDir(childName));
+      }
+      const child = entries.get(childName);
+      if (child.kind !== 'directory') {
+        throw Object.assign(new Error('not a directory'), {name: 'TypeMismatchError'});
+      }
+      return child;
+    },
+    async getFileHandle(childName, {create = false} = {}) {
+      if (!entries.has(childName)) {
+        if (!create) {
+          throw Object.assign(new Error('missing'), {name: 'NotFoundError'});
+        }
+        entries.set(childName, makeFile(childName, dir, ''));
+      }
+      return entries.get(childName);
+    },
+    async removeEntry(childName) {
+      if (!entries.has(childName)) {
+        throw Object.assign(new Error('missing'), {name: 'NotFoundError'});
+      }
+      entries.delete(childName);
+    },
+    async* keys() {
+      for (const key of entries.keys()) {
+        yield key;
+      }
+    }
+  };
+  return dir;
+}
+
+function makeFile(name, parent, content) {
+  const file = {
+    kind: 'file',
+    name,
+    parent,
+    content,
+    async getFile() {
+      return {text: async () => file.content};
+    },
+    async createWritable() {
+      let buffer = '';
+      return {
+        write: async chunk => {
+          buffer += chunk;
+        },
+        close: async () => {
+          file.content = buffer;
+        }
+      };
+    },
+    async move(destDir, newName) {
+      file.parent.entries.delete(file.name);
+      file.name = newName ?? file.name;
+      file.parent = destDir;
+      destDir.entries.set(file.name, file);
+    }
+  };
+  return file;
+}
+
+/** Read a file's content from the tree by '/'-separated path, or undefined. */
+function read(root, path) {
+  const parts = path.split('/');
+  let node = root;
+  for (const part of parts.slice(0, -1)) {
+    node = node.entries.get(part);
+    if (!node) {
+      return undefined;
+    }
+  }
+  return node.entries.get(parts[parts.length - 1])?.content;
+}
+
+describe('usb/FsaBackend', () => {
+  let FsaBackend; let handleStore; let backend; let root; let errors;
+
+  beforeEach(() => {
+    jest.resetModules();
+    handleStore = require('../../../../src/modules/usb/handleStore');
+    FsaBackend = require('../../../../src/modules/usb/FsaBackend').default;
+    errors = require('../../../../src/modules/usb/backend');
+    root = makeDir('device');
+    handleStore.get.mockResolvedValue(root);
+    backend = new FsaBackend();
+  });
+
+  describe('probe', () => {
+    it('reports not configured when no handle is stored', async () => {
+      handleStore.get.mockResolvedValue(undefined);
+      expect(await backend.probe()).toEqual({available: false, permission: 'prompt', configured: false});
+    });
+
+    it('reports the permission when it has not been granted', async () => {
+      root.permission = 'prompt';
+      expect(await backend.probe()).toEqual({available: false, permission: 'prompt', configured: true});
+    });
+
+    it('reports available when granted', async () => {
+      expect(await backend.probe()).toEqual({available: true, permission: 'granted', configured: true});
+    });
+
+    // Some builds reject queryPermission once the underlying entry is gone.
+    it('survives queryPermission throwing', async () => {
+      root.queryPermission = async () => {
+        throw new Error('entry gone');
+      };
+      expect(await backend.probe()).toEqual({available: false, permission: 'prompt', configured: true});
+    });
+  });
+
+  describe('readFile', () => {
+    it('reads a nested file', async () => {
+      const dir = await root.getDirectoryHandle('mailvelope-keystore', {create: true});
+      const file = await dir.getFileHandle('keystore.json', {create: true});
+      file.content = '{"a":1}';
+      expect(await backend.readFile('mailvelope-keystore/keystore.json')).toBe('{"a":1}');
+    });
+
+    it('raises NotFoundError for a missing file', async () => {
+      await root.getDirectoryHandle('mailvelope-keystore', {create: true});
+      await expect(backend.readFile('mailvelope-keystore/nope.json'))
+      .rejects.toBeInstanceOf(errors.NotFoundError);
+    });
+
+    it('raises NotFoundError for a missing directory', async () => {
+      await expect(backend.readFile('no-such-dir/file.json'))
+      .rejects.toBeInstanceOf(errors.NotFoundError);
+    });
+
+    // An unplugged device surfaces as NotReadableError rather than NotFoundError.
+    it('maps an unreadable device to DeviceUnavailableError', async () => {
+      root.getDirectoryHandle = async () => {
+        throw Object.assign(new Error('gone'), {name: 'NotReadableError'});
+      };
+      await expect(backend.readFile('mailvelope-keystore/keystore.json'))
+      .rejects.toBeInstanceOf(errors.DeviceUnavailableError);
+    });
+
+    it('raises DeviceUnavailableError when no handle is configured', async () => {
+      handleStore.get.mockResolvedValue(undefined);
+      await expect(backend.readFile('a/b')).rejects.toBeInstanceOf(errors.DeviceUnavailableError);
+    });
+  });
+
+  describe('writeFile', () => {
+    it('creates parent directories and writes the content', async () => {
+      await backend.writeFile('mailvelope-keystore/keyrings/abc/private.asc', 'KEY');
+      expect(read(root, 'mailvelope-keystore/keyrings/abc/private.asc')).toBe('KEY');
+    });
+
+    it('leaves no .tmp file behind on success', async () => {
+      await backend.writeFile('mailvelope-keystore/a.asc', 'ONE');
+      const dir = root.entries.get('mailvelope-keystore');
+      expect([...dir.entries.keys()]).not.toContain('a.asc.tmp');
+    });
+
+    it('keeps the previous generation as .bak when overwriting', async () => {
+      await backend.writeFile('mailvelope-keystore/a.asc', 'ONE');
+      await backend.writeFile('mailvelope-keystore/a.asc', 'TWO');
+      expect(read(root, 'mailvelope-keystore/a.asc')).toBe('TWO');
+      expect(read(root, 'mailvelope-keystore/a.asc.bak')).toBe('ONE');
+    });
+
+    it('replaces an existing .bak rather than failing on the second overwrite', async () => {
+      await backend.writeFile('mailvelope-keystore/a.asc', 'ONE');
+      await backend.writeFile('mailvelope-keystore/a.asc', 'TWO');
+      await backend.writeFile('mailvelope-keystore/a.asc', 'THREE');
+      expect(read(root, 'mailvelope-keystore/a.asc')).toBe('THREE');
+      expect(read(root, 'mailvelope-keystore/a.asc.bak')).toBe('TWO');
+    });
+
+    // The point of staging: a bad write must not replace good data.
+    it('does not touch the primary file when the staged copy fails verification', async () => {
+      await backend.writeFile('mailvelope-keystore/a.asc', 'GOOD');
+      const dir = root.entries.get('mailvelope-keystore');
+      const originalGetFileHandle = dir.getFileHandle.bind(dir);
+      dir.getFileHandle = async (name, opts) => {
+        const handle = await originalGetFileHandle(name, opts);
+        if (name.endsWith('.tmp')) {
+          // Simulate a short write: the staged file does not match what we asked for.
+          handle.getFile = async () => ({text: async () => 'TRUNCATED'});
+        }
+        return handle;
+      };
+      await expect(backend.writeFile('mailvelope-keystore/a.asc', 'NEW')).rejects.toThrow(/verification/i);
+      expect(read(root, 'mailvelope-keystore/a.asc')).toBe('GOOD');
+    });
+
+    it('reports a device pulled mid-write as DeviceUnavailableError', async () => {
+      const dir = await root.getDirectoryHandle('mailvelope-keystore', {create: true});
+      dir.getFileHandle = async () => {
+        throw Object.assign(new Error('gone'), {name: 'NotReadableError'});
+      };
+      await expect(backend.writeFile('mailvelope-keystore/a.asc', 'X'))
+      .rejects.toBeInstanceOf(errors.DeviceUnavailableError);
+    });
+
+    // move() is Chromium 111+; without it the write is less safe but must still work.
+    it('falls back to a direct write when move() is unavailable', async () => {
+      const dir = await root.getDirectoryHandle('mailvelope-keystore', {create: true});
+      const originalGetFileHandle = dir.getFileHandle.bind(dir);
+      dir.getFileHandle = async (name, opts) => {
+        const handle = await originalGetFileHandle(name, opts);
+        delete handle.move;
+        return handle;
+      };
+      await backend.writeFile('mailvelope-keystore/a.asc', 'ONE');
+      expect(read(root, 'mailvelope-keystore/a.asc')).toBe('ONE');
+      expect([...dir.entries.keys()]).not.toContain('a.asc.tmp');
+    });
+  });
+
+  describe('removeFile', () => {
+    it('removes an existing file', async () => {
+      await backend.writeFile('mailvelope-keystore/a.asc', 'ONE');
+      await backend.removeFile('mailvelope-keystore/a.asc');
+      expect(read(root, 'mailvelope-keystore/a.asc')).toBeUndefined();
+    });
+
+    it('treats a missing file as already gone', async () => {
+      await root.getDirectoryHandle('mailvelope-keystore', {create: true});
+      await expect(backend.removeFile('mailvelope-keystore/nope.asc')).resolves.toBeUndefined();
+    });
+
+    it('treats a missing directory as already gone', async () => {
+      await expect(backend.removeFile('no-dir/nope.asc')).resolves.toBeUndefined();
+    });
+  });
+
+  describe('listDir', () => {
+    it('lists entry names', async () => {
+      await backend.writeFile('mailvelope-keystore/keyrings/abc/private.asc', 'K');
+      await backend.writeFile('mailvelope-keystore/keyrings/def/private.asc', 'K');
+      expect((await backend.listDir('mailvelope-keystore/keyrings')).sort()).toEqual(['abc', 'def']);
+    });
+
+    it('returns nothing for a missing directory', async () => {
+      expect(await backend.listDir('mailvelope-keystore/keyrings')).toEqual([]);
+    });
+  });
+
+  describe('handle caching', () => {
+    it('reads the stored handle once and reuses it', async () => {
+      await backend.probe();
+      await backend.probe();
+      expect(handleStore.get).toHaveBeenCalledTimes(1);
+    });
+
+    it('re-reads after the cache is cleared, so a re-provision takes effect', async () => {
+      await backend.probe();
+      backend.clearCache();
+      await backend.probe();
+      expect(handleStore.get).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/test/unit/modules/usb/NativeBackend.chunking.test.js
+++ b/test/unit/modules/usb/NativeBackend.chunking.test.js
@@ -1,0 +1,178 @@
+/**
+ * Copyright (C) 2026 Noam Rathaus
+ * Licensed under the GNU Affero General Public License version 3
+ *
+ * A browser drops a native message over 1 MB before the extension sees it, and the
+ * helper refused an oversized message in the other direction -- so importing a
+ * public keyring exported with `gpg --export --armor` failed at the save with
+ * "message of 1392580 bytes exceeds the limit", and could not have been read back
+ * even if it had been written.
+ *
+ * These tests drive the backend against a fake helper that implements the offset
+ * protocol, because the part that can silently corrupt a keyring is the bookkeeping:
+ * a chunk written at the wrong offset, or a character split across two chunks.
+ */
+
+describe('NativeBackend chunking', () => {
+  let NativeBackend;
+  let savedRuntime;
+  let host;
+
+  /** Bytes of content per message, as the backend uses. */
+  const CHUNK = 384 * 1024;
+
+  /**
+   * A fake helper: one in-memory file per path, with the host's own offset rules.
+   */
+  function fakeHost() {
+    const files = new Map();
+    const staged = new Map();
+    const requests = [];
+    const encoder = new TextEncoder();
+    const decoder = new TextDecoder();
+    const handle = request => {
+      requests.push(request);
+      if (request.op === 'hello') {
+        return {version: 1, chunkBytes: CHUNK, maxFileBytes: 16 * 1024 * 1024};
+      }
+      if (request.op === 'write') {
+        const data = encoder.encode(request.content);
+        const previous = staged.get(request.path) ?? new Uint8Array(0);
+        const offset = request.offset ?? 0;
+        if (offset && offset !== previous.length) {
+          return {error: 'bad_offset', message: `staged write holds ${previous.length} bytes`};
+        }
+        const base = offset ? previous : new Uint8Array(0);
+        const merged = new Uint8Array(base.length + data.length);
+        merged.set(base);
+        merged.set(data, base.length);
+        staged.set(request.path, merged);
+        if (request.final) {
+          files.set(request.path, merged);
+          staged.delete(request.path);
+        }
+        return {ok: true};
+      }
+      if (request.op === 'read') {
+        const bytes = files.get(request.path);
+        if (!bytes) {
+          return {error: 'not_found', message: 'no such file'};
+        }
+        const offset = request.offset ?? 0;
+        let end = Math.min(offset + Math.min(request.maxBytes ?? CHUNK, CHUNK), bytes.length);
+        while (end > offset && end < bytes.length && (bytes[end] & 0xc0) === 0x80) {
+          end -= 1;
+        }
+        return {
+          content: decoder.decode(bytes.subarray(offset, end)),
+          offset,
+          bytesRead: end - offset,
+          nextOffset: end,
+          size: bytes.length,
+          eof: end >= bytes.length
+        };
+      }
+      return {error: 'unknown_op', message: request.op};
+    };
+    return {
+      files,
+      requests,
+      send: request => {
+        const answer = handle(request);
+        return Promise.resolve(answer.error ? answer : {result: answer});
+      },
+      text: path => decoder.decode(files.get(path))
+    };
+  }
+
+  function backendFor(fake) {
+    global.chrome.runtime = {
+      sendNativeMessage: jest.fn((_name, request) => fake.send(request)),
+      lastError: undefined
+    };
+    const backend = new NativeBackend();
+    backend.setRoot('/run/media/u/STICK');
+    return backend;
+  }
+
+  beforeEach(() => {
+    jest.resetModules();
+    savedRuntime = global.chrome.runtime;
+    NativeBackend = require('../../../../src/modules/usb/NativeBackend').default;
+    host = fakeHost();
+  });
+
+  afterEach(() => {
+    global.chrome.runtime = savedRuntime;
+  });
+
+  // The failure that started this: a whole exported public keyring.
+  it('writes and reads back a keyring larger than a single message', async () => {
+    const block = `${'-----BEGIN PGP PUBLIC KEY BLOCK-----\n'}${'mQINBF'.repeat(200)}\n-----END PGP PUBLIC KEY BLOCK-----\n`;
+    const keyring = block.repeat(1200); // comfortably over 1 MB
+    expect(new TextEncoder().encode(keyring).length).toBeGreaterThan(1024 * 1024);
+    const backend = backendFor(host);
+    await backend.writeFile('mailvelope-keystore/keyrings/00/public.asc', keyring);
+    const read = await backend.readFile('mailvelope-keystore/keyrings/00/public.asc');
+    expect(read).toBe(keyring);
+  });
+
+  it('sends chunks in order, each starting where the last ended', async () => {
+    const content = 'x'.repeat(CHUNK * 2 + 17);
+    const backend = backendFor(host);
+    await backend.writeFile('mailvelope-keystore/public.asc', content);
+    const writes = host.requests.filter(r => r.op === 'write');
+    expect(writes.map(r => r.offset)).toEqual([0, CHUNK, CHUNK * 2]);
+    expect(writes.map(r => r.final)).toEqual([false, false, true]);
+  });
+
+  // One message per small file: the common case must not pay for the large one.
+  it('writes a small file in a single final message', async () => {
+    const backend = backendFor(host);
+    await backend.writeFile('mailvelope-keystore/meta.json', '{"a":1}');
+    const writes = host.requests.filter(r => r.op === 'write');
+    expect(writes).toHaveLength(1);
+    expect(writes[0]).toMatchObject({offset: 0, final: true, content: '{"a":1}'});
+  });
+
+  it('writes an empty file rather than nothing at all', async () => {
+    const backend = backendFor(host);
+    await backend.writeFile('mailvelope-keystore/meta.json', '');
+    expect(host.requests.filter(r => r.op === 'write')).toHaveLength(1);
+    expect(host.text('mailvelope-keystore/meta.json')).toBe('');
+  });
+
+  // A user ID with a non-ASCII name lands on a chunk boundary sooner or later. Split
+  // a character across two chunks and both halves are lost, silently.
+  it('never splits a multi-byte character across chunks', async () => {
+    // 'é' is two bytes, so the boundary falls inside a character.
+    const content = `${'a'.repeat(CHUNK - 1)}${'é'.repeat(2000)}`;
+    const backend = backendFor(host);
+    await backend.writeFile('mailvelope-keystore/public.asc', content);
+    expect(host.text('mailvelope-keystore/public.asc')).toBe(content);
+    expect(await backend.readFile('mailvelope-keystore/public.asc')).toBe(content);
+  });
+
+  it('reports a missing file as not found, chunked read or not', async () => {
+    const backend = backendFor(host);
+    await expect(backend.readFile('mailvelope-keystore/public.asc')).rejects.toMatchObject({
+      code: 'USB_NOT_FOUND'
+    });
+  });
+
+  // A helper that claims neither progress nor the end of the file would otherwise be
+  // read in a loop that never ends.
+  it('gives up on a helper that stops making progress', async () => {
+    global.chrome.runtime = {
+      sendNativeMessage: jest.fn(() => Promise.resolve({
+        result: {content: '', offset: 0, bytesRead: 0, nextOffset: 0, size: 10, eof: false}
+      })),
+      lastError: undefined
+    };
+    const backend = new NativeBackend();
+    backend.setRoot('/run/media/u/STICK');
+    await expect(backend.readFile('mailvelope-keystore/public.asc')).rejects.toMatchObject({
+      code: 'USB_HOST_PROTOCOL'
+    });
+  });
+});

--- a/test/unit/modules/usb/NativeBackend.support.test.js
+++ b/test/unit/modules/usb/NativeBackend.support.test.js
@@ -85,6 +85,43 @@ describe('NativeBackend.isSupported', () => {
     });
   });
 
+  describe('probe', () => {
+    function withHost(reply) {
+      global.chrome.runtime = {
+        sendNativeMessage: jest.fn(() => Promise.resolve(reply)),
+        lastError: undefined
+      };
+    }
+
+    // probe() discarded the helper's answer and returned a fixed object, so a
+    // write-protected device still reported as fully usable and the write was
+    // attempted anyway. The helper is the only source that can answer this before
+    // a write, since the File System Access API cannot.
+    it('forwards writability reported by the helper', async () => {
+      withHost({result: {version: 1, writable: false}});
+      const backend = new NativeBackend();
+      backend.setRoot('/run/media/u/STICK');
+      // hello and probe both answer from the same stub, which is enough here.
+      const result = await backend.probe();
+      expect(result.writable).toBe(false);
+    });
+
+    it('treats a writable device as writable', async () => {
+      withHost({result: {version: 1, writable: true}});
+      const backend = new NativeBackend();
+      backend.setRoot('/run/media/u/STICK');
+      expect((await backend.probe()).writable).toBe(true);
+    });
+
+    // An older helper that does not report the field must not be read as read-only.
+    it('assumes writable when the helper does not say', async () => {
+      withHost({result: {version: 1}});
+      const backend = new NativeBackend();
+      backend.setRoot('/run/media/u/STICK');
+      expect((await backend.probe()).writable).toBe(true);
+    });
+  });
+
   // Calling without the permission must name the permission, not blame the helper:
   // telling someone to install software they already have is worse than silence.
   it('reports a missing permission distinctly from a missing helper', async () => {

--- a/test/unit/modules/usb/NativeBackend.support.test.js
+++ b/test/unit/modules/usb/NativeBackend.support.test.js
@@ -1,0 +1,98 @@
+/**
+ * Copyright (C) 2026 Noam Rathaus
+ * Licensed under the GNU Affero General Public License version 3
+ *
+ * Firefox hides permission-gated APIs until the permission is granted, and
+ * nativeMessaging is optional. Testing for chrome.runtime.sendNativeMessage
+ * therefore made support read as false until granted -- while the UI that asks for
+ * the grant was itself gated on support. Unreachable by construction, and exactly
+ * what happened in Firefox.
+ */
+
+describe('NativeBackend.isSupported', () => {
+  let NativeBackend;
+  let savedRuntime;
+  let savedPermissions;
+
+  beforeEach(() => {
+    jest.resetModules();
+    savedRuntime = global.chrome.runtime;
+    savedPermissions = global.chrome.permissions;
+    NativeBackend = require('../../../../src/modules/usb/NativeBackend').default;
+  });
+
+  afterEach(() => {
+    global.chrome.runtime = savedRuntime;
+    global.chrome.permissions = savedPermissions;
+  });
+
+  it('is supported when the API is already exposed', () => {
+    global.chrome.runtime = {sendNativeMessage: jest.fn()};
+    global.chrome.permissions = undefined;
+    expect(NativeBackend.isSupported()).toBe(true);
+  });
+
+  // The case that was broken: Firefox before the permission is granted.
+  it('is supported when the API is hidden but the permission can be requested', () => {
+    global.chrome.runtime = {};
+    global.chrome.permissions = {request: jest.fn()};
+    expect(NativeBackend.isSupported()).toBe(true);
+  });
+
+  it('is not supported when neither the API nor a way to request it exists', () => {
+    global.chrome.runtime = {};
+    global.chrome.permissions = undefined;
+    expect(NativeBackend.isSupported()).toBe(false);
+  });
+
+  describe('calling convention', () => {
+    // Firefox exposes chrome.* as an alias for browser.*, and the two have
+    // historically differed on promise versus callback. Assuming promises would make
+    // a callback-only implementation resolve to undefined, which the class reports as
+    // "the helper returned no response" -- a missing-helper message for a working
+    // helper.
+    it('works when the API returns a promise', async () => {
+      global.chrome.runtime = {
+        sendNativeMessage: jest.fn(() => Promise.resolve({result: {version: 1}})),
+        lastError: undefined
+      };
+      const backend = new NativeBackend();
+      await expect(backend.send({op: 'hello'})).resolves.toEqual({version: 1});
+    });
+
+    it('works when the API only calls back', async () => {
+      global.chrome.runtime = {
+        sendNativeMessage: jest.fn((_name, _msg, cb) => cb({result: {version: 1}})),
+        lastError: undefined
+      };
+      const backend = new NativeBackend();
+      await expect(backend.send({op: 'hello'})).resolves.toEqual({version: 1});
+    });
+
+    it('surfaces lastError from the callback path as a helper failure', async () => {
+      global.chrome.runtime = {
+        sendNativeMessage: jest.fn((_name, _msg, cb) => {
+          global.chrome.runtime.lastError = {message: 'no such native application'};
+          cb(undefined);
+        }),
+        lastError: undefined
+      };
+      const backend = new NativeBackend();
+      await expect(backend.send({op: 'hello'})).rejects.toMatchObject({
+        code: 'USB_HOST_UNAVAILABLE'
+      });
+      global.chrome.runtime.lastError = undefined;
+    });
+  });
+
+  // Calling without the permission must name the permission, not blame the helper:
+  // telling someone to install software they already have is worse than silence.
+  it('reports a missing permission distinctly from a missing helper', async () => {
+    global.chrome.runtime = {};
+    global.chrome.permissions = {request: jest.fn()};
+    const backend = new NativeBackend();
+    await expect(backend.send({op: 'hello'})).rejects.toMatchObject({
+      code: 'USB_HOST_PERMISSION'
+    });
+  });
+});

--- a/test/unit/modules/usb/debugLog.test.js
+++ b/test/unit/modules/usb/debugLog.test.js
@@ -1,0 +1,123 @@
+/**
+ * Copyright (C) 2026 Noam Rathaus
+ * Licensed under the GNU Affero General Public License version 3
+ *
+ * A diagnostic log that writes to disk is a liability for an encryption extension,
+ * so the property that matters most is that it stays silent until explicitly turned
+ * on, and forgets what it captured when turned off.
+ */
+
+describe('usb/debugLog', () => {
+  let debugLog; let store;
+
+  function seedStorage(initial = {}) {
+    store = {...initial};
+    chrome.storage.local.get.mockImplementation(key =>
+      Promise.resolve(key in store ? {[key]: store[key]} : {}));
+    chrome.storage.local.set.mockImplementation(obj => {
+      Object.assign(store, obj);
+      return Promise.resolve();
+    });
+    return store;
+  }
+
+  beforeEach(() => {
+    jest.resetModules();
+    chrome.storage.local.get.mockReset();
+    chrome.storage.local.set.mockReset();
+    seedStorage({});
+    debugLog = require('../../../../src/modules/usb/debugLog');
+  });
+
+  describe('disabled by default', () => {
+    it('records nothing and writes nothing', async () => {
+      await debugLog.log('probe', {state: 'READY'});
+      expect(await debugLog.getLog()).toEqual([]);
+      expect(chrome.storage.local.set).not.toHaveBeenCalled();
+    });
+
+    it('ignores errors too', async () => {
+      await debugLog.logError('provision', new Error('boom'));
+      expect(await debugLog.getLog()).toEqual([]);
+    });
+
+    it('treats any stored value other than true as off', async () => {
+      seedStorage({'mvelo.usb.debugEnabled': 'yes'});
+      await debugLog.log('probe');
+      expect(await debugLog.getLog()).toEqual([]);
+    });
+  });
+
+  describe('once enabled', () => {
+    beforeEach(async () => {
+      await debugLog.setEnabled(true);
+      chrome.storage.local.set.mockClear();
+    });
+
+    it('records events with a timestamp', async () => {
+      await debugLog.log('probe', {state: 'ABSENT'});
+      const entries = await debugLog.getLog();
+      expect(entries).toHaveLength(1);
+      expect(entries[0].event).toBe('probe');
+      expect(entries[0].t).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+      expect(entries[0].detail).toContain('ABSENT');
+    });
+
+    it('keeps the identifying parts of an error, not its stack', async () => {
+      const error = new Error('device gone');
+      error.code = 'USB_KEYSTORE_UNAVAILABLE';
+      await debugLog.logError('write', error, {path: 'a/b.asc'});
+      const [entry] = await debugLog.getLog();
+      expect(entry.detail).toContain('USB_KEYSTORE_UNAVAILABLE');
+      expect(entry.detail).toContain('a/b.asc');
+      expect(entry.detail).not.toContain('at Object');
+    });
+
+    // An unbounded log on a device people carry around is its own problem.
+    it('bounds the ring buffer', async () => {
+      for (let i = 0; i < 320; i++) {
+        await debugLog.log('probe', {i});
+      }
+      const entries = await debugLog.getLog();
+      expect(entries).toHaveLength(300);
+      expect(entries[entries.length - 1].detail).toContain('319');
+    });
+
+    it('clips an oversized detail rather than storing it whole', async () => {
+      await debugLog.log('big', 'x'.repeat(5000));
+      const [entry] = await debugLog.getLog();
+      expect(entry.detail.length).toBeLessThan(600);
+      expect(entry.detail.endsWith('…')).toBe(true);
+    });
+  });
+
+  describe('turning it off', () => {
+    // Switching off should also be a way to clean up, not just to stop adding.
+    it('erases what was already captured', async () => {
+      await debugLog.setEnabled(true);
+      await debugLog.log('probe', {state: 'READY'});
+      expect(await debugLog.getLog()).toHaveLength(1);
+
+      await debugLog.setEnabled(false);
+      expect(await debugLog.getLog()).toEqual([]);
+      expect(store['mvelo.usb.debug']).toEqual([]);
+      expect(store['mvelo.usb.debugEnabled']).toBe(false);
+    });
+
+    it('stays silent afterwards', async () => {
+      await debugLog.setEnabled(true);
+      await debugLog.setEnabled(false);
+      await debugLog.log('probe');
+      expect(await debugLog.getLog()).toEqual([]);
+    });
+  });
+
+  describe('router treatment', () => {
+    it('keeps its storage keys local, so the leak net does not have to guess', () => {
+      const {isAllowedLocal} = require('../../../../src/modules/usb/router');
+      for (const key of debugLog.DEBUG_STORAGE_KEYS) {
+        expect(isAllowedLocal(key)).toBe(true);
+      }
+    });
+  });
+});

--- a/test/unit/modules/usb/guard.test.js
+++ b/test/unit/modules/usb/guard.test.js
@@ -6,7 +6,7 @@
  * material, and generating a key with no passphrase.
  */
 
-jest.mock('../../../../src/modules/usb/state', () => ({isEnabled: jest.fn()}));
+jest.mock('../../../../src/modules/usb/state', () => ({isEnabled: jest.fn(), assertUsable: jest.fn()}));
 
 describe('usb/guard', () => {
   let guard; let state; let USB_KEYSTORE_UNAVAILABLE;
@@ -42,6 +42,35 @@ describe('usb/guard', () => {
       } catch (e) {
         expect(e.code).toBe(USB_KEYSTORE_UNAVAILABLE);
       }
+    });
+  });
+
+  describe('crypto operations', () => {
+    it('is a no-op when keys are stored locally', async () => {
+      state.isEnabled.mockReturnValue(false);
+      await expect(guard.assertKeystoreForCrypto()).resolves.toBeUndefined();
+      expect(state.assertUsable).not.toHaveBeenCalled();
+    });
+
+    it('allows the operation when the device is connected', async () => {
+      state.isEnabled.mockReturnValue(true);
+      state.assertUsable.mockResolvedValue(undefined);
+      await expect(guard.assertKeystoreForCrypto()).resolves.toBeUndefined();
+    });
+
+    // "key not found" would suggest the key is gone rather than unreachable, which
+    // for a device that is the only copy is the message most likely to make someone
+    // abandon a perfectly good key.
+    it('explains that the device is disconnected, not that the key is missing', async () => {
+      state.isEnabled.mockReturnValue(true);
+      state.assertUsable.mockRejectedValue(new Error('USB keystore is not available (ABSENT)'));
+      await expect(guard.assertKeystoreForCrypto()).rejects.toMatchObject({
+        code: USB_KEYSTORE_UNAVAILABLE,
+        message: expect.stringMatching(/Connect the device to use your keys/)
+      });
+      await expect(guard.assertKeystoreForCrypto()).rejects.not.toMatchObject({
+        message: expect.stringMatching(/not found/i)
+      });
     });
   });
 

--- a/test/unit/modules/usb/guard.test.js
+++ b/test/unit/modules/usb/guard.test.js
@@ -1,0 +1,79 @@
+/**
+ * Copyright (C) 2026 Noam Rathaus
+ * Licensed under the GNU Affero General Public License version 3
+ *
+ * Covers the guards for paths that bypass storage entirely: remote uploads of key
+ * material, and generating a key with no passphrase.
+ */
+
+jest.mock('../../../../src/modules/usb/state', () => ({isEnabled: jest.fn()}));
+
+describe('usb/guard', () => {
+  let guard; let state; let USB_KEYSTORE_UNAVAILABLE;
+
+  beforeEach(() => {
+    jest.resetModules();
+    state = require('../../../../src/modules/usb/state');
+    guard = require('../../../../src/modules/usb/guard');
+    ({USB_KEYSTORE_UNAVAILABLE} = require('../../../../src/modules/usb/constants'));
+  });
+
+  describe('remote key storage', () => {
+    it('is allowed when no USB keystore is configured, so upstream behaviour is unchanged', () => {
+      state.isEnabled.mockReturnValue(false);
+      expect(guard.isRemoteKeyStorageAllowed()).toBe(true);
+      expect(() => guard.assertRemoteKeyStorageAllowed('private key backup')).not.toThrow();
+    });
+
+    // createPrivateKeyBackup uploads an encrypted private key to a sync server, and
+    // keyring sync uploads the keyring. Both put key material outside the device.
+    it('is refused while a USB keystore is configured', () => {
+      state.isEnabled.mockReturnValue(true);
+      expect(guard.isRemoteKeyStorageAllowed()).toBe(false);
+      expect(() => guard.assertRemoteKeyStorageAllowed('private key backup'))
+      .toThrow(/private key backup is not available/);
+    });
+
+    it('reports the USB error code so callers can map it to a message', () => {
+      state.isEnabled.mockReturnValue(true);
+      try {
+        guard.assertRemoteKeyStorageAllowed('keyring sync');
+        throw new Error('should have thrown');
+      } catch (e) {
+        expect(e.code).toBe(USB_KEYSTORE_UNAVAILABLE);
+      }
+    });
+  });
+
+  describe('passphrase requirement', () => {
+    it('is not imposed when keys are stored locally', () => {
+      state.isEnabled.mockReturnValue(false);
+      expect(() => guard.assertPassphrase('')).not.toThrow();
+      expect(() => guard.assertPassphrase(undefined)).not.toThrow();
+    });
+
+    // The device gives separation, not confidentiality: without a passphrase a lost
+    // device hands over the identity outright.
+    it('rejects an empty or missing passphrase in USB mode', () => {
+      state.isEnabled.mockReturnValue(true);
+      expect(() => guard.assertPassphrase('')).toThrow(/passphrase is required/);
+      expect(() => guard.assertPassphrase(undefined)).toThrow(/passphrase is required/);
+      expect(() => guard.assertPassphrase(null)).toThrow(/passphrase is required/);
+    });
+
+    it('accepts a passphrase in USB mode', () => {
+      state.isEnabled.mockReturnValue(true);
+      expect(() => guard.assertPassphrase('correct horse battery staple')).not.toThrow();
+    });
+
+    it('uses a distinct code so the UI can explain why generation was refused', () => {
+      state.isEnabled.mockReturnValue(true);
+      try {
+        guard.assertPassphrase('');
+        throw new Error('should have thrown');
+      } catch (e) {
+        expect(e.code).toBe('USB_KEYSTORE_PASSPHRASE_REQUIRED');
+      }
+    });
+  });
+});

--- a/test/unit/modules/usb/handlers.test.js
+++ b/test/unit/modules/usb/handlers.test.js
@@ -7,6 +7,10 @@
  * listeners for the life of the service worker.
  */
 
+// The keyring subsystem is only here to count the keys already in memory, and
+// importing it for real drags the whole crypto stack into the test.
+jest.mock('../../../../src/modules/keyring', () => ({getAll: jest.fn(() => Promise.resolve([]))}));
+
 jest.mock('../../../../src/modules/usb/provision', () => ({
   reprobe: jest.fn(),
   provision: jest.fn(),

--- a/test/unit/modules/usb/handlers.test.js
+++ b/test/unit/modules/usb/handlers.test.js
@@ -65,9 +65,14 @@ describe('usb/handlers', () => {
     ]);
   });
 
-  it('answers usb-get-status from the state machine', () => {
-    state.getStatus.mockReturnValue({state: 'READY', enabled: true});
-    expect(controller.handlers.get('usb-get-status')()).toEqual({state: 'READY', enabled: true});
+  // Answering from cache would leave a page showing a device that has since gone
+  // away, and the periodic alarm cannot be relied on as the only trigger.
+  it('probes the device on usb-get-status rather than answering from cache', async () => {
+    provision.reprobe.mockResolvedValue({state: 'ABSENT', enabled: true});
+    const result = await controller.handlers.get('usb-get-status')();
+    expect(provision.reprobe).toHaveBeenCalled();
+    expect(state.getStatus).not.toHaveBeenCalled();
+    expect(result).toEqual({state: 'ABSENT', enabled: true});
   });
 
   it('routes each action to provision', async () => {

--- a/test/unit/modules/usb/handlers.test.js
+++ b/test/unit/modules/usb/handlers.test.js
@@ -13,7 +13,9 @@ jest.mock('../../../../src/modules/usb/provision', () => ({
   disable: jest.fn(),
   diagnostics: jest.fn(),
   inspectLocalKeyMaterial: jest.fn(),
-  migrateLocalKeyMaterial: jest.fn()
+  migrateLocalKeyMaterial: jest.fn(),
+  listDevices: jest.fn(),
+  selectDevice: jest.fn()
 }));
 
 jest.mock('../../../../src/modules/usb/state', () => ({
@@ -59,9 +61,11 @@ describe('usb/handlers', () => {
       'usb-disable',
       'usb-get-status',
       'usb-inspect-local',
+      'usb-list-devices',
       'usb-migrate',
       'usb-probe',
-      'usb-provision'
+      'usb-provision',
+      'usb-select-device'
     ]);
   });
 
@@ -93,6 +97,14 @@ describe('usb/handlers', () => {
 
     await controller.handlers.get('usb-migrate')();
     expect(provision.migrateLocalKeyMaterial).toHaveBeenCalled();
+
+    // Native-host only: Firefox has no directory picker, so a device is chosen
+    // from the list the helper reports rather than through a file dialog.
+    await controller.handlers.get('usb-list-devices')();
+    expect(provision.listDevices).toHaveBeenCalled();
+
+    await controller.handlers.get('usb-select-device')({devicePath: '/run/media/u/X'});
+    expect(provision.selectDevice).toHaveBeenCalledWith('/run/media/u/X');
   });
 
   it('tolerates usb-provision being called with no arguments', async () => {

--- a/test/unit/modules/usb/handlers.test.js
+++ b/test/unit/modules/usb/handlers.test.js
@@ -80,7 +80,7 @@ describe('usb/handlers', () => {
     expect(provision.reprobe).toHaveBeenCalled();
 
     await controller.handlers.get('usb-provision')({label: 'stick'});
-    expect(provision.provision).toHaveBeenCalledWith({label: 'stick'});
+    expect(provision.provision).toHaveBeenCalledWith({label: 'stick', adopt: undefined});
 
     await controller.handlers.get('usb-disable')();
     expect(provision.disable).toHaveBeenCalled();
@@ -97,7 +97,15 @@ describe('usb/handlers', () => {
 
   it('tolerates usb-provision being called with no arguments', async () => {
     await controller.handlers.get('usb-provision')();
-    expect(provision.provision).toHaveBeenCalledWith({label: undefined});
+    expect(provision.provision).toHaveBeenCalledWith({label: undefined, adopt: undefined});
+  });
+
+  // This assertion previously read toHaveBeenCalledWith({label}) and passed only
+  // because the handler dropped adopt -- encoding the bug as expected behaviour and
+  // making the "use this folder anyway" override impossible.
+  it('forwards the adopt flag the user explicitly granted', async () => {
+    await controller.handlers.get('usb-provision')({label: 'stick', adopt: true});
+    expect(provision.provision).toHaveBeenCalledWith({label: 'stick', adopt: true});
   });
 
   it('pushes status changes to the view', () => {

--- a/test/unit/modules/usb/handlers.test.js
+++ b/test/unit/modules/usb/handlers.test.js
@@ -1,0 +1,126 @@
+/**
+ * Copyright (C) 2026 Noam Rathaus
+ * Licensed under the GNU Affero General Public License version 3
+ *
+ * Covers the port wiring: that every event the settings UI relies on is registered,
+ * and that status changes are pushed to the view without a dead port accumulating
+ * listeners for the life of the service worker.
+ */
+
+jest.mock('../../../../src/modules/usb/provision', () => ({
+  reprobe: jest.fn(),
+  provision: jest.fn(),
+  disable: jest.fn(),
+  diagnostics: jest.fn(),
+  inspectLocalKeyMaterial: jest.fn(),
+  migrateLocalKeyMaterial: jest.fn()
+}));
+
+jest.mock('../../../../src/modules/usb/state', () => ({
+  getStatus: jest.fn(),
+  addStateListener: jest.fn()
+}));
+
+describe('usb/handlers', () => {
+  let registerUsbHandlers; let provision; let state; let controller; let listener;
+
+  /** Stand-in for a SubController: records handlers and exposes a fake main port. */
+  function makeController({withPort = true} = {}) {
+    const handlers = new Map();
+    const emit = jest.fn();
+    return {
+      mainType: 'app',
+      ports: withPort ? {app: {emit}} : {},
+      handlers,
+      emit,
+      on(event, handler) {
+        handlers.set(event, handler);
+      }
+    };
+  }
+
+  beforeEach(() => {
+    jest.resetModules();
+    provision = require('../../../../src/modules/usb/provision');
+    state = require('../../../../src/modules/usb/state');
+    listener = null;
+    state.addStateListener.mockImplementation(fn => {
+      listener = fn;
+      return jest.fn();
+    });
+    ({registerUsbHandlers} = require('../../../../src/modules/usb/handlers'));
+    controller = makeController();
+    registerUsbHandlers(controller);
+  });
+
+  it('registers every event the settings page uses', () => {
+    expect([...controller.handlers.keys()].sort()).toEqual([
+      'usb-diagnostics',
+      'usb-disable',
+      'usb-get-status',
+      'usb-inspect-local',
+      'usb-migrate',
+      'usb-probe',
+      'usb-provision'
+    ]);
+  });
+
+  it('answers usb-get-status from the state machine', () => {
+    state.getStatus.mockReturnValue({state: 'READY', enabled: true});
+    expect(controller.handlers.get('usb-get-status')()).toEqual({state: 'READY', enabled: true});
+  });
+
+  it('routes each action to provision', async () => {
+    await controller.handlers.get('usb-probe')();
+    expect(provision.reprobe).toHaveBeenCalled();
+
+    await controller.handlers.get('usb-provision')({label: 'stick'});
+    expect(provision.provision).toHaveBeenCalledWith({label: 'stick'});
+
+    await controller.handlers.get('usb-disable')();
+    expect(provision.disable).toHaveBeenCalled();
+
+    await controller.handlers.get('usb-diagnostics')();
+    expect(provision.diagnostics).toHaveBeenCalled();
+
+    await controller.handlers.get('usb-inspect-local')();
+    expect(provision.inspectLocalKeyMaterial).toHaveBeenCalled();
+
+    await controller.handlers.get('usb-migrate')();
+    expect(provision.migrateLocalKeyMaterial).toHaveBeenCalled();
+  });
+
+  it('tolerates usb-provision being called with no arguments', async () => {
+    await controller.handlers.get('usb-provision')();
+    expect(provision.provision).toHaveBeenCalledWith({label: undefined});
+  });
+
+  it('pushes status changes to the view', () => {
+    const status = {state: 'ABSENT', enabled: true};
+    listener('ABSENT', 'READY', status);
+    expect(controller.emit).toHaveBeenCalledWith('usb-status-changed', status);
+  });
+
+  it('does nothing when the view has no port', () => {
+    const detached = makeController({withPort: false});
+    registerUsbHandlers(detached);
+    expect(() => listener('ABSENT', 'READY', {})).not.toThrow();
+  });
+
+  // A closed view must not leave a listener emitting into it on every probe for
+  // the remaining life of the service worker.
+  it('stops forwarding once the port rejects an emit', () => {
+    const unregister = jest.fn();
+    state.addStateListener.mockImplementation(fn => {
+      listener = fn;
+      return unregister;
+    });
+    const dead = makeController();
+    dead.ports.app.emit = jest.fn(() => {
+      throw new Error('port closed');
+    });
+    registerUsbHandlers(dead);
+    expect(() => listener('ABSENT', 'READY', {})).not.toThrow();
+    expect(unregister).toHaveBeenCalled();
+  });
+});

--- a/test/unit/modules/usb/install.test.js
+++ b/test/unit/modules/usb/install.test.js
@@ -41,6 +41,19 @@ jest.mock('../../../../src/modules/usb/FsaBackend', () => {
   return {__esModule: true, default: FakeBackend};
 });
 
+// Two backends exist now, so a test that means "no backend at all" has to say so
+// for both. Native support is off by default here; the Firefox path has its own
+// tests.
+jest.mock('../../../../src/modules/usb/NativeBackend', () => {
+  class FakeNative {
+    static isSupported() {
+      return FakeNative.supported === true;
+    }
+  }
+  FakeNative.supported = false;
+  return {__esModule: true, default: FakeNative};
+});
+
 const KEYSTORE_ID = 'abc123';
 const MAIN = 'localhost|#|mailvelope';
 const PRIV_KEY = 'mvelo.keyring.localhost|#|mailvelope.privateKeys';

--- a/test/unit/modules/usb/install.test.js
+++ b/test/unit/modules/usb/install.test.js
@@ -1,0 +1,303 @@
+/**
+ * Copyright (C) 2026 Noam Rathaus
+ * Licensed under the GNU Affero General Public License version 3
+ *
+ * Covers the mvelo.storage interception: what reaches the device, what stays local,
+ * and what is refused. This is the enforcement point for the requirement that no
+ * crypto material is stored anywhere but the device, so it is also where the
+ * storage audit in the plan's Phase 4 lives.
+ *
+ * Uses the real lib-mvelo, router and state modules against a fake backend, so the
+ * wrapper is exercised through the same path the extension takes.
+ */
+
+jest.mock('../../../../src/modules/keyring', () => ({getAll: jest.fn()}));
+jest.mock('../../../../src/modules/pwdCache', () => ({clear: jest.fn()}));
+
+jest.mock('../../../../src/modules/usb/FsaBackend', () => {
+  const mocks = {
+    supported: true,
+    probe: jest.fn(),
+    readFile: jest.fn(),
+    writeFile: jest.fn(),
+    removeFile: jest.fn(),
+    listDir: jest.fn()
+  };
+  class FakeBackend {
+    static isSupported() {
+      return mocks.supported;
+    }
+
+    constructor() {
+      this.clearCache = jest.fn();
+      this.probe = mocks.probe;
+      this.readFile = mocks.readFile;
+      this.writeFile = mocks.writeFile;
+      this.removeFile = mocks.removeFile;
+      this.listDir = mocks.listDir;
+    }
+  }
+  FakeBackend.__mocks = mocks;
+  return {__esModule: true, default: FakeBackend};
+});
+
+const KEYSTORE_ID = 'abc123';
+const MAIN = 'localhost|#|mailvelope';
+const PRIV_KEY = 'mvelo.keyring.localhost|#|mailvelope.privateKeys';
+const ATTR_KEY = 'mvelo.keyring.attributes';
+const PRIVATE_ARMORED = '-----BEGIN PGP PRIVATE KEY BLOCK-----\nsecret\n-----END PGP PRIVATE KEY BLOCK-----';
+
+describe('usb/install storage interception', () => {
+  let mvelo; let state; let constants; let mocks; let install; let localStore; let device;
+
+  /** Fake device filesystem, so writes and reads can be asserted by path. */
+  function seedDevice() {
+    device = {};
+    mocks.writeFile.mockImplementation((path, content) => {
+      device[path] = content;
+      return Promise.resolve();
+    });
+    mocks.readFile.mockImplementation(path => {
+      if (!(path in device)) {
+        const {NotFoundError} = require('../../../../src/modules/usb/backend');
+        return Promise.reject(new NotFoundError(path));
+      }
+      return Promise.resolve(device[path]);
+    });
+    mocks.removeFile.mockImplementation(path => {
+      delete device[path];
+      return Promise.resolve();
+    });
+  }
+
+  function seedStorage(initial = {}) {
+    localStore = {...initial};
+    chrome.storage.local.get.mockImplementation(key =>
+      Promise.resolve(key in localStore ? {[key]: localStore[key]} : {}));
+    chrome.storage.local.set.mockImplementation(obj => {
+      Object.assign(localStore, obj);
+      return Promise.resolve();
+    });
+    chrome.storage.local.remove.mockImplementation(key => {
+      delete localStore[key];
+      return Promise.resolve();
+    });
+  }
+
+  function load() {
+    jest.resetModules();
+    chrome.storage.local.get.mockReset();
+    chrome.storage.local.set.mockReset();
+    chrome.storage.local.remove.mockReset();
+    chrome.action.setBadgeText.mockClear();
+    constants = require('../../../../src/modules/usb/constants');
+    mocks = require('../../../../src/modules/usb/FsaBackend').default.__mocks;
+    mocks.supported = true;
+    seedDevice();
+    mvelo = require('../../../../src/lib/lib-mvelo').default;
+    state = require('../../../../src/modules/usb/state');
+    install = require('../../../../src/modules/usb/install');
+  }
+
+  /** Configured and reachable. */
+  async function bootReady() {
+    seedStorage({[constants.USB_CONFIG_KEY]: {keystoreId: KEYSTORE_ID}});
+    device['mailvelope-keystore/keystore.json'] = JSON.stringify({keystoreId: KEYSTORE_ID});
+    mocks.probe.mockResolvedValue({available: true, permission: 'granted', configured: true});
+    await install.installUsbKeystore();
+    expect(state.getState()).toBe(constants.USB_STATE.READY);
+  }
+
+  /** Configured but the device is gone. */
+  async function bootAbsent() {
+    seedStorage({[constants.USB_CONFIG_KEY]: {keystoreId: KEYSTORE_ID}});
+    mocks.probe.mockResolvedValue({available: true, permission: 'granted', configured: true});
+    await install.installUsbKeystore();
+    expect(state.getState()).toBe(constants.USB_STATE.ABSENT);
+  }
+
+  beforeEach(() => {
+    load();
+  });
+
+  describe('when no keystore is configured', () => {
+    it('passes everything through to local storage, unchanged', async () => {
+      seedStorage({});
+      await install.installUsbKeystore();
+      await mvelo.storage.set(PRIV_KEY, [PRIVATE_ARMORED]);
+      expect(localStore[PRIV_KEY]).toEqual([PRIVATE_ARMORED]);
+      expect(await mvelo.storage.get(PRIV_KEY)).toEqual([PRIVATE_ARMORED]);
+      expect(mocks.writeFile).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when the device is READY', () => {
+    it('writes armored keys to the device as .asc and never locally', async () => {
+      await bootReady();
+      await mvelo.storage.set(PRIV_KEY, [PRIVATE_ARMORED]);
+      const path = `mailvelope-keystore/keyrings/${Buffer.from(MAIN).toString('hex')}/private.asc`;
+      expect(device[path]).toContain('BEGIN PGP PRIVATE KEY BLOCK');
+      expect(localStore[PRIV_KEY]).toBeUndefined();
+    });
+
+    it('reads armored keys back from the device', async () => {
+      await bootReady();
+      await mvelo.storage.set(PRIV_KEY, [PRIVATE_ARMORED]);
+      expect(await mvelo.storage.get(PRIV_KEY)).toEqual([PRIVATE_ARMORED]);
+    });
+
+    it('reports an empty keyring, not an error, when nothing is stored yet', async () => {
+      await bootReady();
+      expect(await mvelo.storage.get(PRIV_KEY)).toBeUndefined();
+    });
+
+    it('splits keyring attributes: crypto fields to the device, registry local', async () => {
+      await bootReady();
+      await mvelo.storage.set(ATTR_KEY, {[MAIN]: {default_key: 'ff00', sanitized: true}});
+      expect(localStore[ATTR_KEY]).toEqual({[MAIN]: {sanitized: true}});
+      const attrPath = 'mailvelope-keystore/keyrings/attributes.json';
+      expect(JSON.parse(device[attrPath])).toEqual({[MAIN]: {default_key: 'ff00'}});
+    });
+
+    it('merges both halves of the attribute map on read', async () => {
+      await bootReady();
+      await mvelo.storage.set(ATTR_KEY, {[MAIN]: {default_key: 'ff00', sanitized: true}});
+      expect(await mvelo.storage.get(ATTR_KEY)).toEqual({[MAIN]: {default_key: 'ff00', sanitized: true}});
+    });
+
+    it('keeps settings and OAuth tokens local', async () => {
+      await bootReady();
+      await mvelo.storage.set('mvelo.preferences', {security: {}});
+      await mvelo.storage.set('mvelo.oauth.gmail', {token: 'x'});
+      expect(localStore['mvelo.preferences']).toEqual({security: {}});
+      expect(localStore['mvelo.oauth.gmail']).toEqual({token: 'x'});
+    });
+
+    it('removes key files from the device', async () => {
+      await bootReady();
+      await mvelo.storage.set(PRIV_KEY, [PRIVATE_ARMORED]);
+      await mvelo.storage.remove(PRIV_KEY);
+      expect(await mvelo.storage.get(PRIV_KEY)).toBeUndefined();
+    });
+  });
+
+  describe('when the device is ABSENT', () => {
+    // keyring.init() wraps buildKeyring in a try/catch that DELETES the keyring
+    // from the attribute map on failure. A throwing read would therefore destroy
+    // the registry entry just because the device was unplugged at startup, so
+    // reads must degrade to "empty" instead.
+    it('reports an empty keyring rather than throwing, so keyring init survives', async () => {
+      await bootAbsent();
+      await expect(mvelo.storage.get(PRIV_KEY)).resolves.toBeUndefined();
+    });
+
+    it('still returns the local keyring registry so keyrings can be enumerated', async () => {
+      seedStorage({
+        [constants.USB_CONFIG_KEY]: {keystoreId: KEYSTORE_ID},
+        [ATTR_KEY]: {[MAIN]: {sanitized: true}}
+      });
+      mocks.probe.mockResolvedValue({available: true, permission: 'granted', configured: true});
+      await install.installUsbKeystore();
+      expect(await mvelo.storage.get(ATTR_KEY)).toEqual({[MAIN]: {sanitized: true}});
+    });
+
+    it('refuses writes of key material and leaves local storage untouched', async () => {
+      await bootAbsent();
+      await expect(mvelo.storage.set(PRIV_KEY, [PRIVATE_ARMORED])).rejects.toMatchObject({
+        code: constants.USB_KEYSTORE_UNAVAILABLE
+      });
+      expect(localStore[PRIV_KEY]).toBeUndefined();
+    });
+
+    it('never falls back to local storage for key material', async () => {
+      await bootAbsent();
+      await mvelo.storage.set(PRIV_KEY, [PRIVATE_ARMORED]).catch(() => {});
+      expect(JSON.stringify(localStore)).not.toContain('BEGIN PGP');
+    });
+  });
+
+  describe('a fresh profile with no device attached', () => {
+    // keyringAttr.init() creates the main keyring and stores it immediately. If
+    // that write required the device, a first run without one would leave the
+    // keyring subsystem unable to initialise at all.
+    it('can create a keyring with no crypto attributes and no device', async () => {
+      await bootAbsent();
+      await expect(mvelo.storage.set(ATTR_KEY, {[MAIN]: {}})).resolves.toBeUndefined();
+      expect(localStore[ATTR_KEY]).toEqual({[MAIN]: {}});
+      expect(mocks.writeFile).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('leak safety net for unrecognised storage keys', () => {
+    it('refuses armored key material under an unknown key', async () => {
+      await bootReady();
+      await expect(mvelo.storage.set('mvelo.something.new', {blob: PRIVATE_ARMORED}))
+      .rejects.toMatchObject({code: 'USB_KEYSTORE_LEAK_BLOCKED'});
+      expect(localStore['mvelo.something.new']).toBeUndefined();
+    });
+
+    it('allows ordinary values under an unknown key', async () => {
+      await bootReady();
+      await mvelo.storage.set('mvelo.something.new', {harmless: true});
+      expect(localStore['mvelo.something.new']).toEqual({harmless: true});
+    });
+  });
+
+  describe('purge on device loss', () => {
+    it('clears the passphrase cache and in-memory keyrings', async () => {
+      const {getAll} = require('../../../../src/modules/keyring');
+      const {clear} = require('../../../../src/modules/pwdCache');
+      const keystore = {clear: jest.fn()};
+      getAll.mockResolvedValue([{keystore}]);
+      await bootReady();
+      delete device['mailvelope-keystore/keystore.json'];
+      await state.probe();
+      expect(clear).toHaveBeenCalled();
+      await Promise.resolve();
+      expect(keystore.clear).toHaveBeenCalled();
+    });
+  });
+
+  describe('badge arbitration with uiLog', () => {
+    // uiLog sets a green 'Ok' on user interaction and clears it 2s later. A clear
+    // must restore the USB warning rather than blanking the toolbar.
+    it('restores the warning when something clears the badge', async () => {
+      await bootAbsent();
+      chrome.action.setBadgeText.mockClear();
+      mvelo.action.state({badge: ''});
+      expect(chrome.action.setBadgeText).toHaveBeenCalledWith({text: '!'});
+    });
+
+    it('leaves the badge alone while the device is READY', async () => {
+      await bootReady();
+      chrome.action.setBadgeText.mockClear();
+      mvelo.action.state({badge: ''});
+      expect(chrome.action.setBadgeText).toHaveBeenCalledWith({text: ''});
+    });
+  });
+
+  // The plan's requirement 3 as an assertion rather than a claim.
+  describe('storage audit: no crypto material outside the device', () => {
+    it('holds no armored key or crypto attribute locally after a full session', async () => {
+      await bootReady();
+      await mvelo.storage.set(ATTR_KEY, {[MAIN]: {}});
+      await mvelo.storage.set(PRIV_KEY, [PRIVATE_ARMORED]);
+      await mvelo.storage.set('mvelo.keyring.localhost|#|mailvelope.publicKeys', [PRIVATE_ARMORED]);
+      await mvelo.storage.set(`mvelo.autocrypt.${MAIN}`, {'a@b.c': {keydata: 'AAAA'}});
+      await mvelo.storage.set(ATTR_KEY, {
+        [MAIN]: {default_key: 'ff00', sanitized: true, key_binding: {'a@b.c': {fingerprint: 'ff'}}}
+      });
+
+      const serialized = JSON.stringify(localStore);
+      expect(serialized).not.toContain('BEGIN PGP');
+      expect(Object.keys(localStore)).not.toContain(PRIV_KEY);
+      expect(Object.keys(localStore)).not.toContain(`mvelo.autocrypt.${MAIN}`);
+      for (const field of ['default_key', 'primary_key', 'sync_data', 'key_binding']) {
+        expect(serialized).not.toContain(field);
+      }
+      // ...and it is all on the device instead.
+      expect(JSON.stringify(device)).toContain('BEGIN PGP');
+      expect(JSON.stringify(device)).toContain('default_key');
+    });
+  });
+});

--- a/test/unit/modules/usb/install.test.js
+++ b/test/unit/modules/usb/install.test.js
@@ -258,6 +258,67 @@ describe('usb/install storage interception', () => {
     });
   });
 
+  describe('remembering that the device has held keys', () => {
+    // A detached device cannot be asked whether it holds keys, so the answer has to
+    // be remembered. Keys are written rarely but read on every startup, so the read
+    // path is what makes this work for a profile set up before the flag existed.
+    it('records the flag when private keys are read from the device', async () => {
+      await bootReady();
+      const path = `mailvelope-keystore/keyrings/${Buffer.from(MAIN).toString('hex')}/private.asc`;
+      device[path] = PRIVATE_ARMORED;
+      await mvelo.storage.get(PRIV_KEY);
+      expect((await state.getConfig()).hadKeys).toBe(true);
+    });
+
+    it('records the flag when private keys are written', async () => {
+      await bootReady();
+      await mvelo.storage.set(PRIV_KEY, [PRIVATE_ARMORED]);
+      expect((await state.getConfig()).hadKeys).toBe(true);
+    });
+
+    it('does not claim keys for an empty keyring', async () => {
+      await bootReady();
+      await mvelo.storage.set(PRIV_KEY, []);
+      await mvelo.storage.get(PRIV_KEY);
+      expect((await state.getConfig()).hadKeys).toBeUndefined();
+    });
+  });
+
+  describe('reload when the device returns', () => {
+    // Reads degrade to empty while the device is away, so every keyring in memory
+    // is blank by the time it comes back. Without a reload the warning clears while
+    // the UI still shows no keys, which reads as data loss.
+    it('reloads the keyrings from the device on return to READY', async () => {
+      const {getAll} = require('../../../../src/modules/keyring');
+      const keystore = {clear: jest.fn(), load: jest.fn().mockResolvedValue(undefined)};
+      getAll.mockResolvedValue([{keystore}]);
+      await bootReady();
+      const marker = device['mailvelope-keystore/keystore.json'];
+      delete device['mailvelope-keystore/keystore.json'];
+      await state.probe();
+      expect(state.getState()).toBe(constants.USB_STATE.ABSENT);
+      keystore.clear.mockClear();
+
+      device['mailvelope-keystore/keystore.json'] = marker;
+      await state.probe();
+      expect(state.getState()).toBe(constants.USB_STATE.READY);
+      await new Promise(resolve => setTimeout(resolve, 0));
+      expect(keystore.clear).toHaveBeenCalled();
+      expect(keystore.load).toHaveBeenCalled();
+    });
+
+    it('does not reload while the device stays away', async () => {
+      const {getAll} = require('../../../../src/modules/keyring');
+      const keystore = {clear: jest.fn(), load: jest.fn().mockResolvedValue(undefined)};
+      getAll.mockResolvedValue([{keystore}]);
+      await bootAbsent();
+      keystore.load.mockClear();
+      await state.probe();
+      await new Promise(resolve => setTimeout(resolve, 0));
+      expect(keystore.load).not.toHaveBeenCalled();
+    });
+  });
+
   describe('badge arbitration with uiLog', () => {
     // uiLog sets a green 'Ok' on user interaction and clears it 2s later. A clear
     // must restore the USB warning rather than blanking the toolbar.

--- a/test/unit/modules/usb/install.test.js
+++ b/test/unit/modules/usb/install.test.js
@@ -332,6 +332,75 @@ describe('usb/install storage interception', () => {
     });
   });
 
+  describe('a write-protected device', () => {
+    // FAT mounts commonly carry errors=remount-ro, so a filesystem error silently
+    // makes a stick read-only. Without a state for it, a delete appeared to succeed:
+    // the keyring mutates memory before persisting, so the key vanished from the UI
+    // while remaining on the device. A key deleted because it was compromised,
+    // appearing gone while still there, is the dangerous version of that.
+    async function bootReadOnly() {
+      seedStorage({[constants.USB_CONFIG_KEY]: {keystoreId: KEYSTORE_ID}});
+      device['mailvelope-keystore/keystore.json'] = JSON.stringify({keystoreId: KEYSTORE_ID});
+      mocks.probe.mockResolvedValue({
+        available: true, permission: 'granted', configured: true, writable: false
+      });
+      await install.installUsbKeystore();
+    }
+
+    it('is READ_ONLY, not ABSENT: the keys still work', async () => {
+      await bootReadOnly();
+      expect(state.getState()).toBe(constants.USB_STATE.READ_ONLY);
+      expect(state.isUsable()).toBe(true);
+      expect(state.isWritable()).toBe(false);
+    });
+
+    it('still reads keys from the device', async () => {
+      await bootReadOnly();
+      const path = `mailvelope-keystore/keyrings/${Buffer.from(MAIN).toString('hex')}/private.asc`;
+      device[path] = PRIVATE_ARMORED;
+      expect(await mvelo.storage.get(PRIV_KEY)).toEqual([PRIVATE_ARMORED]);
+    });
+
+    it('refuses a write with a message naming write protection', async () => {
+      await bootReadOnly();
+      await expect(mvelo.storage.set(PRIV_KEY, [PRIVATE_ARMORED])).rejects.toMatchObject({
+        code: 'USB_READ_ONLY'
+      });
+    });
+
+    it('does not write anything to the device', async () => {
+      await bootReadOnly();
+      mocks.writeFile.mockClear();
+      await mvelo.storage.set(PRIV_KEY, [PRIVATE_ARMORED]).catch(() => {});
+      expect(mocks.writeFile).not.toHaveBeenCalled();
+    });
+
+    // Discovered reactively on Chromium, where the File System Access API cannot
+    // report writability in advance.
+    it('records read-only when a write is refused by the platform', async () => {
+      await bootReady();
+      const failure = new Error('operation not permitted');
+      failure.name = 'NoModificationAllowedError';
+      mocks.writeFile.mockRejectedValue(failure);
+      await mvelo.storage.set(PRIV_KEY, [PRIVATE_ARMORED]).catch(() => {});
+      expect(state.getState()).toBe(constants.USB_STATE.READ_ONLY);
+    });
+
+    // Callers mutate the keyring before persisting, so a failed write leaves memory
+    // disagreeing with the device. Reloading is what stops a failed delete looking
+    // like a successful one.
+    it('reloads the keyrings after a failed write', async () => {
+      const {getAll} = require('../../../../src/modules/keyring');
+      const keystore = {clear: jest.fn(), load: jest.fn().mockResolvedValue(undefined)};
+      getAll.mockResolvedValue([{keystore}]);
+      await bootReady();
+      mocks.writeFile.mockRejectedValue(new Error('device gone'));
+      await mvelo.storage.set(PRIV_KEY, [PRIVATE_ARMORED]).catch(() => {});
+      await new Promise(resolve => setTimeout(resolve, 0));
+      expect(keystore.load).toHaveBeenCalled();
+    });
+  });
+
   describe('badge arbitration with uiLog', () => {
     // uiLog sets a green 'Ok' on user interaction and clears it 2s later. A clear
     // must restore the USB warning rather than blanking the toolbar.

--- a/test/unit/modules/usb/install.test.js
+++ b/test/unit/modules/usb/install.test.js
@@ -260,7 +260,7 @@ describe('usb/install storage interception', () => {
     it('clears the passphrase cache and in-memory keyrings', async () => {
       const {getAll} = require('../../../../src/modules/keyring');
       const {clear} = require('../../../../src/modules/pwdCache');
-      const keystore = {clear: jest.fn()};
+      const keystore = {clear: jest.fn(), reload: jest.fn().mockResolvedValue(undefined)};
       getAll.mockResolvedValue([{keystore}]);
       await bootReady();
       delete device['mailvelope-keystore/keystore.json'];
@@ -303,7 +303,7 @@ describe('usb/install storage interception', () => {
     // the UI still shows no keys, which reads as data loss.
     it('reloads the keyrings from the device on return to READY', async () => {
       const {getAll} = require('../../../../src/modules/keyring');
-      const keystore = {clear: jest.fn(), load: jest.fn().mockResolvedValue(undefined)};
+      const keystore = {clear: jest.fn(), reload: jest.fn().mockResolvedValue(undefined)};
       getAll.mockResolvedValue([{keystore}]);
       await bootReady();
       const marker = device['mailvelope-keystore/keystore.json'];
@@ -316,19 +316,20 @@ describe('usb/install storage interception', () => {
       await state.probe();
       expect(state.getState()).toBe(constants.USB_STATE.READY);
       await new Promise(resolve => setTimeout(resolve, 0));
-      expect(keystore.clear).toHaveBeenCalled();
-      expect(keystore.load).toHaveBeenCalled();
+      // reload(), rather than clear() then load(): a reader during the refill would
+      // otherwise see a fraction of the keyring. KeyStoreBase.reload has its own test.
+      expect(keystore.reload).toHaveBeenCalled();
     });
 
     it('does not reload while the device stays away', async () => {
       const {getAll} = require('../../../../src/modules/keyring');
-      const keystore = {clear: jest.fn(), load: jest.fn().mockResolvedValue(undefined)};
+      const keystore = {clear: jest.fn(), reload: jest.fn().mockResolvedValue(undefined)};
       getAll.mockResolvedValue([{keystore}]);
       await bootAbsent();
-      keystore.load.mockClear();
+      keystore.reload.mockClear();
       await state.probe();
       await new Promise(resolve => setTimeout(resolve, 0));
-      expect(keystore.load).not.toHaveBeenCalled();
+      expect(keystore.reload).not.toHaveBeenCalled();
     });
   });
 
@@ -391,13 +392,13 @@ describe('usb/install storage interception', () => {
     // like a successful one.
     it('reloads the keyrings after a failed write', async () => {
       const {getAll} = require('../../../../src/modules/keyring');
-      const keystore = {clear: jest.fn(), load: jest.fn().mockResolvedValue(undefined)};
+      const keystore = {clear: jest.fn(), reload: jest.fn().mockResolvedValue(undefined)};
       getAll.mockResolvedValue([{keystore}]);
       await bootReady();
       mocks.writeFile.mockRejectedValue(new Error('device gone'));
       await mvelo.storage.set(PRIV_KEY, [PRIVATE_ARMORED]).catch(() => {});
       await new Promise(resolve => setTimeout(resolve, 0));
-      expect(keystore.load).toHaveBeenCalled();
+      expect(keystore.reload).toHaveBeenCalled();
     });
   });
 

--- a/test/unit/modules/usb/provision.test.js
+++ b/test/unit/modules/usb/provision.test.js
@@ -1,0 +1,319 @@
+/**
+ * Copyright (C) 2026 Noam Rathaus
+ * Licensed under the GNU Affero General Public License version 3
+ *
+ * Covers provisioning, migration and teardown.
+ *
+ * Migration deletes the local copy of key material, so the cases that matter most
+ * here are the failure paths: a failed or unverified write must leave the local copy
+ * exactly where it was.
+ */
+
+jest.mock('../../../../src/modules/usb/FsaBackend', () => {
+  const mocks = {
+    supported: true,
+    probe: jest.fn(),
+    readFile: jest.fn(),
+    writeFile: jest.fn(),
+    removeFile: jest.fn(),
+    listDir: jest.fn()
+  };
+  class FakeBackend {
+    static isSupported() {
+      return mocks.supported;
+    }
+
+    constructor() {
+      this.clearCache = jest.fn();
+      this.probe = mocks.probe;
+      this.readFile = mocks.readFile;
+      this.writeFile = mocks.writeFile;
+      this.removeFile = mocks.removeFile;
+      this.listDir = mocks.listDir;
+    }
+  }
+  FakeBackend.__mocks = mocks;
+  return {__esModule: true, default: FakeBackend};
+});
+
+jest.mock('../../../../src/modules/usb/handleStore', () => ({
+  get: jest.fn(),
+  put: jest.fn(),
+  remove: jest.fn()
+}));
+
+const KEYSTORE_ID = 'abc123';
+const MAIN = 'localhost|#|mailvelope';
+const PRIV_KEY = `mvelo.keyring.${MAIN}.privateKeys`;
+const PUB_KEY = `mvelo.keyring.${MAIN}.publicKeys`;
+const AUTOCRYPT_KEY = `mvelo.autocrypt.${MAIN}`;
+const ATTR_KEY = 'mvelo.keyring.attributes';
+const PRIV = '-----BEGIN PGP PRIVATE KEY BLOCK-----\nsecret\n-----END PGP PRIVATE KEY BLOCK-----';
+const PUB = '-----BEGIN PGP PUBLIC KEY BLOCK-----\npublic\n-----END PGP PUBLIC KEY BLOCK-----';
+
+describe('usb/provision', () => {
+  let provision; let state; let constants; let mocks; let handleStore; let store; let device;
+
+  function seedStorage(initial = {}) {
+    store = {...initial};
+    // The real API returns every item for get(null), which readLocalStorage relies on.
+    chrome.storage.local.get.mockImplementation(key => {
+      if (key === null || key === undefined) {
+        return Promise.resolve({...store});
+      }
+      return Promise.resolve(key in store ? {[key]: store[key]} : {});
+    });
+    chrome.storage.local.set.mockImplementation(obj => {
+      Object.assign(store, obj);
+      return Promise.resolve();
+    });
+    chrome.storage.local.remove.mockImplementation(key => {
+      delete store[key];
+      return Promise.resolve();
+    });
+  }
+
+  function seedDevice(initial = {}) {
+    device = {...initial};
+    mocks.writeFile.mockImplementation((path, content) => {
+      device[path] = content;
+      return Promise.resolve();
+    });
+    mocks.readFile.mockImplementation(path => {
+      if (!(path in device)) {
+        const {NotFoundError} = require('../../../../src/modules/usb/backend');
+        return Promise.reject(new NotFoundError(path));
+      }
+      return Promise.resolve(device[path]);
+    });
+    mocks.removeFile.mockImplementation(path => {
+      delete device[path];
+      return Promise.resolve();
+    });
+    mocks.listDir.mockResolvedValue([]);
+  }
+
+  function load() {
+    jest.resetModules();
+    chrome.storage.local.get.mockReset();
+    chrome.storage.local.set.mockReset();
+    chrome.storage.local.remove.mockReset();
+    constants = require('../../../../src/modules/usb/constants');
+    mocks = require('../../../../src/modules/usb/FsaBackend').default.__mocks;
+    mocks.supported = true;
+    handleStore = require('../../../../src/modules/usb/handleStore');
+    state = require('../../../../src/modules/usb/state');
+    provision = require('../../../../src/modules/usb/provision');
+  }
+
+  /** Bring the state machine up with a reachable, correctly-marked device. */
+  async function bootReady(localSeed = {}) {
+    seedStorage({[constants.USB_CONFIG_KEY]: {keystoreId: KEYSTORE_ID}, ...localSeed});
+    seedDevice({'mailvelope-keystore/keystore.json': JSON.stringify({keystoreId: KEYSTORE_ID})});
+    mocks.probe.mockResolvedValue({available: true, permission: 'granted', configured: true});
+    await state.init();
+    expect(state.getState()).toBe(constants.USB_STATE.READY);
+  }
+
+  const keyringDir = `mailvelope-keystore/keyrings/${Buffer.from(MAIN).toString('hex')}`;
+
+  beforeEach(() => {
+    load();
+  });
+
+  describe('provision', () => {
+    it('creates a marker and records it as this profile keystore', async () => {
+      seedStorage({});
+      seedDevice({});
+      mocks.probe.mockResolvedValue({available: true, permission: 'granted', configured: true});
+      await state.init();
+      const status = await provision.provision({label: 'my stick'});
+      const marker = JSON.parse(device['mailvelope-keystore/keystore.json']);
+      expect(marker.keystoreId).toMatch(/^[0-9a-f-]+$/i);
+      expect(marker.label).toBe('my stick');
+      expect(marker.version).toBe(constants.KEYSTORE_VERSION);
+      expect((await state.getConfig()).keystoreId).toBe(marker.keystoreId);
+      expect(status.state).toBe(constants.USB_STATE.READY);
+    });
+
+    // A device set up on another machine should be adoptable rather than reset,
+    // which would orphan the keys already on it.
+    it('adopts an existing keystore without rewriting its id', async () => {
+      seedStorage({});
+      const existing = {version: 1, keystoreId: 'pre-existing', label: 'old stick'};
+      seedDevice({'mailvelope-keystore/keystore.json': JSON.stringify(existing)});
+      mocks.probe.mockResolvedValue({available: true, permission: 'granted', configured: true});
+      await state.init();
+      await provision.provision({label: 'ignored'});
+      expect(JSON.parse(device['mailvelope-keystore/keystore.json']).keystoreId).toBe('pre-existing');
+      expect((await state.getConfig()).keystoreId).toBe('pre-existing');
+    });
+
+    it('refuses when the browser has no backend', async () => {
+      seedStorage({});
+      mocks.supported = false;
+      await state.init();
+      await expect(provision.provision({})).rejects.toThrow(/no usb keystore backend/i);
+    });
+  });
+
+  describe('inspectLocalKeyMaterial', () => {
+    it('counts what is still held locally, per type', async () => {
+      await bootReady({
+        [PRIV_KEY]: [PRIV],
+        [PUB_KEY]: [PUB, PUB],
+        [AUTOCRYPT_KEY]: {'a@b.c': {keydata: 'x'}, 'd@e.f': {keydata: 'y'}}
+      });
+      const summary = await provision.inspectLocalKeyMaterial();
+      expect(summary.privateKeys).toBe(1);
+      expect(summary.publicKeys).toBe(2);
+      expect(summary.autocrypt).toBe(2);
+      expect(summary.keyrings).toEqual([MAIN]);
+    });
+
+    it('ignores settings and tokens', async () => {
+      await bootReady({
+        'mvelo.preferences': {security: {}},
+        'mvelo.watchlist': [{site: 'x'}],
+        'mvelo.oauth.gmail': {token: 'x'}
+      });
+      const summary = await provision.inspectLocalKeyMaterial();
+      expect(summary).toEqual({keyrings: [], privateKeys: 0, publicKeys: 0, autocrypt: 0});
+    });
+
+    it('changes nothing', async () => {
+      await bootReady({[PRIV_KEY]: [PRIV]});
+      await provision.inspectLocalKeyMaterial();
+      expect(store[PRIV_KEY]).toEqual([PRIV]);
+      expect(mocks.writeFile).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('migrateLocalKeyMaterial', () => {
+    it('moves key material to the device and deletes the local copy', async () => {
+      await bootReady({[PRIV_KEY]: [PRIV], [PUB_KEY]: [PUB]});
+      const {moved, failed} = await provision.migrateLocalKeyMaterial();
+      expect(failed).toEqual([]);
+      expect(moved).toContain(PRIV_KEY);
+      expect(device[`${keyringDir}/private.asc`]).toContain('BEGIN PGP PRIVATE KEY BLOCK');
+      expect(device[`${keyringDir}/public.asc`]).toContain('BEGIN PGP PUBLIC KEY BLOCK');
+      expect(store[PRIV_KEY]).toBeUndefined();
+      expect(store[PUB_KEY]).toBeUndefined();
+    });
+
+    // The whole point of write-verify-delete: a failure must not lose the only copy.
+    it('keeps the local copy when the device write fails', async () => {
+      await bootReady({[PRIV_KEY]: [PRIV]});
+      mocks.writeFile.mockRejectedValue(new Error('device full'));
+      const {moved, failed} = await provision.migrateLocalKeyMaterial();
+      expect(moved).not.toContain(PRIV_KEY);
+      expect(failed).toEqual([{key: PRIV_KEY, error: 'device full'}]);
+      expect(store[PRIV_KEY]).toEqual([PRIV]);
+    });
+
+    it('keeps the local copy when the written data does not read back identically', async () => {
+      await bootReady({[PRIV_KEY]: [PRIV]});
+      // Only the key file must read back wrong; the marker still has to be
+      // readable or assertUsable() would fail the device before migration starts.
+      mocks.writeFile.mockResolvedValue(undefined); // pretend success, write nothing
+      const realRead = mocks.readFile.getMockImplementation();
+      mocks.readFile.mockImplementation(path =>
+        (path.endsWith('.asc') ? Promise.resolve('truncated') : realRead(path)));
+      const {moved, failed} = await provision.migrateLocalKeyMaterial();
+      expect(moved).not.toContain(PRIV_KEY);
+      expect(failed[0].error).toMatch(/verification/i);
+      expect(store[PRIV_KEY]).toEqual([PRIV]);
+    });
+
+    it('moves what it can and reports the rest, rather than aborting', async () => {
+      await bootReady({[PRIV_KEY]: [PRIV], [PUB_KEY]: [PUB]});
+      mocks.writeFile.mockImplementation((path, content) => {
+        if (path.endsWith('private.asc')) {
+          return Promise.reject(new Error('nope'));
+        }
+        device[path] = content;
+        return Promise.resolve();
+      });
+      const {moved, failed} = await provision.migrateLocalKeyMaterial();
+      expect(moved).toContain(PUB_KEY);
+      expect(failed.map(f => f.key)).toEqual([PRIV_KEY]);
+      expect(store[PRIV_KEY]).toEqual([PRIV]);
+      expect(store[PUB_KEY]).toBeUndefined();
+    });
+
+    it('splits attributes, leaving the keyring registry local', async () => {
+      await bootReady({[ATTR_KEY]: {[MAIN]: {default_key: 'ff00', sanitized: true}}});
+      await provision.migrateLocalKeyMaterial();
+      expect(store[ATTR_KEY]).toEqual({[MAIN]: {sanitized: true}});
+      expect(JSON.parse(device['mailvelope-keystore/keyrings/attributes.json']))
+      .toEqual({[MAIN]: {default_key: 'ff00'}});
+    });
+
+    it('leaves settings and tokens alone', async () => {
+      await bootReady({
+        'mvelo.preferences': {security: {}},
+        'mvelo.oauth.gmail': {token: 'x'},
+        [PRIV_KEY]: [PRIV]
+      });
+      await provision.migrateLocalKeyMaterial();
+      expect(store['mvelo.preferences']).toEqual({security: {}});
+      expect(store['mvelo.oauth.gmail']).toEqual({token: 'x'});
+    });
+
+    it('refuses to run without a usable device', async () => {
+      seedStorage({[constants.USB_CONFIG_KEY]: {keystoreId: KEYSTORE_ID}, [PRIV_KEY]: [PRIV]});
+      seedDevice({});
+      mocks.probe.mockResolvedValue({available: true, permission: 'granted', configured: true});
+      await state.init();
+      expect(state.getState()).toBe(constants.USB_STATE.ABSENT);
+      await expect(provision.migrateLocalKeyMaterial()).rejects.toMatchObject({
+        code: constants.USB_KEYSTORE_UNAVAILABLE
+      });
+      expect(store[PRIV_KEY]).toEqual([PRIV]);
+    });
+
+    // Those stale [] entries left behind when USB mode is first enabled.
+    it('clears empty key arrays too', async () => {
+      await bootReady({[PRIV_KEY]: [], [PUB_KEY]: []});
+      const {moved, failed} = await provision.migrateLocalKeyMaterial();
+      expect(failed).toEqual([]);
+      expect(moved).toContain(PRIV_KEY);
+      expect(store[PRIV_KEY]).toBeUndefined();
+    });
+  });
+
+  describe('disable', () => {
+    it('drops this profile config and handle, leaving the device untouched', async () => {
+      await bootReady({[PRIV_KEY]: [PRIV]});
+      const before = {...device};
+      const status = await provision.disable();
+      expect(await state.getConfig()).toBeUndefined();
+      expect(handleStore.remove).toHaveBeenCalled();
+      expect(device).toEqual(before);
+      expect(status.state).toBe(constants.USB_STATE.NOT_CONFIGURED);
+      expect(state.isEnabled()).toBe(false);
+    });
+  });
+
+  describe('diagnostics', () => {
+    it('lists keyring directories when the device is ready', async () => {
+      await bootReady();
+      mocks.listDir.mockImplementation(path =>
+        Promise.resolve(path.endsWith('/keyrings') ? ['6162', 'not-hex'] : ['private.asc']));
+      const result = await provision.diagnostics();
+      expect(result.keyrings).toEqual([{dir: '6162', files: ['private.asc']}]);
+    });
+
+    it('reports state without touching the device when it is not ready', async () => {
+      seedStorage({[constants.USB_CONFIG_KEY]: {keystoreId: KEYSTORE_ID}});
+      seedDevice({});
+      mocks.probe.mockResolvedValue({available: true, permission: 'granted', configured: true});
+      await state.init();
+      mocks.listDir.mockClear();
+      const result = await provision.diagnostics();
+      expect(result.state).toBe(constants.USB_STATE.ABSENT);
+      expect(result.keyrings).toEqual([]);
+      expect(mocks.listDir).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/test/unit/modules/usb/provision.test.js
+++ b/test/unit/modules/usb/provision.test.js
@@ -42,6 +42,19 @@ jest.mock('../../../../src/modules/usb/handleStore', () => ({
   remove: jest.fn()
 }));
 
+// Two backends exist now, so a test that means "no backend at all" has to say so
+// for both. Native support is off by default here; the Firefox path has its own
+// tests.
+jest.mock('../../../../src/modules/usb/NativeBackend', () => {
+  class FakeNative {
+    static isSupported() {
+      return FakeNative.supported === true;
+    }
+  }
+  FakeNative.supported = false;
+  return {__esModule: true, default: FakeNative};
+});
+
 const KEYSTORE_ID = 'abc123';
 const MAIN = 'localhost|#|mailvelope';
 const PRIV_KEY = `mvelo.keyring.${MAIN}.privateKeys`;
@@ -240,6 +253,32 @@ describe('usb/provision', () => {
       const marker = JSON.parse(device['mailvelope-keystore/keystore.json']);
       expect(marker.label).toBe('fresh');
       expect((await state.getConfig()).keystoreId).toBe(marker.keystoreId);
+    });
+
+    // devicePath is written by selectDevice() on the native path and is the only
+    // thing telling that backend where the device is. Replacing the config rather
+    // than merging dropped it, and the state machine then reported "no keystore
+    // configured" while the label and id were plainly displayed from that config.
+    it('keeps configuration it did not set, such as the native device path', async () => {
+      seedStorage({[constants.USB_CONFIG_KEY]: {devicePath: '/run/media/u/STICK'}});
+      seedDevice({});
+      mocks.probe.mockResolvedValue({available: true, permission: 'granted', configured: true});
+      await state.init();
+      await provision.provision({label: 'STICK'});
+      const config = await state.getConfig();
+      expect(config.devicePath).toBe('/run/media/u/STICK');
+      expect(config.keystoreId).toBeTruthy();
+    });
+
+    it('keeps the device path when adopting an existing keystore too', async () => {
+      seedStorage({[constants.USB_CONFIG_KEY]: {devicePath: '/run/media/u/STICK'}});
+      seedDevice({'mailvelope-keystore/keystore.json': JSON.stringify({keystoreId: 'existing', label: 'STICK'})});
+      mocks.probe.mockResolvedValue({available: true, permission: 'granted', configured: true});
+      await state.init();
+      await provision.provision({label: 'STICK'});
+      const config = await state.getConfig();
+      expect(config.devicePath).toBe('/run/media/u/STICK');
+      expect(config.keystoreId).toBe('existing');
     });
 
     it('refuses when the browser has no backend', async () => {

--- a/test/unit/modules/usb/provision.test.js
+++ b/test/unit/modules/usb/provision.test.js
@@ -136,6 +136,37 @@ describe('usb/provision', () => {
       expect(status.state).toBe(constants.USB_STATE.READY);
     });
 
+    // Whoever finds this folder may be doing so because Mailvelope is gone, so
+    // the recovery instructions have to live on the device.
+    it('leaves recovery instructions on the device', async () => {
+      seedStorage({});
+      seedDevice({});
+      mocks.probe.mockResolvedValue({available: true, permission: 'granted', configured: true});
+      await state.init();
+      await provision.provision({label: 'stick'});
+      const readme = device['mailvelope-keystore/README.txt'];
+      expect(readme).toContain('gpg --import');
+      expect(readme).toContain('private.asc');
+      // It must also explain the mistake the guard exists to catch.
+      expect(readme).toContain('not this folder itself');
+    });
+
+    it('still provisions when the README cannot be written', async () => {
+      seedStorage({});
+      seedDevice({});
+      mocks.probe.mockResolvedValue({available: true, permission: 'granted', configured: true});
+      await state.init();
+      mocks.writeFile.mockImplementation((path, content) => {
+        if (path.endsWith('README.txt')) {
+          return Promise.reject(new Error('read-only'));
+        }
+        device[path] = content;
+        return Promise.resolve();
+      });
+      const status = await provision.provision({label: 'stick'});
+      expect(status.state).toBe(constants.USB_STATE.READY);
+    });
+
     // A device set up on another machine should be adoptable rather than reset,
     // which would orphan the keys already on it.
     it('adopts an existing keystore without rewriting its id', async () => {
@@ -147,6 +178,68 @@ describe('usb/provision', () => {
       await provision.provision({label: 'ignored'});
       expect(JSON.parse(device['mailvelope-keystore/keystore.json']).keystoreId).toBe('pre-existing');
       expect((await state.getConfig()).keystoreId).toBe('pre-existing');
+    });
+
+    // Picking the keystore folder itself nests a second keystore inside the first,
+    // and it is the natural choice when reconnecting because it is the folder the
+    // user can actually see.
+    it('refuses the keystore folder itself', async () => {
+      seedStorage({});
+      seedDevice({'keystore.json': JSON.stringify({keystoreId: 'inner', version: 1})});
+      mocks.probe.mockResolvedValue({available: true, permission: 'granted', configured: true});
+      await state.init();
+      await expect(provision.provision({label: 'mailvelope-keystore'}))
+      .rejects.toMatchObject({code: 'USB_KEYSTORE_NESTED_PICK'});
+      // Nothing nested was created.
+      expect(device['mailvelope-keystore/keystore.json']).toBeUndefined();
+    });
+
+    // Silently repointing would leave the user looking at an empty keyring while
+    // their keys sat on the previous device.
+    it('refuses to switch to a different keystore without being told to', async () => {
+      await bootReady();
+      seedDevice({'mailvelope-keystore/keystore.json': JSON.stringify({keystoreId: 'someone-else'})});
+      await expect(provision.provision({label: 'other'}))
+      .rejects.toMatchObject({code: 'USB_KEYSTORE_DIFFERENT_DEVICE'});
+      expect((await state.getConfig()).keystoreId).toBe(KEYSTORE_ID);
+    });
+
+    it('refuses a folder holding no keystore when one is already configured', async () => {
+      await bootReady();
+      seedDevice({});
+      await expect(provision.provision({label: 'empty'}))
+      .rejects.toMatchObject({code: 'USB_KEYSTORE_NOT_CONFIGURED_DEVICE'});
+      expect((await state.getConfig()).keystoreId).toBe(KEYSTORE_ID);
+      // No new identity was minted over the configured one.
+      expect(device['mailvelope-keystore/keystore.json']).toBeUndefined();
+    });
+
+    it('switches when the user explicitly adopts the other keystore', async () => {
+      await bootReady();
+      seedDevice({'mailvelope-keystore/keystore.json': JSON.stringify({keystoreId: 'someone-else', label: 'other'})});
+      await provision.provision({label: 'other', adopt: true});
+      expect((await state.getConfig()).keystoreId).toBe('someone-else');
+    });
+
+    // A React click event reached this flag as `adopt` once, making every pick
+    // adopt silently and defeating the identity check. Only an explicit true counts.
+    it('treats a non-boolean adopt flag as no consent', async () => {
+      await bootReady();
+      seedDevice({'mailvelope-keystore/keystore.json': JSON.stringify({keystoreId: 'someone-else'})});
+      for (const bogus of [{nativeEvent: {}}, 'yes', 1, {}]) {
+        await expect(provision.provision({label: 'other', adopt: bogus}))
+        .rejects.toMatchObject({code: 'USB_KEYSTORE_DIFFERENT_DEVICE'});
+      }
+      expect((await state.getConfig()).keystoreId).toBe(KEYSTORE_ID);
+    });
+
+    it('creates a keystore on an empty folder when the user adopts it', async () => {
+      await bootReady();
+      seedDevice({});
+      await provision.provision({label: 'fresh', adopt: true});
+      const marker = JSON.parse(device['mailvelope-keystore/keystore.json']);
+      expect(marker.label).toBe('fresh');
+      expect((await state.getConfig()).keystoreId).toBe(marker.keystoreId);
     });
 
     it('refuses when the browser has no backend', async () => {

--- a/test/unit/modules/usb/provision.test.js
+++ b/test/unit/modules/usb/provision.test.js
@@ -448,4 +448,69 @@ describe('usb/provision', () => {
       expect(mocks.listDir).not.toHaveBeenCalled();
     });
   });
+  describe('migration onto a device that already holds a keystore', () => {
+    const DEVICE_KEY = '-----BEGIN PGP PRIVATE KEY BLOCK-----\ndevice\n-----END PGP PRIVATE KEY BLOCK-----';
+    const LOCAL_KEY = '-----BEGIN PGP PRIVATE KEY BLOCK-----\nlocal\n-----END PGP PRIVATE KEY BLOCK-----';
+    const PRIV_PATH = `mailvelope-keystore/keyrings/${Buffer.from(MAIN).toString('hex')}/private.asc`;
+
+    // Migration wrote the local value straight over the device path, so moving keys
+    // onto a device that already had a keystore destroyed its keys -- recoverable
+    // only from the .bak the atomic write happens to leave behind. Observed on real
+    // hardware: a device key was replaced by the migrated one.
+    it('keeps the keys already on the device', async () => {
+      seedStorage({
+        [constants.USB_CONFIG_KEY]: {keystoreId: KEYSTORE_ID},
+        [`mvelo.keyring.${MAIN}.privateKeys`]: [LOCAL_KEY]
+      });
+      seedDevice({
+        'mailvelope-keystore/keystore.json': JSON.stringify({keystoreId: KEYSTORE_ID}),
+        [PRIV_PATH]: DEVICE_KEY
+      });
+      mocks.probe.mockResolvedValue({available: true, permission: 'granted', configured: true});
+      await state.init();
+
+      const result = await provision.migrateLocalKeyMaterial();
+      expect(result.failed).toEqual([]);
+      expect(device[PRIV_PATH]).toContain('device');
+      expect(device[PRIV_PATH]).toContain('local');
+      expect(result.added).toBe(1);
+    });
+
+    it('does not duplicate a key already present on the device', async () => {
+      seedStorage({
+        [constants.USB_CONFIG_KEY]: {keystoreId: KEYSTORE_ID},
+        [`mvelo.keyring.${MAIN}.privateKeys`]: [DEVICE_KEY]
+      });
+      seedDevice({
+        'mailvelope-keystore/keystore.json': JSON.stringify({keystoreId: KEYSTORE_ID}),
+        [PRIV_PATH]: DEVICE_KEY
+      });
+      mocks.probe.mockResolvedValue({available: true, permission: 'granted', configured: true});
+      await state.init();
+
+      const result = await provision.migrateLocalKeyMaterial();
+      const blocks = device[PRIV_PATH].match(/BEGIN PGP PRIVATE KEY BLOCK/g) || [];
+      expect(blocks).toHaveLength(1);
+      expect(result.added).toBe(0);
+    });
+
+    // attributes.json named a default key that migration had just removed from the
+    // keystore, leaving the device internally inconsistent.
+    it('does not repoint the default key of an existing keystore', async () => {
+      const attrPath = 'mailvelope-keystore/keyrings/attributes.json';
+      seedStorage({
+        [constants.USB_CONFIG_KEY]: {keystoreId: KEYSTORE_ID},
+        'mvelo.keyring.attributes': {[MAIN]: {default_key: 'incoming'}}
+      });
+      seedDevice({
+        'mailvelope-keystore/keystore.json': JSON.stringify({keystoreId: KEYSTORE_ID}),
+        [attrPath]: JSON.stringify({[MAIN]: {default_key: 'already-there'}})
+      });
+      mocks.probe.mockResolvedValue({available: true, permission: 'granted', configured: true});
+      await state.init();
+
+      await provision.migrateLocalKeyMaterial();
+      expect(JSON.parse(device[attrPath])[MAIN].default_key).toBe('already-there');
+    });
+  });
 });

--- a/test/unit/modules/usb/provision.test.js
+++ b/test/unit/modules/usb/provision.test.js
@@ -433,7 +433,41 @@ describe('usb/provision', () => {
       mocks.listDir.mockImplementation(path =>
         Promise.resolve(path.endsWith('/keyrings') ? ['6162', 'not-hex'] : ['private.asc']));
       const result = await provision.diagnostics();
-      expect(result.keyrings).toEqual([{dir: '6162', files: ['private.asc']}]);
+      expect(result.keyrings).toEqual([{
+        dir: '6162',
+        files: ['private.asc'],
+        onDevice: {publicKeys: 0, privateKeys: 0},
+        loaded: null
+      }]);
+    });
+
+    // The number the settings page shows: what the device holds, next to what the
+    // extension actually loaded. A read that returns part of a file leaves a keyring
+    // that looks ordinary but short, and this is the only place the two are compared.
+    it('counts the keys on the device and the keys held in memory', async () => {
+      await bootReady();
+      seedDevice({
+        'mailvelope-keystore/keyrings/6162/public.asc': `${PUB}\n${PUB}`,
+        'mailvelope-keystore/keyrings/6162/private.asc': PRIV
+      });
+      mocks.listDir.mockImplementation(path =>
+        Promise.resolve(path.endsWith('/keyrings') ? ['6162'] : ['public.asc', 'private.asc']));
+      const result = await provision.diagnostics({loaded: {6162: {publicKeys: 1, privateKeys: 1}}});
+      expect(result.keyrings[0].onDevice).toEqual({publicKeys: 2, privateKeys: 1});
+      expect(result.keyrings[0].loaded).toEqual({publicKeys: 1, privateKeys: 1});
+    });
+
+    // A keyring file that is not there yet is not a failure, and must not read as a
+    // shortfall against what is loaded.
+    it('counts a missing key file as no keys rather than failing', async () => {
+      await bootReady();
+      mocks.listDir.mockImplementation(path =>
+        Promise.resolve(path.endsWith('/keyrings') ? ['6162'] : []));
+      const result = await provision.diagnostics();
+      expect(result.keyrings[0].onDevice).toEqual({publicKeys: 0, privateKeys: 0});
+      // detail carries the status's own null when nothing went wrong; a message here
+      // would mean the missing file had been treated as a read failure.
+      expect(result.detail).toBeFalsy();
     });
 
     it('reports state without touching the device when it is not ready', async () => {

--- a/test/unit/modules/usb/router.test.js
+++ b/test/unit/modules/usb/router.test.js
@@ -1,0 +1,151 @@
+/**
+ * Copyright (C) 2026 Noam Rathaus
+ * Licensed under the GNU Affero General Public License version 3
+ */
+
+import {
+  classify, encodeKeyringId, isAllowedLocal, containsKeyMaterial, splitAttributes,
+  mergeAttributes, serialize, deserialize, TARGET, KEYRING_ATTRIBUTES_KEY
+} from '../../../../src/modules/usb/router';
+import {MAIN_KEYRING_ID, GNUPG_KEYRING_ID} from '../../../../src/lib/constants';
+
+const PRIVATE_ARMORED = '-----BEGIN PGP PRIVATE KEY BLOCK-----\nabc\n-----END PGP PRIVATE KEY BLOCK-----';
+const PUBLIC_ARMORED = '-----BEGIN PGP PUBLIC KEY BLOCK-----\nxyz\n-----END PGP PUBLIC KEY BLOCK-----';
+
+describe('usb/router', () => {
+  describe('classify', () => {
+    it('routes armored key arrays to the device as .asc files', () => {
+      expect(classify(`mvelo.keyring.${MAIN_KEYRING_ID}.privateKeys`)).toEqual({
+        target: TARGET.DEVICE,
+        path: `mailvelope-keystore/keyrings/${encodeKeyringId(MAIN_KEYRING_ID)}/private.asc`,
+        format: 'asc',
+        keyringId: MAIN_KEYRING_ID
+      });
+      expect(classify(`mvelo.keyring.${MAIN_KEYRING_ID}.publicKeys`).path).toMatch(/\/public\.asc$/);
+    });
+
+    it('splits the keyring attribute map', () => {
+      expect(classify(KEYRING_ATTRIBUTES_KEY).target).toBe(TARGET.SPLIT);
+    });
+
+    it('routes autocrypt records to the device', () => {
+      const route = classify(`mvelo.autocrypt.${MAIN_KEYRING_ID}`);
+      expect(route.target).toBe(TARGET.DEVICE);
+      expect(route.format).toBe('json');
+    });
+
+    it('leaves settings and OAuth tokens local', () => {
+      expect(classify('mvelo.preferences').target).toBe(TARGET.LOCAL);
+      expect(classify('mvelo.watchlist').target).toBe(TARGET.LOCAL);
+      expect(classify('mvelo.oauth.gmail').target).toBe(TARGET.LOCAL);
+    });
+
+    it('handles API keyring IDs containing dots', () => {
+      const keyringId = 'example.co.uk|#|someapp';
+      expect(classify(`mvelo.keyring.${keyringId}.privateKeys`).keyringId).toBe(keyringId);
+    });
+  });
+
+  describe('encodeKeyringId', () => {
+    it('produces a filesystem-safe single-case name', () => {
+      const encoded = encodeKeyringId(MAIN_KEYRING_ID);
+      expect(encoded).toMatch(/^[0-9a-f]+$/);
+      expect(encoded).not.toContain('|');
+    });
+
+    it('round-trips', () => {
+      const encoded = encodeKeyringId(MAIN_KEYRING_ID);
+      const bytes = encoded.match(/../g).map(byte => parseInt(byte, 16));
+      expect(new TextDecoder().decode(new Uint8Array(bytes))).toBe(MAIN_KEYRING_ID);
+    });
+
+    // FAT32 and exFAT are case-insensitive, so a case-sensitive encoding such as
+    // base64 could map two distinct keyring IDs onto one directory.
+    it('does not collide on case-insensitive filesystems', () => {
+      expect(encodeKeyringId('AbC|#|x')).not.toBe(encodeKeyringId('aBc|#|x'));
+    });
+  });
+
+  describe('leak safety net', () => {
+    it('recognises known-safe storage keys', () => {
+      expect(isAllowedLocal('mvelo.preferences')).toBe(true);
+      expect(isAllowedLocal('mvelo.oauth.anything')).toBe(true);
+      expect(isAllowedLocal('mvelo.something.new')).toBe(false);
+    });
+
+    it('detects armored key material at any depth', () => {
+      expect(containsKeyMaterial(PRIVATE_ARMORED)).toBe(true);
+      expect(containsKeyMaterial({a: {b: [PRIVATE_ARMORED]}})).toBe(true);
+      expect(containsKeyMaterial(PUBLIC_ARMORED)).toBe(true);
+    });
+
+    it('does not flag ordinary values', () => {
+      expect(containsKeyMaterial({hello: 'world'})).toBe(false);
+      expect(containsKeyMaterial(undefined)).toBe(false);
+      expect(containsKeyMaterial(null)).toBe(false);
+    });
+  });
+
+  describe('attribute splitting', () => {
+    const attributes = {
+      [MAIN_KEYRING_ID]: {
+        default_key: 'aabb',
+        sanitized: true,
+        key_binding: {'a@b.c': {fingerprint: 'ff', last_seen: 1}},
+        sync_data: {eTag: '1', changeLog: {}, modified: false}
+      },
+      [GNUPG_KEYRING_ID]: {sanitized: true}
+    };
+
+    it('sends only crypto fields to the device', () => {
+      const {device} = splitAttributes(attributes);
+      expect(Object.keys(device[MAIN_KEYRING_ID]).sort()).toEqual(['default_key', 'key_binding', 'sync_data']);
+      expect(device[GNUPG_KEYRING_ID]).toBeUndefined();
+    });
+
+    // keyring.init() reads this map to learn which keyrings exist. If the whole map
+    // lived on the device, starting without it would leave the keyring subsystem
+    // unable to initialise rather than merely without keys.
+    it('keeps the keyring registry local', () => {
+      const {local} = splitAttributes(attributes);
+      expect(local[MAIN_KEYRING_ID]).toEqual({sanitized: true});
+      expect(Object.keys(local)).toEqual([MAIN_KEYRING_ID, GNUPG_KEYRING_ID]);
+    });
+
+    it('lists a keyring locally even when it has no local attributes', () => {
+      expect(Object.keys(splitAttributes({x: {default_key: 'a'}}).local)).toEqual(['x']);
+    });
+
+    it('produces an empty device map when there is no crypto metadata', () => {
+      expect(splitAttributes({x: {sanitized: true}}).device).toEqual({});
+    });
+
+    it('round-trips through merge', () => {
+      const {device, local} = splitAttributes(attributes);
+      expect(mergeAttributes(local, device)).toEqual(attributes);
+    });
+
+    it('yields no crypto fields when the device is absent', () => {
+      const {local} = splitAttributes(attributes);
+      expect(mergeAttributes(local, {})[MAIN_KEYRING_ID]).toEqual({sanitized: true});
+    });
+  });
+
+  describe('serialization', () => {
+    it('round-trips armored keys, keeping the file gpg-importable', () => {
+      const serialized = serialize([PRIVATE_ARMORED, PUBLIC_ARMORED], 'asc');
+      expect(serialized).toContain('-----BEGIN PGP PRIVATE KEY BLOCK-----');
+      expect(deserialize(serialized, 'asc')).toEqual([PRIVATE_ARMORED, PUBLIC_ARMORED]);
+    });
+
+    it('treats an empty or missing .asc file as an empty keyring', () => {
+      expect(deserialize('', 'asc')).toEqual([]);
+      expect(serialize([], 'asc')).toBe('');
+    });
+
+    it('round-trips JSON values', () => {
+      expect(deserialize(serialize({a: 1}, 'json'), 'json')).toEqual({a: 1});
+      expect(deserialize('', 'json')).toBeUndefined();
+    });
+  });
+});

--- a/test/unit/modules/usb/state.test.js
+++ b/test/unit/modules/usb/state.test.js
@@ -1,0 +1,278 @@
+/**
+ * Copyright (C) 2026 Noam Rathaus
+ * Licensed under the GNU Affero General Public License version 3
+ *
+ * Covers the availability state machine against a fake backend. Most of state.js
+ * had never executed outside the one manual provisioning run, so these exercise
+ * every transition the UI and the storage wrapper depend on.
+ */
+
+// A controllable stand-in for the File System Access backend.
+jest.mock('../../../../src/modules/usb/FsaBackend', () => {
+  const mocks = {
+    supported: true,
+    probe: jest.fn(),
+    readFile: jest.fn(),
+    writeFile: jest.fn(),
+    removeFile: jest.fn(),
+    listDir: jest.fn()
+  };
+  class FakeBackend {
+    static isSupported() {
+      return mocks.supported;
+    }
+
+    constructor() {
+      this.clearCache = jest.fn();
+      this.probe = mocks.probe;
+      this.readFile = mocks.readFile;
+      this.writeFile = mocks.writeFile;
+      this.removeFile = mocks.removeFile;
+      this.listDir = mocks.listDir;
+    }
+  }
+  FakeBackend.__mocks = mocks;
+  return {__esModule: true, default: FakeBackend};
+});
+
+const KEYSTORE_ID = 'abc123';
+const MARKER_PATH = 'mailvelope-keystore/keystore.json';
+
+function seedStorage(initial = {}) {
+  const store = {...initial};
+  chrome.storage.local.get.mockImplementation(key =>
+    Promise.resolve(key in store ? {[key]: store[key]} : {}));
+  chrome.storage.local.set.mockImplementation(obj => {
+    Object.assign(store, obj);
+    return Promise.resolve();
+  });
+  chrome.storage.local.remove.mockImplementation(key => {
+    delete store[key];
+    return Promise.resolve();
+  });
+  return store;
+}
+
+describe('usb/state', () => {
+  let state; let constants; let backend; let mocks; let USB_STATE;
+
+  function load() {
+    jest.resetModules();
+    chrome.storage.local.get.mockReset();
+    chrome.storage.local.set.mockReset();
+    chrome.storage.local.remove.mockReset();
+    constants = require('../../../../src/modules/usb/constants');
+    USB_STATE = constants.USB_STATE;
+    backend = require('../../../../src/modules/usb/FsaBackend').default;
+    mocks = backend.__mocks;
+    mocks.supported = true;
+    state = require('../../../../src/modules/usb/state');
+  }
+
+  /** Configured device whose marker matches, i.e. the happy path. */
+  function seedReady() {
+    seedStorage({[constants.USB_CONFIG_KEY]: {keystoreId: KEYSTORE_ID}});
+    mocks.probe.mockResolvedValue({available: true, permission: 'granted', configured: true});
+    mocks.readFile.mockResolvedValue(JSON.stringify({keystoreId: KEYSTORE_ID, label: 'stick'}));
+  }
+
+  beforeEach(() => {
+    load();
+  });
+
+  describe('state resolution', () => {
+    it('is NOT_CONFIGURED with no config, and reports the browser as supported', async () => {
+      seedStorage({});
+      expect(await state.probe()).toBe(USB_STATE.NOT_CONFIGURED);
+      expect(state.isEnabled()).toBe(false);
+      // Not opting in must take precedence over backend availability, so an
+      // unconfigured profile looks like stock Mailvelope.
+      expect(state.getStatus().supported).toBe(false); // no backend selected until init()
+    });
+
+    it('is UNSUPPORTED when configured but the browser has no backend', async () => {
+      seedStorage({[constants.USB_CONFIG_KEY]: {keystoreId: KEYSTORE_ID}});
+      mocks.supported = false;
+      await state.init();
+      expect(state.getState()).toBe(USB_STATE.UNSUPPORTED);
+      // Critically: still 'enabled', so the storage wrapper fails closed rather
+      // than silently writing keys to local storage.
+      expect(state.isEnabled()).toBe(true);
+    });
+
+    it('is PERMISSION_REQUIRED when the grant is missing', async () => {
+      seedStorage({[constants.USB_CONFIG_KEY]: {keystoreId: KEYSTORE_ID}});
+      mocks.probe.mockResolvedValue({available: false, permission: 'prompt', configured: true});
+      await state.init();
+      expect(state.getState()).toBe(USB_STATE.PERMISSION_REQUIRED);
+    });
+
+    it('is ABSENT when the marker file is missing', async () => {
+      const {NotFoundError} = require('../../../../src/modules/usb/backend');
+      seedReady();
+      mocks.readFile.mockRejectedValue(new NotFoundError(MARKER_PATH));
+      await state.init();
+      expect(state.getState()).toBe(USB_STATE.ABSENT);
+    });
+
+    it('is ABSENT when the device itself is unreachable', async () => {
+      const {DeviceUnavailableError} = require('../../../../src/modules/usb/backend');
+      seedReady();
+      mocks.readFile.mockRejectedValue(new DeviceUnavailableError());
+      await state.init();
+      expect(state.getState()).toBe(USB_STATE.ABSENT);
+    });
+
+    it('is WRONG_DEVICE when the marker belongs to another keystore', async () => {
+      seedReady();
+      mocks.readFile.mockResolvedValue(JSON.stringify({keystoreId: 'someone-else', label: 'other'}));
+      await state.init();
+      expect(state.getState()).toBe(USB_STATE.WRONG_DEVICE);
+      expect(state.getStatus().detail).toBe('other');
+    });
+
+    it('is ERROR on unexpected failures, not silently ABSENT', async () => {
+      seedReady();
+      mocks.readFile.mockRejectedValue(new Error('disk on fire'));
+      await state.init();
+      expect(state.getState()).toBe(USB_STATE.ERROR);
+      expect(state.getStatus().detail).toBe('disk on fire');
+    });
+
+    it('is ERROR when the marker is not valid JSON', async () => {
+      seedReady();
+      mocks.readFile.mockResolvedValue('not json at all');
+      await state.init();
+      expect(state.getState()).toBe(USB_STATE.ERROR);
+    });
+
+    it('is READY when the marker matches', async () => {
+      seedReady();
+      await state.init();
+      expect(state.getState()).toBe(USB_STATE.READY);
+      expect(state.isUsable()).toBe(true);
+      expect(state.isEnabled()).toBe(true);
+    });
+
+    // Presence is established by reading the marker, not by resolving the handle:
+    // automounters differ in whether the mount point vanishes on removal or is
+    // left behind as an empty directory.
+    it('reads the marker file to decide presence', async () => {
+      seedReady();
+      await state.init();
+      expect(mocks.readFile).toHaveBeenCalledWith(MARKER_PATH);
+    });
+  });
+
+  describe('assertUsable', () => {
+    it('resolves when READY', async () => {
+      seedReady();
+      await state.init();
+      await expect(state.assertUsable()).resolves.toBeUndefined();
+    });
+
+    it('rejects with USB_KEYSTORE_UNAVAILABLE when the device is gone', async () => {
+      const {NotFoundError} = require('../../../../src/modules/usb/backend');
+      seedReady();
+      await state.init();
+      mocks.readFile.mockRejectedValue(new NotFoundError(MARKER_PATH));
+      await expect(state.assertUsable(true)).rejects.toMatchObject({
+        code: constants.USB_KEYSTORE_UNAVAILABLE
+      });
+    });
+
+    // A stale READY reading must not let a write proceed against a pulled device.
+    it('re-probes before writes when asked', async () => {
+      seedReady();
+      await state.init();
+      mocks.readFile.mockClear();
+      await state.assertUsable(true);
+      expect(mocks.readFile).toHaveBeenCalled();
+    });
+
+    it('does not re-probe on reads while READY', async () => {
+      seedReady();
+      await state.init();
+      mocks.readFile.mockClear();
+      await state.assertUsable();
+      expect(mocks.readFile).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('listeners', () => {
+    it('notifies on transition, with previous and next state', async () => {
+      const {NotFoundError} = require('../../../../src/modules/usb/backend');
+      seedReady();
+      await state.init();
+      const seen = [];
+      state.addStateListener((next, previous) => seen.push([previous, next]));
+      mocks.readFile.mockRejectedValue(new NotFoundError(MARKER_PATH));
+      await state.probe();
+      expect(seen).toEqual([[USB_STATE.READY, USB_STATE.ABSENT]]);
+    });
+
+    it('does not notify when the state is unchanged', async () => {
+      seedReady();
+      await state.init();
+      const listener = jest.fn();
+      state.addStateListener(listener);
+      await state.probe();
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it('unregisters', async () => {
+      const {NotFoundError} = require('../../../../src/modules/usb/backend');
+      seedReady();
+      await state.init();
+      const listener = jest.fn();
+      state.addStateListener(listener)();
+      mocks.readFile.mockRejectedValue(new NotFoundError(MARKER_PATH));
+      await state.probe();
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it('survives a throwing listener so one bad consumer cannot block others', async () => {
+      const {NotFoundError} = require('../../../../src/modules/usb/backend');
+      seedReady();
+      await state.init();
+      const good = jest.fn();
+      state.addStateListener(() => {
+        throw new Error('bad listener');
+      });
+      state.addStateListener(good);
+      mocks.readFile.mockRejectedValue(new NotFoundError(MARKER_PATH));
+      await state.probe();
+      expect(good).toHaveBeenCalled();
+    });
+  });
+
+  describe('config and probing', () => {
+    it('starts the periodic probe on init', async () => {
+      seedReady();
+      await state.init();
+      expect(chrome.alarms.create).toHaveBeenCalledWith(
+        constants.PROBE_ALARM,
+        {periodInMinutes: constants.PROBE_PERIOD_MINUTES}
+      );
+    });
+
+    it('round-trips and clears config without touching mvelo.storage', async () => {
+      seedStorage({});
+      await state.setConfig({keystoreId: KEYSTORE_ID});
+      expect(await state.getConfig()).toEqual({keystoreId: KEYSTORE_ID});
+      await state.clearConfig();
+      expect(await state.getConfig()).toBeUndefined();
+    });
+
+    it('recovers to READY when the device comes back', async () => {
+      const {NotFoundError} = require('../../../../src/modules/usb/backend');
+      seedReady();
+      await state.init();
+      const marker = JSON.stringify({keystoreId: KEYSTORE_ID});
+      mocks.readFile.mockRejectedValue(new NotFoundError(MARKER_PATH));
+      expect(await state.probe()).toBe(USB_STATE.ABSENT);
+      mocks.readFile.mockResolvedValue(marker);
+      expect(await state.probe()).toBe(USB_STATE.READY);
+    });
+  });
+});

--- a/test/unit/modules/usb/state.test.js
+++ b/test/unit/modules/usb/state.test.js
@@ -35,6 +35,19 @@ jest.mock('../../../../src/modules/usb/FsaBackend', () => {
   return {__esModule: true, default: FakeBackend};
 });
 
+// Two backends exist now, so a test that means "no backend at all" has to say so
+// for both. Native support is off by default here; the Firefox path has its own
+// tests.
+jest.mock('../../../../src/modules/usb/NativeBackend', () => {
+  class FakeNative {
+    static isSupported() {
+      return FakeNative.supported === true;
+    }
+  }
+  FakeNative.supported = false;
+  return {__esModule: true, default: FakeNative};
+});
+
 const KEYSTORE_ID = 'abc123';
 const MARKER_PATH = 'mailvelope-keystore/keystore.json';
 


### PR DESCRIPTION
# My Goal
I wanted to build a mailvelope version that can support using USB for the key storage rather than locally on the desktop/laptop which may get stolen/lost

The USB key can be FS encrypted if needed, or plugged/unplugged and used only when needed - while a local keystore will be always there as long as Chrome/Firefox run

# Honestly
While I know javascript and can audit code/write python code, I cannot bridge the gap needed to build this without Claude helping me. I hope you integrate this code, as I believe secrecy, privacy and security is the goal of this extension

I have been using this feature for the past few days (both to debug and kill bugs as well as verify it answers what I wanted to do)

Please don't discard this as vibe coding, or AI slop - I reviewed what it code and raised design ideas and requirements throughout the process to prevent it from working "just for me" or from Claude messing with the whole code base

I mainly asked it to avoid making redesign of everything, limit it as much as possible to "hooks" and small changes that are simple to read `if` statements 

I would appreciate if you have any feedback / questions

```From here its Claude explaining what he with my guidance did```
---

# Optional USB keystore: keep all key material on a removable device

Adds an opt-in storage backend that keeps every piece of key material on a removable
device, so that a machine used for encrypted mail holds no private keys at rest. When
the device is absent, crypto operations refuse rather than falling back to local
storage.

Motivation: for people whose threat model is "someone gets this laptop", key
durability matters less than key absence. Losing the stick and losing the keys is an
acceptable trade; leaving a private key in the browser profile is not.

**Entirely opt-in. With no keystore configured, Mailvelope behaves exactly as it does
today** — see *Impact when disabled* below, which is the claim most worth checking.

## Design

The single design decision worth reviewing is **where** the redirection happens.

Key material reaches storage through one place: `mvelo.storage.{get,set,remove}`. The
feature wraps those three functions and routes by key name — `*.publicKeys`,
`*.privateKeys`, `*.attributes`, autocrypt stores and the default-key setting go to the
device; everything else stays local. Non-key preferences are untouched.

The alternative was editing each call site in the keyring layer. Rejected because it
would scatter the "nothing outside the device" rule across a dozen places, each of
which could later drift, and would conflict on every rebase. One wrapper puts the rule
in a single auditable spot and leaves the keyring layer almost untouched.

Everything new lives under `src/modules/usb/`, `src/components/usb/` and
`native-host/`, so the feature is removable by deleting three directories and reverting
~250 lines.

### Two backends, because one browser cannot do it

- **Chromium** — File System Access API. `showDirectoryPicker()` once, and the handle is
  persisted in IndexedDB (it is structured-cloneable but cannot cross
  `chrome.runtime` messaging, so IndexedDB is what the app page and service worker
  share). No install step.
- **Firefox** — no picker exists, and OPFS is not the device, so a small native
  messaging host is the only route. `native-host/mailvelope_usb_keystore.py`, Python 3,
  dependency-free, ~300 lines, user-level install with no sudo.

The host path turns out to be the better interface in two respects: it enumerates
mounted removable devices, so the UI offers a list rather than a file dialog, and it can
show the real path, which the File System Access API deliberately withholds. It also
reports writability directly, so a write-protected device is known *before* a write is
attempted; on the FSA path that can only be discovered by failing.

Confinement is enforced in the host, never in the extension: a root must be under
`/run/media`, `/media`, `/mnt` or `/Volumes` **and** be an actual mount point; paths are
relative only, resolved through `realpath` and re-checked to be inside the root; writes
are restricted to seven known filenames; reads and writes are size-capped. All
confinement tests are load-bearing.

## Impact when disabled

This is the part to review skeptically. Every edit to an existing file is gated on a
configured keystore:

- `pgpModel.js` — five `assertKeystoreForCrypto()` calls. The guard returns on a
  synchronous flag check when no keystore is configured, so the cost is a function call.
- `keyring.js` — every change sits behind `usbKeystoreEnabled()`.
- The storage wrapper installs itself but delegates straight to the originals until a
  keystore is configured.
- UI additions render `null` when the feature is off.

**One exception, disclosed rather than hidden:** `pwdCache.set()` now performs one
`chrome.storage.local` read to decide whether caching is permitted, for all users.
It is on an interactive path (once per key unlock, not per operation), so the cost
should be unmeasurable — but it is a real change and could be avoided if you prefer.
It reads storage rather than an in-memory flag deliberately: the flag is false until the
first device probe, and a false negative there permits exactly the leak it prevents.

## A finding that affects all users, not just this feature

While auditing the profile for leaked key material we found that **Mailvelope writes a
private key's full fingerprint to disk whenever the passphrase cache is used**, on
`master`, independent of this feature.

`pwdCache` names its expiry alarm `PWD_ALARM_<fingerprint>`, and Chrome persists alarm
names to `Extension State/` with `persistAcrossSessions: true`. The alarm is cleared
correctly on expiry, but that store is LevelDB: the record survives in the append-only
log until compaction. On a real profile the fingerprint was still readable **seven hours
after the alarm had fired**. `security.password_cache` defaults to `true`.

No passphrase or key material is exposed — `chrome.storage.session` is genuinely
memory-only — so this is metadata: it records which key a machine used. That may still
matter to some users.

This PR only stops it for USB mode, where a fingerprint on the local disk contradicts
the feature's premise. **A general fix is yours to decide**; naming the alarm by an
opaque id and resolving it through the existing session entry would cost little and
would help every user. Happy to submit that separately if wanted.

## UI

Key Storage settings offers **Local (default)** or **USB device**, showing the folder,
keystore ID and how recently the device was checked. Elsewhere: a status badge on the
key list, a banner while the device is missing, and destructive controls (delete,
revoke, generate, import) **disabled with the reason in the tooltip** rather than
offered and then refused — the keyring mutates memory before persisting, so a refused
delete otherwise makes a key vanish and reappear.

Detection is a 30-second alarm plus 1-second polling while a page is visible, and a
probe before every keystore operation. There is no filesystem removal event, so presence
is always established by reading a marker file; automounters differ in whether the mount
point disappears on removal or is left behind empty, and only reading the marker covers
both.

## Verified on real hardware

FAT32 stick, Chromium 151 and Firefox 154:

- Encrypt/decrypt with a device-resident key, both browsers
- **One keystore read by Chrome via FSA and by Firefox via the host** — the same device,
  no key material in either profile
- No private key bytes in either profile, checked by grepping both for 40-char slices of
  the real armored keys; no passphrase on disk
- Physical removal detected in both modes (contents gone; mount point vanishing)
- Reconnect restores keys automatically
- Passphrase and unlocked key purged on removal — verified by unplug/replug/decrypt
  prompting again
- Wrong device: keys physically present and readable stay hidden, because identity gates
  access rather than readability
- Write-protected device: keys readable and decryption works, changes refused, the
  controls that would make them disabled
- FSA permission survives a browser restart when the user takes Chrome's persistent
  option

## Known limitations

- **Migration cannot erase.** Moving existing local keys to the device deletes them from
  `storage.local`, but LevelDB's tombstone leaves the old value recoverable from the
  profile until compaction, which a low-write keyring may never trigger. The UI says so
  and recommends generating a fresh key on the device instead.
- **Torn writes are untested.** Writes stage, `fsync`, rotate the previous generation to
  `.bak` and rename, but pulling a device mid-write is not reproducible by hand. The
  read-only stand-in exercises refused writes, not interrupted ones.
- **Firefox needs the native host installed**, which is a separate artifact with its own
  install story.
- **`hasPrivateKey` reports `false` while the device is detached**, so a provider cannot
  distinguish that from a user who never had a key. Left as-is deliberately: `false` is
  what the caller acts on, and raising a new error code would reach third-party handlers
  written long before this feature. Prompting key generation is already fail-closed.
- **Encryption at rest is the user's job.** The device holds armored keys; private keys
  are passphrase-protected, and the UI requires a passphrase in USB mode and points at
  VeraCrypt/LUKS for protection at rest.

## Diff shape

63 files, +8418/-40. Of that, existing files account for **+247/-40 across 18 files**;
the rest is new code, tests and documentation.

| | |
|---|---|
| New modules | `src/modules/usb/` (13 files), `src/components/usb/` (9), `native-host/` (3) |
| Tests | 664 unit tests / 39 suites, plus 17 host tests (`python3 native-host/test_host.py`) |
| Docs | `doc/usb-keystore-plan.md` (design and rationale), `doc/usb-keystore-status.md` (verification state) |
| Lint | `grunt eslint` clean |

39 commits, each self-contained with its reasoning in the message. Reviewing them in
order is likely easier than the combined diff, since several exist specifically to
document a bug found by running the feature on real hardware.

## Questions for maintainers

1. Is a native messaging host acceptable in-tree, or should it be a separate
   distribution?

2. Should the general `PWD_ALARM_<fingerprint>` fix land separately, for all users? PWN_ALARM at the moment "leaks" the hex ID of the keys with and without USB storage being used, for USB storage mode it may be more critical issue

4. Is the `pwdCache.set()` storage read acceptable, or would you rather it consulted an  in-memory flag and accepted the init-order gap?

5. Is `password_cache` being forced off in USB mode the behavior you would want, or should it remain the user's choice with a warning?